### PR TITLE
Change e2e tests to trigger on operator build

### DIFF
--- a/gitops/opendatahub-integration-test-scenarios.yaml
+++ b/gitops/opendatahub-integration-test-scenarios.yaml
@@ -9,9 +9,9 @@ metadata:
 spec:
   application: opendatahub-release
   contexts:
-  - description: execute the integration test when component odh-operator-bundle
+  - description: execute the integration test when component odh-operator
       updates
-    name: component_odh-operator-bundle
+    name: component_odh-operator
   resolverRef:
     params:
     - name: url

--- a/integration-tests/opendatahub-operator/e2e-test.yaml
+++ b/integration-tests/opendatahub-operator/e2e-test.yaml
@@ -5,22 +5,16 @@ metadata:
   name: opendatahub-operator-e2e-test
 spec:
   description: |
-    An integration test which provisions an ephemeral Hypershift cluster, deploys opendatahub-operator
-    bundle from a Konflux snapshot and runs the e2e tests against it.
+    An integration test which provisions an ephemeral Hypershift cluster, deploys opendatahub-operator 
+    from a Konflux snapshot and runs the e2e tests against it.
   params:
     - description: Snapshot of the application
       name: SNAPSHOT
-      default: '{"components": [{"name":"odh-operator-bundle", "containerImage": "quay.io/opendatahub/opendatahub-operator-bundle:latest"}]}'
+      default: '{"components": [{"name":"odh-operator", "containerImage": "quay.io/opendatahub/opendatahub-operator:latest"}]}'
       type: string
-    - name: GIT_REPO
-      type: string
-      default: https://github.com/opendatahub-io/opendatahub-operator.git
-    - name: GIT_REVISION
-      type: string
-      default: main
     - name: NAMESPACE
       type: string
-      default: openshift-operators
+      default: opendatahub-operator-system
   tasks:
     - name: parse-metadata
       taskRef:
@@ -103,58 +97,9 @@ spec:
                 value: "$(steps.pick-version.results.version)"
               - name: instanceType
                 value: m5.2xlarge
-    - name: deploy-operator
+    - name: deploy-and-test
       runAfter:
         - provision-cluster
-      params:
-        - name: bundleImage
-          value: "$(tasks.parse-metadata.results.component-container-image)"
-        - name: namespace
-          value: "$(params.NAMESPACE)"
-      taskSpec:
-        params:
-          - name: bundleImage
-            type: string
-          - name: namespace
-            type: string
-        volumes:
-          - name: credentials
-            emptyDir: {}
-        steps:
-          - name: get-kubeconfig
-            ref:
-              resolver: git
-              params:
-                - name: url
-                  value: https://github.com/konflux-ci/build-definitions.git
-                - name: revision
-                  value: main
-                - name: pathInRepo
-                  value: stepactions/eaas-get-ephemeral-cluster-credentials/0.1/eaas-get-ephemeral-cluster-credentials.yaml
-            params:
-              - name: eaasSpaceSecretRef
-                value: $(tasks.provision-eaas-space.results.secretRef)
-              - name: clusterName
-                value: "$(tasks.provision-cluster.results.clusterName)"
-              - name: credentials
-                value: credentials
-          - name: operator-sdk-run-bundle
-            image: quay.io/operator-framework/operator-sdk:latest
-            env:
-              - name: KUBECONFIG
-                value: "/credentials/$(steps.get-kubeconfig.results.kubeconfig)"
-            volumeMounts:
-              - name: credentials
-                mountPath: /credentials
-            args:
-              - run
-              - bundle
-              - --namespace
-              - "$(params.namespace)"
-              - "$(params.bundleImage)"
-    - name: run-e2e-tests
-      runAfter:
-        - deploy-operator
       params:
       - name: git-url
         value: "$(tasks.parse-metadata.results.source-git-url)"
@@ -162,6 +107,8 @@ spec:
         value: "$(tasks.parse-metadata.results.target-git-branch)"
       - name: namespace
         value: "$(params.NAMESPACE)"
+      - name: operator-image
+        value: "$(tasks.parse-metadata.results.component-container-image)"
       taskSpec:
         params:
           - name: git-url
@@ -169,6 +116,8 @@ spec:
           - name: git-rev
             type: string
           - name: namespace
+            type: string
+          - name: operator-image
             type: string
         volumes:
           - name: credentials
@@ -201,7 +150,7 @@ spec:
               git config --global --add safe.directory /workspace/source
               cd /workspace/source
 
-          - name: e2e
+          - name: deploy-and-e2e
             image: golang:1.23-alpine
             env:
               - name: KUBECONFIG
@@ -215,5 +164,9 @@ spec:
               && curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" \
               && install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl \
               && rm kubectl
+              # Deploy the operator
+              make deploy IMG=$(params.operator-image) OPERATOR_NAMESPACE=$(params.namespace)
+              # Wait for operator to be ready
               kubectl wait --for=condition=available --timeout=30s deployment/opendatahub-operator-controller-manager -n $(params.namespace)
+              # Run e2e tests
               make e2e-test -e E2E_TEST_OPERATOR_NAMESPACE=$(params.namespace)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
A test run has been successfully run here: https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/open-data-hub-tenant/applications/odh-release/pipelineruns/opendatahub-operator-e2e-poc-lplhx

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated integration test scenario metadata and descriptions to use "odh-operator" instead of "odh-operator-bundle."
  - Simplified the end-to-end test pipeline by combining operator deployment and testing into a single step.
  - Changed default namespace for operator deployment to "opendatahub-operator-system."
  - Removed unnecessary parameters and steps related to bundle deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->