### PR TITLE
Notebooks: Change revision option from `2024b` to `main` and add py312 components

### DIFF
--- a/gitops/opendatahub-release-components.yaml
+++ b/gitops/opendatahub-release-components.yaml
@@ -1121,6 +1121,321 @@ spec:
       dockerfileUrl: codeserver/ubi9-python-3.11/Dockerfile.cpu
       revision: "main"
       url: https://github.com/opendatahub-io/notebooks
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Component
+metadata:
+  annotations:
+    build.appstudio.openshift.io/pipeline: '{"name":"docker-build-oci-ta","bundle":"latest"}'
+    mintmaker.appstudio.redhat.com/disabled: true
+    build.appstudio.openshift.io/request: configure-pac-no-mr
+  name: odh-workbench-jupyter-minimal-cpu-py312-ubi9
+spec:
+  application: opendatahub-release
+  build-nudges-ref:
+    - nudge-only-notebooks
+  componentName: odh-workbench-jupyter-minimal-cpu-py312-ubi9
+  containerImage: quay.io/opendatahub/odh-workbench-jupyter-minimal-cpu-py312-ubi9
+  source:
+    git:
+      context: ./
+      dockerfileUrl: jupyter/minimal/ubi9-python-3.12/Dockerfile.cpu
+      revision: "main"
+      url: https://github.com/opendatahub-io/notebooks
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Component
+metadata:
+  annotations:
+    build.appstudio.openshift.io/pipeline: '{"name":"docker-build-oci-ta","bundle":"latest"}'
+    mintmaker.appstudio.redhat.com/disabled: true
+    build.appstudio.openshift.io/request: configure-pac-no-mr
+  name: odh-workbench-jupyter-minimal-cuda-py312-ubi9
+spec:
+  application: opendatahub-release
+  build-nudges-ref:
+    - nudge-only-notebooks
+  componentName: odh-workbench-jupyter-minimal-cuda-py312-ubi9
+  containerImage: quay.io/opendatahub/odh-workbench-jupyter-minimal-cuda-py312-ubi9
+  source:
+    git:
+      context: ./
+      dockerfileUrl: jupyter/minimal/ubi9-python-3.12/Dockerfile.cuda
+      revision: "main"
+      url: https://github.com/opendatahub-io/notebooks
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Component
+metadata:
+  annotations:
+    build.appstudio.openshift.io/pipeline: '{"name":"docker-build-oci-ta","bundle":"latest"}'
+    mintmaker.appstudio.redhat.com/disabled: true
+    build.appstudio.openshift.io/request: configure-pac-no-mr
+  name: odh-workbench-jupyter-minimal-rocm-py312-ubi9
+spec:
+  application: opendatahub-release
+  build-nudges-ref:
+    - nudge-only-notebooks
+  componentName: odh-workbench-jupyter-minimal-rocm-py312-ubi9
+  containerImage: quay.io/opendatahub/odh-workbench-jupyter-minimal-rocm-py312-ubi9
+  source:
+    git:
+      context: ./
+      dockerfileUrl: jupyter/minimal/ubi9-python-3.12/Dockerfile.rocm
+      revision: "main"
+      url: https://github.com/opendatahub-io/notebooks
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Component
+metadata:
+  annotations:
+    build.appstudio.openshift.io/pipeline: '{"name":"docker-build-oci-ta","bundle":"latest"}'
+    mintmaker.appstudio.redhat.com/disabled: true
+    build.appstudio.openshift.io/request: configure-pac-no-mr
+  name: odh-workbench-jupyter-datascience-cpu-py312-ubi9
+spec:
+  application: opendatahub-release
+  build-nudges-ref:
+    - nudge-only-notebooks
+  componentName: odh-workbench-jupyter-datascience-cpu-py312-ubi9
+  containerImage: quay.io/opendatahub/odh-workbench-jupyter-datascience-cpu-py312-ubi9
+  source:
+    git:
+      context: ./
+      dockerfileUrl: jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
+      revision: "main"
+      url: https://github.com/opendatahub-io/notebooks
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Component
+metadata:
+  annotations:
+    build.appstudio.openshift.io/pipeline: '{"name":"docker-build-oci-ta","bundle":"latest"}'
+    mintmaker.appstudio.redhat.com/disabled: true
+    build.appstudio.openshift.io/request: configure-pac-no-mr
+  name: odh-workbench-jupyter-pytorch-cuda-py312-ubi9
+spec:
+  application: opendatahub-release
+  build-nudges-ref:
+    - nudge-only-notebooks
+  componentName: odh-workbench-jupyter-pytorch-cuda-py312-ubi9
+  containerImage: quay.io/opendatahub/odh-workbench-jupyter-pytorch-cuda-py312-ubi9
+  source:
+    git:
+      context: ./
+      dockerfileUrl: jupyter/pytorch/ubi9-python-3.12/Dockerfile.cuda
+      revision: "main"
+      url: https://github.com/opendatahub-io/notebooks
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Component
+metadata:
+  annotations:
+    build.appstudio.openshift.io/pipeline: '{"name":"docker-build-oci-ta","bundle":"latest"}'
+    mintmaker.appstudio.redhat.com/disabled: true
+    build.appstudio.openshift.io/request: configure-pac-no-mr
+  name: odh-workbench-jupyter-pytorch-rocm-py312-ubi9
+spec:
+  application: opendatahub-release
+  build-nudges-ref:
+    - nudge-only-notebooks
+  componentName: odh-workbench-jupyter-pytorch-rocm-py312-ubi9
+  containerImage: quay.io/opendatahub/odh-workbench-jupyter-pytorch-rocm-py312-ubi9
+  source:
+    git:
+      context: ./
+      dockerfileUrl: jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.rocm
+      revision: "main"
+      url: https://github.com/opendatahub-io/notebooks
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Component
+metadata:
+  annotations:
+    build.appstudio.openshift.io/pipeline: '{"name":"docker-build-oci-ta","bundle":"latest"}'
+    mintmaker.appstudio.redhat.com/disabled: true
+    build.appstudio.openshift.io/request: configure-pac-no-mr
+  name: odh-workbench-jupyter-tensorflow-cuda-py312-ubi9
+spec:
+  application: opendatahub-release
+  build-nudges-ref:
+    - nudge-only-notebooks
+  componentName: odh-workbench-jupyter-tensorflow-cuda-py312-ubi9
+  containerImage: quay.io/opendatahub/odh-workbench-jupyter-tensorflow-cuda-py312-ubi9
+  source:
+    git:
+      context: ./
+      dockerfileUrl: jupyter/tensorflow/ubi9-python-3.12/Dockerfile.cuda
+      revision: "main"
+      url: https://github.com/opendatahub-io/notebooks
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Component
+metadata:
+  annotations:
+    build.appstudio.openshift.io/pipeline: '{"name":"docker-build-oci-ta","bundle":"latest"}'
+    mintmaker.appstudio.redhat.com/disabled: true
+    build.appstudio.openshift.io/request: configure-pac-no-mr
+  name: odh-workbench-jupyter-trustyai-cpu-py312-ubi9
+spec:
+  application: opendatahub-release
+  build-nudges-ref:
+    - nudge-only-notebooks
+  componentName: odh-workbench-jupyter-trustyai-cpu-py312-ubi9
+  containerImage: quay.io/opendatahub/odh-workbench-jupyter-trustyai-cpu-py312-ubi9
+  source:
+    git:
+      context: ./
+      dockerfileUrl: jupyter/trustyai/ubi9-python-3.12/Dockerfile.cpu
+      revision: "main"
+      url: https://github.com/opendatahub-io/notebooks
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Component
+metadata:
+  annotations:
+    build.appstudio.openshift.io/pipeline: '{"name":"docker-build-oci-ta","bundle":"latest"}'
+    mintmaker.appstudio.redhat.com/disabled: true
+    build.appstudio.openshift.io/request: configure-pac-no-mr
+  name: odh-pipeline-runtime-datascience-cpu-py312-ubi9
+spec:
+  application: opendatahub-release
+  build-nudges-ref:
+    - nudge-only-notebooks
+  componentName: odh-pipeline-runtime-datascience-cpu-py312-ubi9
+  containerImage: quay.io/opendatahub/odh-pipeline-runtime-datascience-cpu-py312-ubi9
+  source:
+    git:
+      context: ./
+      dockerfileUrl: runtimes/datascience/ubi9-python-3.12/Dockerfile.cpu
+      revision: "main"
+      url: https://github.com/opendatahub-io/notebooks
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Component
+metadata:
+  annotations:
+    build.appstudio.openshift.io/pipeline: '{"name":"docker-build-oci-ta","bundle":"latest"}'
+    mintmaker.appstudio.redhat.com/disabled: true
+    build.appstudio.openshift.io/request: configure-pac-no-mr
+  name: odh-pipeline-runtime-minimal-cpu-py312-ubi9
+spec:
+  application: opendatahub-release
+  build-nudges-ref:
+    - nudge-only-notebooks
+  componentName: odh-pipeline-runtime-minimal-cpu-py312-ubi9
+  containerImage: quay.io/opendatahub/odh-pipeline-runtime-minimal-cpu-py312-ubi9
+  source:
+    git:
+      context: ./
+      dockerfileUrl: runtimes/minimal/ubi9-python-3.12/Dockerfile.cpu
+      revision: "main"
+      url: https://github.com/opendatahub-io/notebooks
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Component
+metadata:
+  annotations:
+    build.appstudio.openshift.io/pipeline: '{"name":"docker-build-oci-ta","bundle":"latest"}'
+    mintmaker.appstudio.redhat.com/disabled: true
+    build.appstudio.openshift.io/request: configure-pac-no-mr
+  name: odh-pipeline-runtime-pytorch-cuda-py312-ubi9
+spec:
+  application: opendatahub-release
+  build-nudges-ref:
+    - nudge-only-notebooks
+  componentName: odh-pipeline-runtime-pytorch-cuda-py312-ubi9
+  containerImage: quay.io/opendatahub/odh-pipeline-runtime-pytorch-cuda-py312-ubi9
+  source:
+    git:
+      context: ./
+      dockerfileUrl: runtimes/pytorch/ubi9-python-3.12/Dockerfile.cuda
+      revision: "main"
+      url: https://github.com/opendatahub-io/notebooks
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Component
+metadata:
+  annotations:
+    build.appstudio.openshift.io/pipeline: '{"name":"docker-build-oci-ta","bundle":"latest"}'
+    mintmaker.appstudio.redhat.com/disabled: true
+    build.appstudio.openshift.io/request: configure-pac-no-mr
+  name: odh-pipeline-runtime-pytorch-rocm-py312-ubi9
+spec:
+  application: opendatahub-release
+  build-nudges-ref:
+    - nudge-only-notebooks
+  componentName: odh-pipeline-runtime-pytorch-rocm-py312-ubi9
+  containerImage: quay.io/opendatahub/odh-pipeline-runtime-pytorch-rocm-py312-ubi9
+  source:
+    git:
+      context: ./
+      dockerfileUrl: runtimes/rocm-pytorch/ubi9-python-3.12/Dockerfile.rocm
+      revision: "main"
+      url: https://github.com/opendatahub-io/notebooks
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Component
+metadata:
+  annotations:
+    build.appstudio.openshift.io/pipeline: '{"name":"docker-build-oci-ta","bundle":"latest"}'
+    mintmaker.appstudio.redhat.com/disabled: true
+    build.appstudio.openshift.io/request: configure-pac-no-mr
+  name: odh-pipeline-runtime-tensorflow-cuda-py312-ubi9
+spec:
+  application: opendatahub-release
+  build-nudges-ref:
+    - nudge-only-notebooks
+  componentName: odh-pipeline-runtime-tensorflow-cuda-py312-ubi9
+  containerImage: quay.io/opendatahub/odh-pipeline-runtime-tensorflow-cuda-py312-ubi9
+  source:
+    git:
+      context: ./
+      dockerfileUrl: runtimes/tensorflow/ubi9-python-3.12/Dockerfile.cuda
+      revision: "main"
+      url: https://github.com/opendatahub-io/notebooks
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Component
+metadata:
+  annotations:
+    build.appstudio.openshift.io/pipeline: '{"name":"docker-build-oci-ta","bundle":"latest"}'
+    mintmaker.appstudio.redhat.com/disabled: true
+    build.appstudio.openshift.io/request: configure-pac-no-mr
+  name: odh-pipeline-runtime-tensorflow-rocm-py312-ubi9
+spec:
+  application: opendatahub-release
+  build-nudges-ref:
+    - nudge-only-notebooks
+  componentName: odh-pipeline-runtime-tensorflow-rocm-py312-ubi9
+  containerImage: quay.io/opendatahub/odh-pipeline-runtime-tensorflow-rocm-py312-ubi9
+  source:
+    git:
+      context: ./
+      dockerfileUrl: runtimes/rocm-tensorflow/ubi9-python-3.12/Dockerfile.rocm
+      revision: "main"
+      url: https://github.com/opendatahub-io/notebooks
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Component
+metadata:
+  annotations:
+    build.appstudio.openshift.io/pipeline: '{"name":"docker-build-oci-ta","bundle":"latest"}'
+    mintmaker.appstudio.redhat.com/disabled: true
+    build.appstudio.openshift.io/request: configure-pac-no-mr
+  name: odh-workbench-codeserver-datascience-cpu-py312-ubi9
+spec:
+  application: opendatahub-release
+  build-nudges-ref:
+    - nudge-only-notebooks
+  componentName: odh-workbench-codeserver-datascience-cpu-py312-ubi9
+  containerImage: quay.io/opendatahub/odh-workbench-codeserver-datascience-cpu-py312-ubi9
+  source:
+    git:
+      context: ./
+      dockerfileUrl: codeserver/ubi9-python-3.12/Dockerfile.cpu
+      revision: "main"
+      url: https://github.com/opendatahub-io/notebooks
 
 ---
 apiVersion: appstudio.redhat.com/v1alpha1


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Notebooks: Change revision option from `2024b` to `main` and add py312 components

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new notebook and pipeline runtime images supporting Python 3.12, including variants for CPU, CUDA, ROCm, PyTorch, TensorFlow, Trustyai, and codeserver.

* **Chores**
  * Updated existing notebook and pipeline runtime images to use the latest source branch for future updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->