### PR TITLE
Add odh-base-image

### DIFF
--- a/gitops/opendatahub-release-components.yaml
+++ b/gitops/opendatahub-release-components.yaml
@@ -1665,3 +1665,107 @@ spec:
       dockerfileUrl: packages/model-registry/Dockerfile.workspace
       revision: modarch-poc
       url: https://github.com/opendatahub-io/odh-dashboard
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Component
+metadata:
+  annotations:
+    build.appstudio.openshift.io/pipeline: '{"name":"docker-build-oci-ta","bundle":"latest"}'
+    mintmaker.appstudio.redhat.com/disabled: true
+    build.appstudio.openshift.io/request: configure-pac-no-mr
+  name: odh-base-image-cuda-py312-c9s
+spec:
+  application: opendatahub-release
+  componentName: odh-base-image-cuda-py312-c9s
+  containerImage: quay.io/opendatahub/odh-base-image-cuda-py312-c9s
+  source:
+    git:
+      context: .
+      dockerfileUrl: base-images/cuda/12.6/c9s-python-3.12/Dockerfile.cuda
+      revision: poc
+      url: https://github.com/opendatahub-io/notebooks.git
+---
+
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Component
+metadata:
+  annotations:
+    build.appstudio.openshift.io/pipeline: '{"name":"docker-build-oci-ta","bundle":"latest"}'
+    mintmaker.appstudio.redhat.com/disabled: true
+    build.appstudio.openshift.io/request: configure-pac-no-mr
+  name: odh-base-image-cuda-py312-ubi9
+spec:
+  application: opendatahub-release
+  componentName: odh-base-image-cuda-py312-ubi9
+  containerImage: quay.io/opendatahub/odh-base-image-cuda-py312-ubi9
+  source:
+    git:
+      context: .
+      dockerfileUrl: base-images/cuda/12.6/ubi9-python-3.12/Dockerfile.cuda
+      revision: poc
+      url: https://github.com/opendatahub-io/notebooks.git
+---
+
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Component
+metadata:
+  annotations:
+    build.appstudio.openshift.io/pipeline: '{"name":"docker-build-oci-ta","bundle":"latest"}'
+    mintmaker.appstudio.redhat.com/disabled: true
+    build.appstudio.openshift.io/request: configure-pac-no-mr
+  name: odh-base-image-rocm-py312-ubi9
+spec:
+  application: opendatahub-release
+  componentName: odh-base-image-rocm-py312-ubi9
+  containerImage: quay.io/opendatahub/odh-base-image-rocm-py312-ubi9
+  source:
+    git:
+      context: .
+      dockerfileUrl: base-images/rocm/6.2/ubi9-python-3.12/Dockerfile.rocm
+      revision: poc
+      url: https://github.com/opendatahub-io/notebooks.git
+---
+
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Component
+metadata:
+  annotations:
+    build.appstudio.openshift.io/pipeline: '{"name":"docker-build-oci-ta","bundle":"latest"}'
+    mintmaker.appstudio.redhat.com/disabled: true
+    build.appstudio.openshift.io/request: configure-pac-no-mr
+  name: odh-base-image-cuda-py311-c9s
+spec:
+  application: opendatahub-release
+  componentName: odh-base-image-cuda-py311-c9s
+  containerImage: quay.io/opendatahub/odh-base-image-cuda-py311-c9s
+  source:
+    git:
+      context: .
+      dockerfileUrl: base-images/cuda/12.6/c9s-python-3.11/Dockerfile.cuda
+      revision: poc
+      url: https://github.com/opendatahub-io/notebooks.git
+---
+
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Component
+metadata:
+  annotations:
+    build.appstudio.openshift.io/pipeline: '{"name":"docker-build-oci-ta","bundle":"latest"}'
+    mintmaker.appstudio.redhat.com/disabled: true
+    build.appstudio.openshift.io/request: configure-pac-no-mr
+  name: odh-base-image-rocm-py312-c9s
+spec:
+  application: opendatahub-release
+  componentName: odh-base-image-rocm-py312-c9s
+  containerImage: quay.io/opendatahub/odh-base-image-rocm-py312-c9s
+  source:
+    git:
+      context: .
+      dockerfileUrl: base-images/rocm/6.2/c9s-python-3.12/Dockerfile.rocm
+      revision: poc
+      url: https://github.com/opendatahub-io/notebooks.git
+---


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added five new notebook base image options to the Open Data Hub release: CUDA Python 3.12 (CentOS Stream 9), CUDA Python 3.12 (UBI9), ROCm Python 3.12 (UBI9), CUDA Python 3.11 (CentOS Stream 9), and ROCm Python 3.12 (CentOS Stream 9).
  - These images are now available as components in the application, expanding options for GPU-accelerated and Python-version-specific workloads.
- Chores
  - Extended component catalog with additional base-image variants without altering existing entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->