### PR TITLE
RHAIENG-1272: change `nudge-only-notebooks` component git revision from 'main' to 'candidate'

### DIFF
--- a/gitops/opendatahub-release-components.yaml
+++ b/gitops/opendatahub-release-components.yaml
@@ -802,7 +802,7 @@ spec:
     git:
       context: ./
       dockerfileUrl: Dockerfile
-      revision: "main"
+      revision: "candidate"
       url: https://github.com/opendatahub-io/notebooks
 ---
 apiVersion: appstudio.redhat.com/v1alpha1


### PR DESCRIPTION
We want to have nudge-commits to arrive into a `candidate` branch.

```
main -> candidate -> stable
```

## Description

https://issues.redhat.com/browse/RHAIENG-1272

## How Has This Been Tested?

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
