### PR TITLE
RHAIENG-2460: Update compute resources to better perform the build and scanning, avoid OOM

### DIFF
--- a/pipelines/notebooks/multiarch-pull-request-pipeline.yaml
+++ b/pipelines/notebooks/multiarch-pull-request-pipeline.yaml
@@ -94,7 +94,7 @@ spec:
     name: privileged-nested
     type: string
   - default:
-    - linux/x86_64
+    - linux-mxlarge/amd64
     description: List of platforms to build the container images on. The available
       set of values is determined by the configuration of the multi-platform-controller.
     name: build-platforms

--- a/pipelines/notebooks/multiarch-push-pipeline.yaml
+++ b/pipelines/notebooks/multiarch-push-pipeline.yaml
@@ -112,7 +112,7 @@ spec:
     name: privileged-nested
     type: string
   - default:
-    - linux/x86_64
+    - linux-mxlarge/amd64
     description: List of platforms to build the container images on. The available
       set of values is determined by the configuration of the multi-platform-controller.
     name: build-platforms

--- a/pipelines/notebooks/odh-base-image-cpu-py312-c9s-pull-request.yaml
+++ b/pipelines/notebooks/odh-base-image-cpu-py312-c9s-pull-request.yaml
@@ -20,7 +20,7 @@ metadata:
   namespace: open-data-hub-tenant
 spec:
   timeouts:
-    pipeline: 3h
+    pipeline: 6h
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -36,7 +36,7 @@ spec:
     value: .
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-mxlarge/amd64
     - linux/arm64
   pipelineRef:
     name: multiarch-pull-request-pipeline

--- a/pipelines/notebooks/odh-base-image-cpu-py312-c9s-push.yaml
+++ b/pipelines/notebooks/odh-base-image-cpu-py312-c9s-push.yaml
@@ -30,7 +30,7 @@ spec:
     value: .
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-mxlarge/amd64
     - linux/arm64
   pipelineRef:
     name: multiarch-push-pipeline

--- a/pipelines/notebooks/odh-base-image-cpu-py312-ubi9-pull-request.yaml
+++ b/pipelines/notebooks/odh-base-image-cpu-py312-ubi9-pull-request.yaml
@@ -20,7 +20,7 @@ metadata:
   namespace: open-data-hub-tenant
 spec:
   timeouts:
-    pipeline: 3h
+    pipeline: 6h
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -36,7 +36,7 @@ spec:
     value: .
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-mxlarge/amd64
     - linux/arm64
   pipelineRef:
     name: multiarch-pull-request-pipeline

--- a/pipelines/notebooks/odh-base-image-cpu-py312-ubi9-push.yaml
+++ b/pipelines/notebooks/odh-base-image-cpu-py312-ubi9-push.yaml
@@ -30,7 +30,7 @@ spec:
     value: .
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-mxlarge/amd64
     - linux/arm64
   pipelineRef:
     name: multiarch-push-pipeline

--- a/pipelines/notebooks/odh-base-image-cuda-py311-c9s-pull-request.yaml
+++ b/pipelines/notebooks/odh-base-image-cuda-py311-c9s-pull-request.yaml
@@ -23,7 +23,7 @@ metadata:
   namespace: open-data-hub-tenant
 spec:
   timeouts:
-    pipeline: 3h
+    pipeline: 6h
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -35,12 +35,30 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-d160-m4xlarge/amd64
     - linux/arm64
   - name: dockerfile
     value: base-images/cuda/12.6/c9s-python-3.11/Dockerfile.cuda
   - name: path-context
     value: .
+  # Added taskRunSpecs to increase compute resources
+  taskRunSpecs:
+    - pipelineTaskName: clair-scan
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 32Gi
+        limits:
+          cpu: '8'
+          memory: 32Gi
+    - pipelineTaskName: ecosystem-cert-preflight-checks
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 32Gi
+        limits:
+          cpu: '8'
+          memory: 32Gi
   pipelineRef:
     name: multiarch-pull-request-pipeline
   taskRunTemplate:

--- a/pipelines/notebooks/odh-base-image-cuda-py311-c9s-push.yaml
+++ b/pipelines/notebooks/odh-base-image-cuda-py311-c9s-push.yaml
@@ -28,7 +28,7 @@ spec:
     value: base-images/cuda/12.6/c9s-python-3.11/Dockerfile.cuda
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-mxlarge/amd64
     - linux/arm64
   - name: path-context
     value: .

--- a/pipelines/notebooks/odh-base-image-cuda-py312-c9s-pull-request.yaml
+++ b/pipelines/notebooks/odh-base-image-cuda-py312-c9s-pull-request.yaml
@@ -23,7 +23,7 @@ metadata:
   namespace: open-data-hub-tenant
 spec:
   timeouts:
-    pipeline: 3h
+    pipeline: 6h
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -35,7 +35,7 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-d160-m2xlarge/amd64
     - linux/arm64
   - name: dockerfile
     value: base-images/cuda/12.6/c9s-python-3.12/Dockerfile.cuda

--- a/pipelines/notebooks/odh-base-image-cuda-py312-c9s-push.yaml
+++ b/pipelines/notebooks/odh-base-image-cuda-py312-c9s-push.yaml
@@ -28,7 +28,7 @@ spec:
     value: base-images/cuda/12.6/c9s-python-3.12/Dockerfile.cuda
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-mxlarge/amd64
     - linux/arm64
   - name: path-context
     value: .

--- a/pipelines/notebooks/odh-base-image-cuda-py312-ubi9-pull-request.yaml
+++ b/pipelines/notebooks/odh-base-image-cuda-py312-ubi9-pull-request.yaml
@@ -23,7 +23,7 @@ metadata:
   namespace: open-data-hub-tenant
 spec:
   timeouts:
-    pipeline: 3h
+    pipeline: 6h
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -35,12 +35,30 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-mxlarge/amd64
     - linux/arm64
   - name: dockerfile
     value: base-images/cuda/12.6/ubi9-python-3.12/Dockerfile.cuda
   - name: path-context
     value: .
+  # Added taskRunSpecs to increase compute resources
+  taskRunSpecs:
+    - pipelineTaskName: clair-scan
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 32Gi
+        limits:
+          cpu: '8'
+          memory: 32Gi
+    - pipelineTaskName: ecosystem-cert-preflight-checks
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 32Gi
+        limits:
+          cpu: '8'
+          memory: 32Gi
   pipelineRef:
     name: multiarch-pull-request-pipeline
   taskRunTemplate:

--- a/pipelines/notebooks/odh-base-image-cuda-py312-ubi9-push.yaml
+++ b/pipelines/notebooks/odh-base-image-cuda-py312-ubi9-push.yaml
@@ -28,7 +28,7 @@ spec:
     value: base-images/cuda/12.6/ubi9-python-3.12/Dockerfile.cuda
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-mxlarge/amd64
     - linux/arm64
   - name: path-context
     value: .

--- a/pipelines/notebooks/odh-base-image-rocm-py312-c9s-pull-request.yaml
+++ b/pipelines/notebooks/odh-base-image-rocm-py312-c9s-pull-request.yaml
@@ -23,7 +23,7 @@ metadata:
   namespace: open-data-hub-tenant
 spec:
   timeouts:
-    pipeline: 3h
+    pipeline: 6h
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -35,7 +35,7 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-d160-m2xlarge/amd64
   - name: dockerfile
     value: base-images/rocm/6.2/c9s-python-3.12/Dockerfile.rocm
   - name: path-context

--- a/pipelines/notebooks/odh-base-image-rocm-py312-ubi9-pull-request.yaml
+++ b/pipelines/notebooks/odh-base-image-rocm-py312-ubi9-pull-request.yaml
@@ -23,7 +23,7 @@ metadata:
   namespace: open-data-hub-tenant
 spec:
   timeouts:
-    pipeline: 3h
+    pipeline: 6h
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -35,11 +35,29 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-d160-m2xlarge/amd64
   - name: dockerfile
     value: base-images/rocm/6.2/ubi9-python-3.12/Dockerfile.rocm
   - name: path-context
     value: .
+  # Added taskRunSpecs to increase compute resources
+  taskRunSpecs:
+    - pipelineTaskName: clair-scan
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 32Gi
+        limits:
+          cpu: '8'
+          memory: 32Gi
+    - pipelineTaskName: ecosystem-cert-preflight-checks
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 32Gi
+        limits:
+          cpu: '8'
+          memory: 32Gi
   pipelineRef:
     name: multiarch-pull-request-pipeline
   taskRunTemplate:

--- a/pipelines/notebooks/odh-pipeline-runtime-datascience-cpu-py312-ubi9-pull-request.yaml
+++ b/pipelines/notebooks/odh-pipeline-runtime-datascience-cpu-py312-ubi9-pull-request.yaml
@@ -23,7 +23,7 @@ metadata:
   namespace: open-data-hub-tenant
 spec:
   timeouts:
-    pipeline: 3h
+    pipeline: 6h
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -35,7 +35,7 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-mxlarge/amd64
     - linux/ppc64le
     - linux/s390x
   - name: dockerfile

--- a/pipelines/notebooks/odh-pipeline-runtime-minimal-cpu-py312-ubi9-pull-request.yaml
+++ b/pipelines/notebooks/odh-pipeline-runtime-minimal-cpu-py312-ubi9-pull-request.yaml
@@ -23,7 +23,7 @@ metadata:
   namespace: open-data-hub-tenant
 spec:
   timeouts:
-    pipeline: 3h
+    pipeline: 6h
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -35,7 +35,7 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-mxlarge/amd64
     - linux/arm64
     - linux/ppc64le
     - linux/s390x

--- a/pipelines/notebooks/odh-pipeline-runtime-pytorch-cuda-py312-ubi9-pull-request.yaml
+++ b/pipelines/notebooks/odh-pipeline-runtime-pytorch-cuda-py312-ubi9-pull-request.yaml
@@ -23,7 +23,7 @@ metadata:
   namespace: open-data-hub-tenant
 spec:
   timeouts:
-    pipeline: 3h
+    pipeline: 6h
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -35,13 +35,31 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-d160-m4xlarge/amd64
   - name: dockerfile
     value: runtimes/pytorch/ubi9-python-3.12/Dockerfile.cuda
   - name: path-context
     value: .
   - name: build-args-file
     value: runtimes/pytorch/ubi9-python-3.12/build-args/cuda.conf
+  # Added taskRunSpecs to increase compute resources
+  taskRunSpecs:
+    - pipelineTaskName: clair-scan
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 32Gi
+        limits:
+          cpu: '8'
+          memory: 32Gi
+    - pipelineTaskName: ecosystem-cert-preflight-checks
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 32Gi
+        limits:
+          cpu: '8'
+          memory: 32Gi
   pipelineRef:
     name: multiarch-pull-request-pipeline
   taskRunTemplate:

--- a/pipelines/notebooks/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-ubi9-pull-request.yaml
+++ b/pipelines/notebooks/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-ubi9-pull-request.yaml
@@ -23,7 +23,7 @@ metadata:
   namespace: open-data-hub-tenant
 spec:
   timeouts:
-    pipeline: 3h
+    pipeline: 6h
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -35,13 +35,31 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-d160-m2xlarge/amd64
   - name: dockerfile
     value: runtimes/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.cuda
   - name: path-context
     value: .
   - name: build-args-file
     value: runtimes/pytorch+llmcompressor/ubi9-python-3.12/build-args/cuda.conf
+  # Added taskRunSpecs to increase compute resources
+  taskRunSpecs:
+    - pipelineTaskName: clair-scan
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 32Gi
+        limits:
+          cpu: '8'
+          memory: 32Gi
+    - pipelineTaskName: ecosystem-cert-preflight-checks
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 32Gi
+        limits:
+          cpu: '8'
+          memory: 32Gi
   pipelineRef:
     name: multiarch-pull-request-pipeline
   taskRunTemplate:

--- a/pipelines/notebooks/odh-pipeline-runtime-pytorch-rocm-py312-ubi9-pull-request.yaml
+++ b/pipelines/notebooks/odh-pipeline-runtime-pytorch-rocm-py312-ubi9-pull-request.yaml
@@ -23,7 +23,7 @@ metadata:
   namespace: open-data-hub-tenant
 spec:
   timeouts:
-    pipeline: 3h
+    pipeline: 6h
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -35,7 +35,7 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-d160-m2xlarge/amd64
   - name: dockerfile
     value: runtimes/rocm-pytorch/ubi9-python-3.12/Dockerfile.rocm
   - name: path-context

--- a/pipelines/notebooks/odh-pipeline-runtime-tensorflow-cuda-py312-ubi9-pull-request.yaml
+++ b/pipelines/notebooks/odh-pipeline-runtime-tensorflow-cuda-py312-ubi9-pull-request.yaml
@@ -23,7 +23,7 @@ metadata:
   namespace: open-data-hub-tenant
 spec:
   timeouts:
-    pipeline: 3h
+    pipeline: 6h
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -35,7 +35,7 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-d160-m2xlarge/amd64
   - name: dockerfile
     value: runtimes/tensorflow/ubi9-python-3.12/Dockerfile.cuda
   - name: path-context

--- a/pipelines/notebooks/odh-pipeline-runtime-tensorflow-rocm-py312-ubi9-pull-request.yaml
+++ b/pipelines/notebooks/odh-pipeline-runtime-tensorflow-rocm-py312-ubi9-pull-request.yaml
@@ -23,7 +23,7 @@ metadata:
   namespace: open-data-hub-tenant
 spec:
   timeouts:
-    pipeline: 3h
+    pipeline: 6h
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -35,13 +35,31 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-d160-m2xlarge/amd64
   - name: dockerfile
     value: runtimes/rocm-tensorflow/ubi9-python-3.12/Dockerfile.rocm
   - name: path-context
     value: .
   - name: build-args-file
     value: runtimes/rocm-tensorflow/ubi9-python-3.12/build-args/rocm.conf
+  # Added taskRunSpecs to increase compute resources
+  taskRunSpecs:
+    - pipelineTaskName: clair-scan
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 32Gi
+        limits:
+          cpu: '8'
+          memory: 32Gi
+    - pipelineTaskName: ecosystem-cert-preflight-checks
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 32Gi
+        limits:
+          cpu: '8'
+          memory: 32Gi
   pipelineRef:
     name: multiarch-pull-request-pipeline
   taskRunTemplate:

--- a/pipelines/notebooks/odh-workbench-codeserver-datascience-cpu-py312-ubi9-pull-request.yaml
+++ b/pipelines/notebooks/odh-workbench-codeserver-datascience-cpu-py312-ubi9-pull-request.yaml
@@ -23,7 +23,7 @@ metadata:
   namespace: open-data-hub-tenant
 spec:
   timeouts:
-    pipeline: 3h
+    pipeline: 6h
   params:
   - name: git-url
     value: '{{source_url}}'

--- a/pipelines/notebooks/odh-workbench-jupyter-datascience-cpu-py312-ubi9-pull-request.yaml
+++ b/pipelines/notebooks/odh-workbench-jupyter-datascience-cpu-py312-ubi9-pull-request.yaml
@@ -23,7 +23,7 @@ metadata:
   namespace: open-data-hub-tenant
 spec:
   timeouts:
-    pipeline: 3h
+    pipeline: 6h
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -35,7 +35,7 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-mxlarge/amd64
   - name: dockerfile
     value: jupyter/datascience/ubi9-python-3.12/Dockerfile.cpu
   - name: path-context

--- a/pipelines/notebooks/odh-workbench-jupyter-minimal-cpu-py312-ubi9-pull-request.yaml
+++ b/pipelines/notebooks/odh-workbench-jupyter-minimal-cpu-py312-ubi9-pull-request.yaml
@@ -23,7 +23,7 @@ metadata:
   namespace: open-data-hub-tenant
 spec:
   timeouts:
-    pipeline: 3h
+    pipeline: 6h
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -35,7 +35,7 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-mxlarge/amd64
     - linux/ppc64le
   - name: dockerfile
     value: jupyter/minimal/ubi9-python-3.12/Dockerfile.cpu
@@ -43,6 +43,24 @@ spec:
     value: .
   - name: build-args-file
     value: jupyter/minimal/ubi9-python-3.12/build-args/cpu.conf
+  # Added taskRunSpecs to increase compute resources
+  taskRunSpecs:
+    - pipelineTaskName: clair-scan
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 32Gi
+        limits:
+          cpu: '8'
+          memory: 32Gi
+    - pipelineTaskName: ecosystem-cert-preflight-checks
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 32Gi
+        limits:
+          cpu: '8'
+          memory: 32Gi
   pipelineRef:
     name: multiarch-pull-request-pipeline
   taskRunTemplate:

--- a/pipelines/notebooks/odh-workbench-jupyter-minimal-cuda-py312-ubi9-pull-request.yaml
+++ b/pipelines/notebooks/odh-workbench-jupyter-minimal-cuda-py312-ubi9-pull-request.yaml
@@ -23,7 +23,7 @@ metadata:
   namespace: open-data-hub-tenant
 spec:
   timeouts:
-    pipeline: 3h
+    pipeline: 6h
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -35,13 +35,31 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-d160-m4xlarge/amd64
   - name: dockerfile
     value: jupyter/minimal/ubi9-python-3.12/Dockerfile.cuda
   - name: path-context
     value: .
   - name: build-args-file
     value: jupyter/minimal/ubi9-python-3.12/build-args/cuda.conf
+  # Added taskRunSpecs to increase compute resources
+  taskRunSpecs:
+    - pipelineTaskName: clair-scan
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 32Gi
+        limits:
+          cpu: '8'
+          memory: 32Gi
+    - pipelineTaskName: ecosystem-cert-preflight-checks
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 32Gi
+        limits:
+          cpu: '8'
+          memory: 32Gi
   pipelineRef:
     name: multiarch-pull-request-pipeline
   taskRunTemplate:

--- a/pipelines/notebooks/odh-workbench-jupyter-minimal-rocm-py312-ubi9-pull-request.yaml
+++ b/pipelines/notebooks/odh-workbench-jupyter-minimal-rocm-py312-ubi9-pull-request.yaml
@@ -23,7 +23,7 @@ metadata:
   namespace: open-data-hub-tenant
 spec:
   timeouts:
-    pipeline: 3h
+    pipeline: 6h
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -35,13 +35,31 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-d160-m4xlarge/amd64
   - name: dockerfile
     value: jupyter/minimal/ubi9-python-3.12/Dockerfile.rocm
   - name: path-context
     value: .
   - name: build-args-file
     value: jupyter/minimal/ubi9-python-3.12/build-args/rocm.conf
+  # Added taskRunSpecs to increase compute resources
+  taskRunSpecs:
+    - pipelineTaskName: clair-scan
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 32Gi
+        limits:
+          cpu: '8'
+          memory: 32Gi
+    - pipelineTaskName: ecosystem-cert-preflight-checks
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 32Gi
+        limits:
+          cpu: '8'
+          memory: 32Gi
   pipelineRef:
     name: multiarch-pull-request-pipeline
   taskRunTemplate:

--- a/pipelines/notebooks/odh-workbench-jupyter-pytorch-cuda-py312-ubi9-pull-request.yaml
+++ b/pipelines/notebooks/odh-workbench-jupyter-pytorch-cuda-py312-ubi9-pull-request.yaml
@@ -23,7 +23,7 @@ metadata:
   namespace: open-data-hub-tenant
 spec:
   timeouts:
-    pipeline: 3h
+    pipeline: 6h
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -35,13 +35,31 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-d160-m4xlarge/amd64
   - name: dockerfile
     value: jupyter/pytorch/ubi9-python-3.12/Dockerfile.cuda
   - name: path-context
     value: .
   - name: build-args-file
     value: jupyter/pytorch/ubi9-python-3.12/build-args/cuda.conf
+  # Added taskRunSpecs to increase compute resources
+  taskRunSpecs:
+    - pipelineTaskName: clair-scan
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 32Gi
+        limits:
+          cpu: '8'
+          memory: 32Gi
+    - pipelineTaskName: ecosystem-cert-preflight-checks
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 32Gi
+        limits:
+          cpu: '8'
+          memory: 32Gi
   pipelineRef:
     name: multiarch-pull-request-pipeline
   taskRunTemplate:

--- a/pipelines/notebooks/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9-pull-request.yaml
+++ b/pipelines/notebooks/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9-pull-request.yaml
@@ -23,7 +23,7 @@ metadata:
   namespace: open-data-hub-tenant
 spec:
   timeouts:
-    pipeline: 3h
+    pipeline: 6h
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -35,13 +35,31 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-d160-m4xlarge/amd64
   - name: dockerfile
     value: jupyter/pytorch+llmcompressor/ubi9-python-3.12/Dockerfile.cuda
   - name: path-context
     value: .
   - name: build-args-file
     value: jupyter/pytorch+llmcompressor/ubi9-python-3.12/build-args/cuda.conf
+  # Added taskRunSpecs to increase compute resources
+  taskRunSpecs:
+    - pipelineTaskName: clair-scan
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 32Gi
+        limits:
+          cpu: '8'
+          memory: 32Gi
+    - pipelineTaskName: ecosystem-cert-preflight-checks
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 32Gi
+        limits:
+          cpu: '8'
+          memory: 32Gi
   pipelineRef:
     name: multiarch-pull-request-pipeline
   taskRunTemplate:

--- a/pipelines/notebooks/odh-workbench-jupyter-pytorch-rocm-py312-ubi9-pull-request.yaml
+++ b/pipelines/notebooks/odh-workbench-jupyter-pytorch-rocm-py312-ubi9-pull-request.yaml
@@ -23,7 +23,7 @@ metadata:
   namespace: open-data-hub-tenant
 spec:
   timeouts:
-    pipeline: 3h
+    pipeline: 6h
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -35,13 +35,31 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-d160-m2xlarge/amd64
   - name: dockerfile
     value: jupyter/rocm/pytorch/ubi9-python-3.12/Dockerfile.rocm
   - name: path-context
     value: .
   - name: build-args-file
     value: jupyter/rocm/pytorch/ubi9-python-3.12/build-args/rocm.conf
+  # Added taskRunSpecs to increase compute resources
+  taskRunSpecs:
+    - pipelineTaskName: clair-scan
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 32Gi
+        limits:
+          cpu: '8'
+          memory: 32Gi
+    - pipelineTaskName: ecosystem-cert-preflight-checks
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 32Gi
+        limits:
+          cpu: '8'
+          memory: 32Gi
   pipelineRef:
     name: multiarch-pull-request-pipeline
   taskRunTemplate:

--- a/pipelines/notebooks/odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-pull-request.yaml
+++ b/pipelines/notebooks/odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-pull-request.yaml
@@ -23,7 +23,7 @@ metadata:
   namespace: open-data-hub-tenant
 spec:
   timeouts:
-    pipeline: 3h
+    pipeline: 6h
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -35,7 +35,7 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-d160-m2xlarge/amd64
   - name: dockerfile
     value: jupyter/tensorflow/ubi9-python-3.12/Dockerfile.cuda
   - name: path-context

--- a/pipelines/notebooks/odh-workbench-jupyter-tensorflow-rocm-py312-ubi9-pull-request.yaml
+++ b/pipelines/notebooks/odh-workbench-jupyter-tensorflow-rocm-py312-ubi9-pull-request.yaml
@@ -23,7 +23,7 @@ metadata:
   namespace: open-data-hub-tenant
 spec:
   timeouts:
-    pipeline: 3h
+    pipeline: 6h
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -35,13 +35,31 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-d160-m2xlarge/amd64
   - name: dockerfile
     value: jupyter/rocm/tensorflow/ubi9-python-3.12/Dockerfile.rocm
   - name: path-context
     value: .
   - name: build-args-file
     value: jupyter/rocm/tensorflow/ubi9-python-3.12/build-args/rocm.conf
+  # Added taskRunSpecs to increase compute resources
+  taskRunSpecs:
+    - pipelineTaskName: clair-scan
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 32Gi
+        limits:
+          cpu: '8'
+          memory: 32Gi
+    - pipelineTaskName: ecosystem-cert-preflight-checks
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 32Gi
+        limits:
+          cpu: '8'
+          memory: 32Gi
   pipelineRef:
     name: multiarch-pull-request-pipeline
   taskRunTemplate:

--- a/pipelines/notebooks/odh-workbench-jupyter-trustyai-cpu-py312-ubi9-pull-request.yaml
+++ b/pipelines/notebooks/odh-workbench-jupyter-trustyai-cpu-py312-ubi9-pull-request.yaml
@@ -23,7 +23,7 @@ metadata:
   namespace: open-data-hub-tenant
 spec:
   timeouts:
-    pipeline: 3h
+    pipeline: 6h
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -35,7 +35,7 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-d160-m2xlarge/amd64
   - name: dockerfile
     value: jupyter/trustyai/ubi9-python-3.12/Dockerfile.cpu
   - name: path-context

--- a/pipelines/notebooks/odh-workbench-rstudio-minimal-cpu-py312-rhel9-pull-request.yaml
+++ b/pipelines/notebooks/odh-workbench-rstudio-minimal-cpu-py312-rhel9-pull-request.yaml
@@ -23,7 +23,7 @@ metadata:
   namespace: open-data-hub-tenant
 spec:
   timeouts:
-    pipeline: 3h
+    pipeline: 6h
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -35,7 +35,7 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-mxlarge/amd64
   - name: dockerfile
     value: rstudio/rhel9-python-3.12/Dockerfile.cpu
   - name: path-context

--- a/pipelines/notebooks/odh-workbench-rstudio-minimal-cuda-py312-rhel9-pull-request.yaml
+++ b/pipelines/notebooks/odh-workbench-rstudio-minimal-cuda-py312-rhel9-pull-request.yaml
@@ -23,7 +23,7 @@ metadata:
   namespace: open-data-hub-tenant
 spec:
   timeouts:
-    pipeline: 3h
+    pipeline: 6h
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -35,13 +35,31 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux/x86_64
+    - linux-d160-m4xlarge/amd64
   - name: dockerfile
     value: rstudio/rhel9-python-3.12/Dockerfile.cuda
   - name: path-context
     value: .
   - name: build-args-file
     value: rstudio/rhel9-python-3.12/build-args/cuda.conf
+  # Added taskRunSpecs to increase compute resources
+  taskRunSpecs:
+    - pipelineTaskName: clair-scan
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 32Gi
+        limits:
+          cpu: '8'
+          memory: 32Gi
+    - pipelineTaskName: ecosystem-cert-preflight-checks
+      computeResources:
+        requests:
+          cpu: '8'
+          memory: 32Gi
+        limits:
+          cpu: '8'
+          memory: 32Gi
   pipelineRef:
     name: multiarch-pull-request-pipeline
   taskRunTemplate:


### PR DESCRIPTION
First changing from x86_64 to amd4, then resolving the resource issues by stepping to the larger size, to avoid OOM. Also update compute resource for clair-scan and ecosystem-cert-preflight-checks

## Description

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Updated build platform configurations across multiple pipelines to use optimized hardware variants
* Extended pipeline execution timeouts from 3 to 6 hours to accommodate longer processing requirements
* Increased compute resource allocations for specialized build tasks to 8 CPUs and 32GB memory for improved performance

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->