### PR TITLE
chore(notebooks): update additional-tags to `3.4_ea1-v1.41` in PipelineRun YAMLs

### DIFF
--- a/pipelineruns/notebooks/odh-pipeline-runtime-datascience-cpu-py312-ubi9-push.yaml
+++ b/pipelineruns/notebooks/odh-pipeline-runtime-datascience-cpu-py312-ubi9-push.yaml
@@ -32,7 +32,7 @@ spec:
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
-    - 2025a-v1.35
+    - 3.4_ea1-v1.41
   pipelineRef:
     name: singlearch-push-pipeline
   taskRunTemplate:

--- a/pipelineruns/notebooks/odh-pipeline-runtime-minimal-cpu-py312-ubi9-push.yaml
+++ b/pipelineruns/notebooks/odh-pipeline-runtime-minimal-cpu-py312-ubi9-push.yaml
@@ -32,7 +32,7 @@ spec:
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
-    - 2025a-v1.35
+    - 3.4_ea1-v1.41
   pipelineRef:
     name: singlearch-push-pipeline
   taskRunTemplate:

--- a/pipelineruns/notebooks/odh-pipeline-runtime-pytorch-cuda-py312-ubi9-push.yaml
+++ b/pipelineruns/notebooks/odh-pipeline-runtime-pytorch-cuda-py312-ubi9-push.yaml
@@ -34,7 +34,7 @@ spec:
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
-    - 2025a-v1.35
+    - 3.4_ea1-v1.41
   taskRunSpecs:
   - pipelineTaskName: build-container
     stepSpecs:

--- a/pipelineruns/notebooks/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-ubi9-push.yaml
+++ b/pipelineruns/notebooks/odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-ubi9-push.yaml
@@ -34,7 +34,7 @@ spec:
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
-    - 2025a-v1.35
+    - 3.4_ea1-v1.41
   taskRunSpecs:
   - pipelineTaskName: build-container
     stepSpecs:

--- a/pipelineruns/notebooks/odh-pipeline-runtime-pytorch-rocm-py312-ubi9-push.yaml
+++ b/pipelineruns/notebooks/odh-pipeline-runtime-pytorch-rocm-py312-ubi9-push.yaml
@@ -34,7 +34,7 @@ spec:
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
-    - 2025a-v1.35
+    - 3.4_ea1-v1.41
   pipelineRef:
     name: singlearch-push-pipeline
   taskRunTemplate:

--- a/pipelineruns/notebooks/odh-pipeline-runtime-tensorflow-cuda-py312-ubi9-push.yaml
+++ b/pipelineruns/notebooks/odh-pipeline-runtime-tensorflow-cuda-py312-ubi9-push.yaml
@@ -34,7 +34,7 @@ spec:
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
-    - 2025a-v1.35
+    - 3.4_ea1-v1.41
   taskRunSpecs:
   - pipelineTaskName: ecosystem-cert-preflight-checks
     computeResources:

--- a/pipelineruns/notebooks/odh-pipeline-runtime-tensorflow-rocm-py312-ubi9-push.yaml
+++ b/pipelineruns/notebooks/odh-pipeline-runtime-tensorflow-rocm-py312-ubi9-push.yaml
@@ -34,7 +34,7 @@ spec:
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
-    - 2025a-v1.35
+    - 3.4_ea1-v1.41
   taskRunSpecs:
   - pipelineTaskName: build-container
     stepSpecs:

--- a/pipelineruns/notebooks/odh-workbench-codeserver-datascience-cpu-py312-ubi9-push.yaml
+++ b/pipelineruns/notebooks/odh-workbench-codeserver-datascience-cpu-py312-ubi9-push.yaml
@@ -32,7 +32,7 @@ spec:
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
-    - 2025a-v1.35
+    - 3.4_ea1-v1.41
   pipelineRef:
     name: singlearch-push-pipeline
   taskRunTemplate:

--- a/pipelineruns/notebooks/odh-workbench-jupyter-datascience-cpu-py312-ubi9-push.yaml
+++ b/pipelineruns/notebooks/odh-workbench-jupyter-datascience-cpu-py312-ubi9-push.yaml
@@ -32,7 +32,7 @@ spec:
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
-    - 2025a-v1.35
+    - 3.4_ea1-v1.41
   taskRunSpecs:
   - pipelineTaskName: build-container
     stepSpecs:

--- a/pipelineruns/notebooks/odh-workbench-jupyter-minimal-cpu-py312-ubi9-push.yaml
+++ b/pipelineruns/notebooks/odh-workbench-jupyter-minimal-cpu-py312-ubi9-push.yaml
@@ -32,7 +32,7 @@ spec:
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
-    - 2025a-v1.35
+    - 3.4_ea1-v1.41
   pipelineRef:
     name: singlearch-push-pipeline
   taskRunTemplate:

--- a/pipelineruns/notebooks/odh-workbench-jupyter-minimal-cuda-py312-ubi9-push.yaml
+++ b/pipelineruns/notebooks/odh-workbench-jupyter-minimal-cuda-py312-ubi9-push.yaml
@@ -32,7 +32,7 @@ spec:
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
-    - 2025a-v1.35
+    - 3.4_ea1-v1.41
   pipelineRef:
     name: singlearch-push-pipeline
   taskRunTemplate:

--- a/pipelineruns/notebooks/odh-workbench-jupyter-minimal-rocm-py312-ubi9-push.yaml
+++ b/pipelineruns/notebooks/odh-workbench-jupyter-minimal-rocm-py312-ubi9-push.yaml
@@ -34,7 +34,7 @@ spec:
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
-    - 2025a-v1.35
+    - 3.4_ea1-v1.41
   taskRunSpecs:
   - pipelineTaskName: build-container
     stepSpecs:

--- a/pipelineruns/notebooks/odh-workbench-jupyter-pytorch-cuda-py312-ubi9-push.yaml
+++ b/pipelineruns/notebooks/odh-workbench-jupyter-pytorch-cuda-py312-ubi9-push.yaml
@@ -32,7 +32,7 @@ spec:
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
-    - 2025a-v1.35
+    - 3.4_ea1-v1.41
   taskRunSpecs:
   - pipelineTaskName: build-container
     stepSpecs:

--- a/pipelineruns/notebooks/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9-push.yaml
+++ b/pipelineruns/notebooks/odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9-push.yaml
@@ -32,7 +32,7 @@ spec:
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
-    - 2025a-v1.35
+    - 3.4_ea1-v1.41
   taskRunSpecs:
   - pipelineTaskName: build-container
     stepSpecs:

--- a/pipelineruns/notebooks/odh-workbench-jupyter-pytorch-rocm-py312-ubi9-push.yaml
+++ b/pipelineruns/notebooks/odh-workbench-jupyter-pytorch-rocm-py312-ubi9-push.yaml
@@ -32,7 +32,7 @@ spec:
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
-    - 2025a-v1.35
+    - 3.4_ea1-v1.41
   taskRunSpecs:
   - pipelineTaskName: build-container
     stepSpecs:

--- a/pipelineruns/notebooks/odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-push.yaml
+++ b/pipelineruns/notebooks/odh-workbench-jupyter-tensorflow-cuda-py312-ubi9-push.yaml
@@ -32,7 +32,7 @@ spec:
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
-    - 2025a-v1.35
+    - 3.4_ea1-v1.41
   pipelineRef:
     name: singlearch-push-pipeline
   taskRunTemplate:

--- a/pipelineruns/notebooks/odh-workbench-jupyter-tensorflow-rocm-py312-ubi9-push.yaml
+++ b/pipelineruns/notebooks/odh-workbench-jupyter-tensorflow-rocm-py312-ubi9-push.yaml
@@ -34,7 +34,7 @@ spec:
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
-    - 2025a-v1.35
+    - 3.4_ea1-v1.41
   pipelineRef:
     name: singlearch-push-pipeline
   taskRunTemplate:

--- a/pipelineruns/notebooks/odh-workbench-jupyter-trustyai-cpu-py312-ubi9-push.yaml
+++ b/pipelineruns/notebooks/odh-workbench-jupyter-trustyai-cpu-py312-ubi9-push.yaml
@@ -34,7 +34,7 @@ spec:
   - name: additional-tags
     value:
     - '{{target_branch}}-{{revision}}'
-    - 2025a-v1.35
+    - 3.4_ea1-v1.41
   pipelineRef:
     name: singlearch-push-pipeline
   taskRunTemplate:


### PR DESCRIPTION
Needs to be reworked in view of

* https://github.com/opendatahub-io/odh-konflux-central/pull/119

## Description

Looking at diff in

* https://github.com/opendatahub-io/notebooks/pull/2842/changes

I see that we need to update the version tag

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container image tags across notebook and workbench pipeline configurations to reflect new runtime versions. All affected build pipelines now reference updated base image versions for consistent deployment across multiple runtime variants including CPU, CUDA, ROCm, and specialized configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->