### PR TITLE
fix(notebooks): use correct platform flavor name for CUDA base image

### DIFF
--- a/pipelineruns/notebooks/odh-base-image-cuda-12-8-py312-c9s-push.yaml
+++ b/pipelineruns/notebooks/odh-base-image-cuda-12-8-py312-c9s-push.yaml
@@ -27,7 +27,7 @@ spec:
     value: base-images/cuda/12.8/c9s-python-3.12/Dockerfile.cuda
   - name: build-platforms
     value:
-    - linux-d160-m2xlarge
+    - linux-d160-m2xlarge/amd64
     - linux-d160-m2xlarge/arm64
   - name: path-context
     value: .


### PR DESCRIPTION
Specifying 'linux-d160-m2xlarge' without the '/amd64' architecture suffix was causing PipelineRuns to be stuck in Pending because the Konflux multi-platform controller could not match it to a valid cluster resource. This aligns the push pipeline with the pull-request pipeline and official documentation.

## Description

* https://github.com/opendatahub-io/notebooks/pull/2854

I have applied the same fix to the external repository as requested and verified all platform flavors against the provided documentation.

### Changes Implemented

I updated the following file in the `/Users/jdanek/IdeaProjects/odh-konflux-central/pipelineruns/notebooks` directory to fix the invalid platform naming pattern:

- **`odh-base-image-cuda-12-8-py312-c9s-push.yaml`**: Changed `linux-d160-m2xlarge` to `linux-d160-m2xlarge/amd64`.

The fix was applied using `sed` to ensure exact line replacement:

```bash
sed -i '' 's/linux-d160-m2xlarge$/linux-d160-m2xlarge\/amd64/' /Users/jdanek/IdeaProjects/odh-konflux-central/pipelineruns/notebooks/odh-base-image-cuda-12-8-py312-c9s-push.yaml
```

### Flavor Validation Against Documentation

I performed a comprehensive check of all `build-platforms` values in the `/Users/jdanek/IdeaProjects/odh-konflux-central/pipelineruns/notebooks` directory. Here is how the flavors used in the pipelines compare to the official documentation you provided:

| Flavor Pattern Used | Architecture | Doc Status | Notes |
| :--- | :--- | :--- | :--- |
| `linux-mxlarge/amd64` | `amd64` | ✅ Valid | Matches m6a.xlarge (4 CPU, 16GB RAM) |
| `linux-d160-m2xlarge/amd64` | `amd64` | ✅ Valid | Matches m6a.2xlarge with 160GB disk |
| `linux-d160-m2xlarge/arm64` | `arm64` | ✅ Valid | Matches m6g.2xlarge with 160GB disk |
| `linux-m2xlarge/arm64` | `arm64` | ✅ Valid | Matches m6g.2xlarge (8 CPU, 32GB RAM) |
| `linux-extra-fast/amd64` | `amd64` | ✅ Valid | Listed in Cluster Variant table |
| `linux-d160-m4xlarge/amd64` | `amd64` | ✅ Valid | Matches m6a.4xlarge with 160GB disk |
| `linux/x86_64` | `x86_64` | ✅ Valid | Standard default AMD64 pattern |

### Verification Results

1.  **External Directory (`odh-konflux-central`)**: A search for the pattern `linux-` without a `/` architecture suffix now returns **zero results**, confirming all instances have been fixed.
2.  **Local Directory (`.tekton`)**: Already verified and consistent with the naming convention.
3.  **Consistency**: All identified flavors (`mxlarge`, `d160-m2xlarge`, `m2xlarge`, `extra-fast`, `d160-m4xlarge`) correspond to valid instance types or cluster variants defined in the Konflux documentation.

The pipelines are now correctly configured to request resources using the `<flavor>/<architecture>` syntax required by the Konflux multi-platform controller.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined build platform configuration to explicitly target AMD64 architecture alongside existing ARM64 support, improving build consistency across multi-architecture deployments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->