### PR TITLE
Fix duplicate annotation key in odh-mod-arch-gen-ai component

### DIFF
--- a/gitops/opendatahub-release-components.yaml
+++ b/gitops/opendatahub-release-components.yaml
@@ -1797,7 +1797,6 @@ metadata:
     build.appstudio.openshift.io/request: configure-pac-no-mr
     build.appstudio.openshift.io/pipeline: '{"name":"docker-build-oci-ta","bundle":"latest"}'
     mintmaker.appstudio.redhat.com/disabled: true
-    build.appstudio.openshift.io/request: configure-pac-no-mr
   name: odh-mod-arch-gen-ai
 spec:
   application: opendatahub-release


### PR DESCRIPTION
## Summary

Removes a duplicate `build.appstudio.openshift.io/request` annotation from the `odh-mod-arch-gen-ai` component definition in `gitops/opendatahub-release-components.yaml`.

## Problem

The component had the same annotation key defined twice:

```yaml
metadata:
  annotations:
    build.appstudio.openshift.io/request: configure-pac-no-mr  # First occurrence
    build.appstudio.openshift.io/pipeline: '{"name":"docker-build-oci-ta","bundle":"latest"}'
    mintmaker.appstudio.redhat.com/disabled: true
    build.appstudio.openshift.io/request: configure-pac-no-mr  # Duplicate - removed
```

This causes yamllint to report a `key-duplicates` error, and while YAML parsers typically use the last value, having duplicate keys is invalid YAML and can lead to unexpected behavior.

## Solution

Remove the duplicate annotation key, keeping the first occurrence.

## Test plan

- [x] Run `yamllint gitops/opendatahub-release-components.yaml` - no errors
- [x] Verify the component still has the required annotation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed a duplicated configuration annotation to clean up the release manifest.
  * Result: reduced redundancy in component metadata, improving clarity and maintainability of deployment definitions without functional changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->