### PR TITLE
run metadata push earlier in the workflow

### DIFF
--- a/pipeline/multi-arch-operator-build.yaml
+++ b/pipeline/multi-arch-operator-build.yaml
@@ -734,10 +734,6 @@ spec:
             git add --sparse components/odh-operator/${OUTPUT_IMAGE_DIGEST}
             git commit -m "build-meta for operator image ${OUTPUT_IMAGE_DIGEST}"
             git push
-    when:
-    - input: "$(tasks.build-image-index.status)"
-      operator: in
-      values: ["Succeeded"]
     workspaces:
     - name: basic-auth
       workspace: git-auth

--- a/pipeline/multi-arch-operator-build.yaml
+++ b/pipeline/multi-arch-operator-build.yaml
@@ -754,8 +754,6 @@ spec:
     - apply-tags
     - push-dockerfile
     - rpms-signature-scan
-    - sast-coverity-check
-    - coverity-availability-check
     - push-build-metadata
     taskSpec:
       steps:

--- a/pipeline/multi-arch-operator-build.yaml
+++ b/pipeline/multi-arch-operator-build.yaml
@@ -653,28 +653,10 @@ spec:
       operator: in
       values:
       - "false"
-  - name: pipeline-success-indicator
-    runAfter:
-    - build-source-image
-    - sast-shell-check
-    - sast-unicode-check
-    - deprecated-base-image-check
-    - clair-scan
-    - ecosystem-cert-preflight-checks
-    - sast-snyk-check
-    - clamav-scan
-    - apply-tags
-    - push-dockerfile
-    - rpms-signature-scan
-    taskSpec:
-      steps:
-      - name: noop
-        image: quay.io/rhoai-konflux/alpine:latest
-        script: |
-          echo "Success"
-  finally:
   - name: push-build-metadata
     description: push-build-metadata
+    runAfter:
+    - build-image-index
     params:
     - name: build-metadata-repo
       value: "$(params.build-metadata-repo)"
@@ -752,8 +734,6 @@ spec:
             git add --sparse components/odh-operator/${OUTPUT_IMAGE_DIGEST}
             git commit -m "build-meta for operator image ${OUTPUT_IMAGE_DIGEST}"
             git push
-
-
     when:
     - input: "$(tasks.build-image-index.status)"
       operator: in
@@ -761,6 +741,29 @@ spec:
     workspaces:
     - name: basic-auth
       workspace: git-auth
+  - name: pipeline-success-indicator
+    runAfter:
+    - build-source-image
+    - sast-shell-check
+    - sast-unicode-check
+    - deprecated-base-image-check
+    - clair-scan
+    - ecosystem-cert-preflight-checks
+    - sast-snyk-check
+    - clamav-scan
+    - apply-tags
+    - push-dockerfile
+    - rpms-signature-scan
+    - sast-coverity-check
+    - coverity-availability-check
+    - push-build-metadata
+    taskSpec:
+      steps:
+      - name: noop
+        image: quay.io/rhoai-konflux/alpine:latest
+        script: |
+          echo "Success"
+  finally:
   - name: show-sbom
     params:
     - name: IMAGE_URL


### PR DESCRIPTION
## Problem

In `multi-arch-operator-build.yaml`, the `push-build-metadata` task was placed in the `finally` block. This meant it ran concurrently with or after `pipeline-success-indicator`, which signals pipeline completion. Downstream processes like `trigger-bundle-build` depend on the build metadata being available, but could be triggered before `push-build-metadata` had finished — a race condition.

## Fix

- Moved `push-build-metadata` out of `finally` and into the regular tasks section, running after `build-image-index`
- Added `push-build-metadata` to the `runAfter` list of `pipeline-success-indicator`

This ensures metadata is always pushed **before** the pipeline signals success

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved pipeline sequencing so build metadata is pushed only after image index builds finish.
  * Added a pipeline success indicator to make overall build completion explicit.
  * Final notifications and downstream triggers now depend on the success indicator, reducing false or premature alerts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->