### PR TITLE
Add artifact collection and finally block to MaaS pipeline

### DIFF
--- a/integration-tests/models-as-a-service/pr-test-pipelinerun.yaml
+++ b/integration-tests/models-as-a-service/pr-test-pipelinerun.yaml
@@ -12,6 +12,12 @@ spec:
       - description: Snapshot of the application
         name: SNAPSHOT
         type: string
+      - name: oci-artifacts-repo
+        default: 'quay.io/opendatahub/odh-ci-artifacts'
+        description: The OCI container used to store all test artifacts.
+      - name: artifact-browser-url
+        default: 'https://app-artifact-browser.apps.rosa.konflux-qe.zmr9.p3.openshiftapps.com'
+        description: The URL for browsing test artifacts.
     tasks:
       - name: parse-metadata
         taskRef:
@@ -95,6 +101,11 @@ spec:
           results:
           - name: event-type
             description: "stores info about event type"
+          - name: pull-request-author
+          - name: pull-request-number
+          - name: git-repo
+          - name: git-org
+          - name: git-revision
           steps:
           - image: quay.io/konflux-ci/konflux-test:stable
             env:
@@ -102,11 +113,36 @@ spec:
                 valueFrom:
                   fieldRef:
                     fieldPath: metadata.labels['pac.test.appstudio.openshift.io/event-type']
+              - name: PR_AUTHOR
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.annotations['pac.test.appstudio.openshift.io/sender']
+              - name: PR_NUMBER
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.labels['pac.test.appstudio.openshift.io/pull-request']
+              - name: GIT_REPO
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.annotations['pac.test.appstudio.openshift.io/url-repository']
+              - name: GIT_ORG
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.annotations['pac.test.appstudio.openshift.io/url-org']
+              - name: GIT_REVISION
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.annotations['pac.test.appstudio.openshift.io/sha']
             script: |
               #!/bin/bash
               set -e
               echo "EVENT_TYPE=${EVENT_TYPE}"
               echo -n "${EVENT_TYPE}" > $(results.event-type.path)
+              echo -n "${PR_AUTHOR}" > "$(results.pull-request-author.path)"
+              echo -n "${PR_NUMBER}" > "$(results.pull-request-number.path)"
+              echo -n "${GIT_REPO}" > "$(results.git-repo.path)"
+              echo -n "${GIT_ORG}" > "$(results.git-org.path)"
+              echo -n "${GIT_REVISION}" > "$(results.git-revision.path)"
 
       - name: provision-eaas-space
         runAfter:
@@ -185,6 +221,7 @@ spec:
             operator: notin
             values: ["push"]
       - name: e2e-maas-api-openshift
+        timeout: 1h
         runAfter:
           - provision-cluster
         params:
@@ -244,9 +281,12 @@ spec:
 
             - name: e2e-maas-api-openshift
               image: quay.io/rhoai/rhoai-task-toolset:maas
+              onError: continue
               env:
                 - name: KUBECONFIG
                   value: "/credentials/$(steps.get-kubeconfig.results.kubeconfig)"
+                - name: ARTIFACT_DIR
+                  value: /workspace/artifacts-dir
                 - name: MAAS_API_IMAGE
                   value: "$(params.maas-api-image)"
                 - name: MAAS_CONTROLLER_IMAGE
@@ -259,7 +299,166 @@ spec:
                 set -euxo pipefail
                 bash
                 ./test/e2e/scripts/prow_run_smoke_test.sh
+            - name: must-gather
+              onError: continue
+              image: quay.io/rhoai/rhoai-task-toolset:maas
+              env:
+                - name: KUBECONFIG
+                  value: "/credentials/$(steps.get-kubeconfig.results.kubeconfig)"
+                - name: ARTIFACT_DIR
+                  value: /workspace/artifacts-dir
+              workingDir: /workspace/source
+              volumeMounts:
+                - name: credentials
+                  mountPath: /credentials
+              script: |
+                #!/bin/bash
+                # models-as-a-service must-gather
+                mkdir -p "${ARTIFACT_DIR}/gather-models-as-a-service"
+                oc adm must-gather --image=quay.io/chkulkar/must-gather:maas-test-v3 --dest-dir "${ARTIFACT_DIR}/gather-models-as-a-service" -- "export COMPONENT=maas; /usr/bin/gather"
+
+                # openshift-must-gather
+                mkdir -p "${ARTIFACT_DIR}/gather-openshift"
+                oc adm must-gather --dest-dir "${ARTIFACT_DIR}/gather-openshift"
+            - name: git-push-artifacts
+              ref:
+                resolver: git
+                params:
+                  - name: url
+                    value: https://github.com/red-hat-data-services/rhoai-konflux-tasks.git
+                  - name: revision
+                    value: main
+                  - name: pathInRepo
+                    value: stepactions/secure-git-push/0.1/secure-git-push.yaml
+              params:
+                - name: source-path
+                  value: /workspace/artifacts-dir
+                - name: repo-path
+                  value: 'opendatahub-io/odh-build-metadata'
+                - name: repo-branch
+                  value: 'ci-artifacts'
+                - name: sparse-file-path
+                  value: 'test-artifacts/docs'
+                - name: dest-path
+                  value: 'test-artifacts/$(context.pipelineRun.name)'
+                - name: pipelinerun-name
+                  value: $(context.pipelineRun.name)
+            - name: check-test-exit-code
+              image: quay.io/konflux-ci/konflux-test:stable
+              script: |
+                #!/bin/bash
+                EXIT_CODE=$(cat $(steps.e2e-maas-api-openshift.exitCode.path))
+                if [ "${EXIT_CODE}" != "0" ]; then
+                  echo "Tests failed with exit code ${EXIT_CODE}"
+                  exit "${EXIT_CODE}"
+                fi
         when:
           - input: "$(tasks.check-prerequisites.results.event-type)"
             operator: notin
             values: ["push"]
+
+    finally:
+    - name: push-ci-artifacts-and-update-pr
+      params:
+        - name: oci-artifacts-repo
+          value: $(params.oci-artifacts-repo)
+        - name: pipeline-status
+          value: $(tasks.status)
+      taskSpec:
+        volumes:
+          - name: odh-registry-secret-volume
+            secret:
+              secretName: odh-registry-secret
+              items:
+              - key: .dockerconfigjson
+                path: oci-storage-dockerconfigjson
+        params:
+          - name: oci-artifacts-repo
+            description: oci-artifacts-repo
+          - name: pipeline-status
+            type: string
+        steps:
+          - name: pull-ci-artifacts
+            ref:
+              resolver: git
+              params:
+                - name: url
+                  value: https://github.com/red-hat-data-services/rhoai-konflux-tasks.git
+                - name: revision
+                  value: main
+                - name: pathInRepo
+                  value: stepactions/git-clone/0.1/git-clone.yaml
+            params:
+              - name: repo-path
+                value: 'opendatahub-io/odh-build-metadata'
+              - name: repo-branch
+                value: 'ci-artifacts'
+              - name: sparse-file-path
+                value: 'test-artifacts/$(context.pipelineRun.name)'
+              - name: dest-path
+                value: /workspace/odh-ci-artifacts
+              - name: artifacts-dir-path
+                value: 'test-artifacts/$(context.pipelineRun.name)'
+          - name: secure-push-oci
+            ref:
+              resolver: git
+              params:
+                - name: url
+                  value: https://github.com/red-hat-data-services/rhoai-konflux-tasks.git
+                - name: revision
+                  value: main
+                - name: pathInRepo
+                  value: stepactions/secure-push-oci/0.1/secure-push-oci.yaml
+            params:
+              - name: workdir-path
+                value: '/workspace/odh-ci-artifacts/test-artifacts/$(context.pipelineRun.name)'
+              - name: oci-ref
+                value: $(params.oci-artifacts-repo):$(context.pipelineRun.name)
+              - name: credentials-volume-name
+                value: odh-registry-secret-volume
+          - name: share-status-on-pull-request
+            ref:
+              resolver: git
+              params:
+                - name: url
+                  value: https://github.com/red-hat-data-services/rhoai-konflux-tasks.git
+                - name: revision
+                  value: main
+                - name: pathInRepo
+                  value: stepactions/pull-request-comment/0.1/pull-request-comment.yaml
+            params:
+              - name: test-name
+                value: $(context.pipelineRun.name)
+              - name: oci-container
+                value: $(params.oci-artifacts-repo):$(context.pipelineRun.name)
+              - name: pipeline-aggregate-status
+                value: $(params.pipeline-status)
+              - name: pull-request-author
+                value: $(tasks.check-prerequisites.results.pull-request-author)
+              - name: pull-request-number
+                value: $(tasks.check-prerequisites.results.pull-request-number)
+              - name: git-repo
+                value: $(tasks.check-prerequisites.results.git-repo)
+              - name: git-org
+                value: $(tasks.check-prerequisites.results.git-org)
+              - name: git-revision
+                value: $(tasks.check-prerequisites.results.git-revision)
+              - name: artifact-browser-url
+                value: $(params.artifact-browser-url)
+          - name: cleanup-artifacts-from-git
+            ref:
+              resolver: git
+              params:
+                - name: url
+                  value: https://github.com/red-hat-data-services/rhoai-konflux-tasks.git
+                - name: revision
+                  value: main
+                - name: pathInRepo
+                  value: stepactions/cleanup-git-repo/0.1/cleanup-git-repo.yaml
+            params:
+              - name: work-dir
+                value: '/workspace/odh-ci-artifacts'
+              - name: artifacts-dir-path
+                value: 'test-artifacts'
+              - name: dir-to-be-deleted
+                value: '$(context.pipelineRun.name)'


### PR DESCRIPTION
## summary
Add artifact collection, `must-gather` to the MaaS PR pipeline via a `finally` block.

## description
- New params: `oci-artifacts-repo`, `artifact-browser-url`.
- `check-prerequisites` now emits PR metadata (author, number, repo, org, revision) for commenting.
- E2E uses `ARTIFACT_DIR`; e2e + `must-gather` use `onError: continue` so artifacts run on failure; `git-push-artifacts` stages to `ci-artifacts`; `check-test-exit-code` preserves e2e failure.
- `finally`: pull staged artifacts → push OCI → PR comment with links → cleanup git staging.
- `e2e-maas-api-openshift` task timeout set to `1h`.
Defaults keep parameter behavior compatible; failed runs still get artifacts and `finally`, while the task fails on non-zero e2e.
## how it was tested
- YAML/review only; validate by running a PR pipeline and checking OCI tag, PR comment, and failure path with `must-gather` + `finally`.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Test artifacts are automatically collected, pushed to a configurable OCI repository, and linked via an artifact browser.
  * Pull requests receive pipeline status updates and artifact links; PR and Git metadata (author, number, repo, org, revision) are captured and shared.

* **Chores**
  * CI: extended test timeout, continue post-test steps on errors, automated artifact gather/publish, and explicit failure handling when tests exit non‑zero.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->