### PR TITLE
ci: export pipeline logs to OCI artifacts

### DIFF
--- a/pipeline/multi-arch-container-build.yaml
+++ b/pipeline/multi-arch-container-build.yaml
@@ -766,6 +766,28 @@ spec:
       operator: in
       values:
       - "true"
+  - name: export-pipeline-logs
+    taskRef:
+      resolver: git
+      params:
+      - name: url
+        value: https://github.com/konflux-ci/tekton-integration-catalog.git
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: tasks/export-logs/0.1/export-logs-to-quay.yaml
+    params:
+    - name: quay-repo
+      value: quay.io/opendatahub/odh-ci-artifacts
+    - name: pipeline-run-name
+      value: $(context.pipelineRun.name)
+    - name: namespace
+      value: $(context.pipelineRun.namespace)
+    - name: artifact-credentials-secret
+      value: odh-registry-secret
+    workspaces:
+    - name: shared-data
+      workspace: pipeline-logs
   - name: trigger-operator-build
     workspaces:
     - name: basic-auth
@@ -803,4 +825,6 @@ spec:
   - name: git-auth
     optional: true
   - name: netrc
+    optional: true
+  - name: pipeline-logs
     optional: true


### PR DESCRIPTION
## Summary
- Adds `export-pipeline-logs` task to the `finally` block of `multi-arch-container-build.yaml`
- Logs are pushed to `quay.io/opendatahub/odh-ci-artifacts` (same repo as e2e test artifacts), not attached to the build image
- Downloadable via `oras pull quay.io/opendatahub/odh-ci-artifacts:<pipelinerun-name>-<timestamp>-logs`

## Problem
Build pipeline failures (scan failures, image build errors) are not debuggable after PipelineRun pruning (`max-keep-runs: 3`). The Konflux UI only shows logs while the run exists on the cluster. Once pruned, all diagnostic information is lost.

The group test pipeline already pushes must-gather artifacts to `odh-ci-artifacts` via OCI, but the build pipeline has no equivalent — a build failure simply vanishes.

## Solution
Uses the upstream [`export-pipeline-logs`](https://github.com/konflux-ci/tekton-integration-catalog/tree/main/tasks/export-logs/0.1) task from `konflux-ci/tekton-integration-catalog`. This task:
1. Collects all TaskRun pod logs into a single `all-logs.txt`
2. Archives as `logs.tar.gz`
3. Pushes as an OCI artifact to the configured registry

Pointed at `quay.io/opendatahub/odh-ci-artifacts` to keep production image repos clean and align with the existing artifact storage pattern from the group test pipeline.

## Open questions
- [ ] The `pipeline-logs` workspace is marked `optional`. Tekton v1 provides an implicit `emptyDir` for optional unbound workspaces — need to verify this works in practice or whether callers (`.tekton/` PipelineRun configs) need to explicitly bind `pipeline-logs: emptyDir: {}`
- [ ] Confirm `odh-registry-secret` is available to the build pipeline's service accounts (it's used in the group test pipeline already)

## Test plan
- [ ] Trigger a build on a PR and confirm logs appear in `odh-ci-artifacts`
- [ ] Trigger a failing build and confirm logs are still exported (finally block)
- [ ] Verify `oras pull` retrieves the logs artifact
- [ ] Verify the task works without explicit workspace binding from callers

🤖 Generated with [Claude Code](https://claude.com/claude-code)