### PR TITLE
ci: export pipeline logs for kserve group test

### DIFF
--- a/integration-tests/kserve/pr-group-testing-pipeline.yaml
+++ b/integration-tests/kserve/pr-group-testing-pipeline.yaml
@@ -1619,6 +1619,28 @@ spec:
             echo "deploy-and-e2e step succeeded"
 
   finally:
+  - name: export-pipeline-logs
+    taskRef:
+      resolver: git
+      params:
+      - name: url
+        value: https://github.com/konflux-ci/tekton-integration-catalog.git
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: tasks/export-logs/0.1/export-logs-to-quay.yaml
+    params:
+    - name: quay-repo
+      value: $(params.oci-artifacts-repo)
+    - name: pipeline-run-name
+      value: $(context.pipelineRun.name)
+    - name: namespace
+      value: $(context.pipelineRun.namespace)
+    - name: artifact-credentials-secret
+      value: odh-registry-secret
+    workspaces:
+    - name: shared-data
+      workspace: pipeline-logs
   - name: push-ci-artifacts-and-update-pr
     workspaces:
     - name: basic-auth
@@ -1734,4 +1756,6 @@ spec:
   - name: git-auth
     optional: true
   - name: netrc
+    optional: true
+  - name: pipeline-logs
     optional: true

--- a/integration-tests/kserve/pr-group-testing-pipeline.yaml
+++ b/integration-tests/kserve/pr-group-testing-pipeline.yaml
@@ -1758,4 +1758,3 @@ spec:
   - name: netrc
     optional: true
   - name: pipeline-logs
-    optional: true


### PR DESCRIPTION
## Summary
- Adds `export-pipeline-logs` task to the `finally` block of `integration-tests/kserve/pr-group-testing-pipeline.yaml`
- Tekton task logs are pushed to the same `oci-artifacts-repo` (`quay.io/opendatahub/odh-ci-artifacts`) as the existing must-gather artifacts
- Downloadable via `oras pull quay.io/opendatahub/odh-ci-artifacts:<pipelinerun-name>-<timestamp>-logs`

## Problem
The group test pipeline already pushes must-gather artifacts (pod logs, CRDs, events) to Quay as OCI artifacts, but the Tekton task logs themselves (setup scripts, image builds, test runner output) are not preserved. After PipelineRun pruning (`max-keep-runs: 3`), these logs are lost.

This makes it difficult to debug failures in the setup/provisioning steps that happen *before* must-gather runs — for example, cluster provisioning timeouts or KServe installation errors.

## Solution
Uses the upstream [`export-pipeline-logs`](https://github.com/konflux-ci/tekton-integration-catalog/tree/main/tasks/export-logs/0.1) task. Placed first in the `finally` block so it runs before the artifact push, ensuring logs are collected even if other finally tasks fail.

Companion PR for the build pipeline: #226

## Test plan
- [ ] Trigger a group test via `/group-test` on a kserve PR
- [ ] Verify logs artifact appears in `odh-ci-artifacts` alongside must-gather
- [ ] Verify `oras pull` retrieves both must-gather and logs artifacts
- [ ] Verify logs are captured on a failing run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic export of pipeline logs after test runs, improving diagnostics and auditability.

* **Bug Fixes**
  * Ensured pipeline log workspace is declared so the final export step can access and upload logs reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->