### PR TITLE
add trainer-ci integration test scenario

### DIFF
--- a/gitops/integration-testing-prerequisites.yaml
+++ b/gitops/integration-testing-prerequisites.yaml
@@ -155,3 +155,26 @@ spec:
         value: integration-tests/opendatahub-operator/pr-test-pipelinerun.yaml
     resolver: git
     resourceKind: pipelinerun
+---
+apiVersion: appstudio.redhat.com/v1beta2
+kind: IntegrationTestScenario
+metadata:
+  labels:
+    test.appstudio.openshift.io/optional: "false"
+  name: trainer-ci-its-manual
+  namespace: open-data-hub-tenant
+spec:
+  application: opendatahub-builds
+  contexts:
+    - description: execute the integration test when component trainer-ci updates
+      name: component_trainer-ci
+  resolverRef:
+    params:
+      - name: url
+        value: https://github.com/opendatahub-io/odh-konflux-central.git
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: integration-tests/trainer/pr-testing-pipeline.yaml
+    resolver: git
+    resourceKind: pipelinerun


### PR DESCRIPTION
## Description

Add an IntegrationTestScenario resource for the `trainer-ci` component to `gitops/integration-testing-prerequisites.yaml`.

This wires up the existing trainer integration test pipeline (`integration-tests/trainer/pr-testing-pipeline.yaml`) so that Konflux automatically triggers it when the `trainer-ci` component is updated.

## How Has This Been Tested?

- Verified the ITS resource follows the same pattern as existing scenarios (odh-model-controller, models-as-a-service, odh-operator)
- The `trainer-ci` component already exists in Konflux

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
