### PR TITLE
feat: Add bundle and FBC pipeline support for ODH operator releases

### DIFF
--- a/.github/workflows/odh-konflux-onboarder.yml
+++ b/.github/workflows/odh-konflux-onboarder.yml
@@ -217,6 +217,7 @@ jobs:
 
                 sed -i -E 's|\$\$OUTPUT_IMAGE_TAG\$\$|'"${EFFECTIVE_TAG}"'|g' "$target_file"
                 sed -i -E 's|\$\$TARGET_BRANCH\$\$|'"${TARGET_BRANCH}"'|g' "$target_file"
+                sed -i -E 's|\$\$BUILD_TYPE\$\$|'"${{ inputs.build_type }}"'|g' "$target_file"
 
               ########################################
               # Other pipelines
@@ -256,8 +257,43 @@ jobs:
               sed -i -E 's|(name: .*)-on-push|\1-on-release-push|' "$target_file"
               sed -i -E 's|\$\$OUTPUT_IMAGE_TAG\$\$|'"${VERSION}"'|g' "$target_file"
               sed -i -E 's|\$\$TARGET_BRANCH\$\$|'"${TARGET_BRANCH}"'|g' "$target_file"
+              sed -i -E 's|\$\$BUILD_TYPE\$\$|'"${{ inputs.build_type }}"'|g' "$target_file"
 
             done
+          fi
+
+          ##################################################
+          # ODH OPERATOR RELEASE BUNDLE/FBC PIPELINES
+          ##################################################
+
+          # Process bundle and FBC pipelines for opendatahub-operator only
+          if [ "${{ inputs.component }}" = "opendatahub-operator" ] && [ "$BUILD_TYPE" = "Release" ]; then
+            echo "Processing opendatahub-operator release bundle/FBC pipelines"
+
+            # Extract VERSION from OUTPUT_IMAGE_TAG (remove 'v' prefix if present)
+            VERSION_VALUE=$(echo "${VERSION}" | sed 's/^v//')
+
+            release_folder="$repo_folder/release"
+
+            if [ -d "$release_folder" ]; then
+              find "$release_folder" -type f -name "*-release-push.yaml" | while read src_file; do
+
+                base_name=$(basename "$src_file")
+                target_file=".tekton/$base_name"
+
+                echo "Processing release template: $target_file"
+                cp "$src_file" "$target_file"
+
+                # Apply standard substitutions
+                sed -i -E 's|\$\$OUTPUT_IMAGE_TAG\$\$|'"${VERSION}"'|g' "$target_file"
+                sed -i -E 's|\$\$TARGET_BRANCH\$\$|'"${TARGET_BRANCH}"'|g' "$target_file"
+                sed -i -E 's|\$\$BUILD_TYPE\$\$|'"${{ inputs.build_type }}"'|g' "$target_file"
+                sed -i -E 's|\$\$VERSION\$\$|'"${VERSION_VALUE}"'|g' "$target_file"
+
+              done
+            else
+              echo "No release/ folder found for opendatahub-operator"
+            fi
           fi
 
           ##################################################

--- a/integration-tests/opendatahub-operator/e2e-test.yaml
+++ b/integration-tests/opendatahub-operator/e2e-test.yaml
@@ -101,11 +101,11 @@ spec:
               echo -n "${EVENT_TYPE}" > $(results.event-type.path)
               echo -n "${PR_NUMBER}" > $(results.pr-number.path)
 
-              if [ -n "${PR_NUMBER}" ] || [ "${BUILD_TYPE}" = "RELEASE" ]; then
-                echo "Prerequisites met: PR_NUMBER is set or BUILD_TYPE is RELEASE"
+              if [ -n "${PR_NUMBER}" ] || [ "${BUILD_TYPE}" = "Release" ]; then
+                echo "Prerequisites met: PR_NUMBER is set or BUILD_TYPE is Release"
                 echo -n "true" > $(results.prerequisites-met.path)
               else
-                echo "Prerequisites not met: PR_NUMBER is empty and BUILD_TYPE is not RELEASE"
+                echo "Prerequisites not met: PR_NUMBER is empty and BUILD_TYPE is not Release"
                 echo -n "false" > $(results.prerequisites-met.path)
               fi
 

--- a/integration-tests/opendatahub-operator/pr-test-pipelinerun.yaml
+++ b/integration-tests/opendatahub-operator/pr-test-pipelinerun.yaml
@@ -68,9 +68,12 @@ spec:
         params:
           - name: BUILD_TYPE
             value: $(params.BUILD_TYPE)
+          - name: TARGET_BRANCH
+            value: $(tasks.parse-metadata.results.target-git-branch)
         taskSpec:
           params:
           - name: BUILD_TYPE
+          - name: TARGET_BRANCH
           results:
           - name: event-type
             description: "stores info about event type"
@@ -90,6 +93,8 @@ spec:
                 valueFrom:
                   fieldRef:
                     fieldPath: metadata.labels['pac.test.appstudio.openshift.io/pull-request']
+              - name: TARGET_BRANCH
+                value: $(params.TARGET_BRANCH)
               - name: BUILD_TYPE
                 value: $(params.BUILD_TYPE)
             script: |
@@ -97,15 +102,23 @@ spec:
               set -e
               echo "EVENT_TYPE=${EVENT_TYPE}"
               echo "PR_NUMBER=${PR_NUMBER}"
+              echo "TARGET_BRANCH=${TARGET_BRANCH}"
               echo "BUILD_TYPE=${BUILD_TYPE}"
               echo -n "${EVENT_TYPE}" > $(results.event-type.path)
               echo -n "${PR_NUMBER}" > $(results.pr-number.path)
 
-              if [ -n "${PR_NUMBER}" ] || [ "${BUILD_TYPE}" = "RELEASE" ]; then
-                echo "Prerequisites met: PR_NUMBER is set or BUILD_TYPE is RELEASE"
+              # Check if target branch matches ODH release pattern (odh-x.y.z or odh-x.y.z-anything)
+              ODH_RELEASE_BRANCH=""
+              if [[ "${TARGET_BRANCH}" =~ ^odh-[0-9]+\.[0-9]+\.[0-9]+.*$ ]]; then
+                ODH_RELEASE_BRANCH="true"
+                echo "Target branch matches ODH release pattern: ${TARGET_BRANCH}"
+              fi
+
+              if [ -n "${PR_NUMBER}" ] || [ "${BUILD_TYPE}" = "Release" ] || [ "${ODH_RELEASE_BRANCH}" = "true" ]; then
+                echo "Prerequisites met: PR_NUMBER is set, BUILD_TYPE is Release, or TARGET_BRANCH matches ODH release pattern"
                 echo -n "true" > $(results.prerequisites-met.path)
               else
-                echo "Prerequisites not met: PR_NUMBER is empty and BUILD_TYPE is not RELEASE"
+                echo "Prerequisites not met: PR_NUMBER is empty, BUILD_TYPE is not Release, and TARGET_BRANCH doesn't match ODH release pattern"
                 echo -n "false" > $(results.prerequisites-met.path)
               fi
 

--- a/integration-tests/opendatahub-operator/pr-test-pipelinerun.yaml
+++ b/integration-tests/opendatahub-operator/pr-test-pipelinerun.yaml
@@ -19,6 +19,22 @@ spec:
       - name: BUILD_TYPE
         type: string
         default: "CI"
+      - name: repo-owner
+        type: string
+        default: "opendatahub-io"
+        description: "Owner of the FBC processor repository"
+      - name: repo-name
+        type: string
+        default: "opendatahub-operator"
+        description: "Name of the FBC processor repository"
+      - name: fbc-workflow
+        type: string
+        default: "release-process-fbc-fragment.yaml"
+        description: "GitHub Actions workflow file to trigger"
+      - name: fbc-enabled
+        type: string
+        default: "true"
+        description: "Whether to trigger FBC processing after successful E2E"
     tasks:
       - name: parse-metadata
         taskRef:
@@ -308,3 +324,82 @@ spec:
           - input: "$(tasks.check-prerequisites.results.prerequisites-met)"
             operator: in
             values: ["true"]
+
+    finally:
+      - name: trigger-fbc-processor
+        when:
+          - input: "$(tasks.status)"
+            operator: in
+            values: ["Succeeded"]
+          - input: "$(params.BUILD_TYPE)"
+            operator: in
+            values: ["Release"]
+          - input: "$(params.fbc-enabled)"
+            operator: in
+            values: ["true"]
+        params:
+          - name: release-branch
+            value: "$(tasks.parse-metadata.results.target-git-branch)"
+          - name: build-commit
+            value: "$(tasks.parse-metadata.results.source-git-revision)"
+          - name: pr-number
+            value: "$(tasks.parse-metadata.results.pull-request-number)"
+          - name: component-image
+            value: "$(tasks.parse-metadata.results.component-container-image)"
+          - name: test-event-type
+            value: "$(tasks.parse-metadata.results.test-event-type)"
+        taskSpec:
+          params:
+            - name: release-branch
+            - name: build-commit
+            - name: pr-number
+            - name: component-image
+            - name: test-event-type
+          steps:
+            - name: trigger-fbc-workflow
+              image: quay.io/rhoai/rhoai-task-toolset:its
+              env:
+                - name: GITHUB_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: rhods-ci
+                      key: secret
+                - name: FBC_REPO_OWNER
+                  value: "$(params.repo-owner)"
+                - name: FBC_REPO_NAME
+                  value: "$(params.repo-name)"
+                - name: FBC_WORKFLOW_FILE
+                  value: "$(params.fbc-workflow)"
+              script: |
+                #!/bin/bash
+                set -e
+
+                # For Release builds, use the release branch (e.g., odh-3.4.0)
+                TARGET_REF="$(params.release-branch)"
+
+                echo "Triggering FBC processor workflow for successful E2E completion"
+                echo "Repository: $FBC_REPO_OWNER/$FBC_REPO_NAME"
+                echo "Workflow: $FBC_WORKFLOW_FILE"
+                echo "Target ref: $TARGET_REF"
+                echo "Build type: Release"
+                echo "Release branch: $(params.release-branch)"
+                echo "Build commit: $(params.build-commit)"
+
+                # Validate that target ref follows ODH release pattern
+                if [[ ! "$TARGET_REF" =~ ^odh-[0-9]+\.[0-9]+\.[0-9]+.*$ ]]; then
+                  echo "WARNING: Target ref '$TARGET_REF' does not match ODH release pattern (odh-x.y.z)"
+                  echo "FBC processor workflow requires branches starting with 'odh-' and will not run otherwise"
+                  exit 0
+                fi
+
+                curl -f -X POST "https://api.github.com/repos/$FBC_REPO_OWNER/$FBC_REPO_NAME/actions/workflows/$FBC_WORKFLOW_FILE/dispatches" \
+                  -H "Accept: application/vnd.github.v3+json" \
+                  -H "Authorization: Bearer $GITHUB_TOKEN" \
+                  -H "Content-Type: application/json" \
+                  -d "{\"ref\": \"$TARGET_REF\"}" || {
+                    echo "WARNING: Failed to trigger FBC processor workflow, but continuing pipeline"
+                    echo "This may be due to network issues or insufficient permissions"
+                    exit 0
+                  }
+
+                echo "FBC processor workflow triggered successfully on branch: $TARGET_REF"

--- a/pipeline/multi-arch-operator-build.yaml
+++ b/pipeline/multi-arch-operator-build.yaml
@@ -734,6 +734,14 @@ spec:
             git add --sparse components/odh-operator/${OUTPUT_IMAGE_DIGEST}
             git commit -m "build-meta for operator image ${OUTPUT_IMAGE_DIGEST}"
             git push
+
+    when:
+    - input: "$(tasks.build-image-index.status)"
+      operator: in
+      values: ["Succeeded"]
+    - input: "$(params.build-type)"
+      operator: notin
+      values: ["Release"]
     workspaces:
     - name: basic-auth
       workspace: git-auth
@@ -830,6 +838,9 @@ spec:
       operator: in
       values:
         - "push"
+    - input: "$(params.build-type)"
+      operator: notin
+      values: ["Release"]
   workspaces:
   - name: git-auth
     optional: true

--- a/pipelineruns/opendatahub-operator/odh-operator-push.yaml
+++ b/pipelineruns/opendatahub-operator/odh-operator-push.yaml
@@ -39,7 +39,9 @@ spec:
     - '{{target_branch}}-{{revision}}'
   - name: build-args
     value:
-    - BUILD_TYPE=CI
+    - BUILD_TYPE=$$BUILD_TYPE$$
+  - name: build-type
+    value: $$BUILD_TYPE$$
   pipelineRef:
     resolver: git
     params:

--- a/pipelineruns/opendatahub-operator/release/odh-operator-bundle-release-push.yaml
+++ b/pipelineruns/opendatahub-operator/release/odh-operator-bundle-release-push.yaml
@@ -1,0 +1,93 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/opendatahub-operator?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    # Trigger on bundle file changes, Dockerfile changes, or manual test comments
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      (event == "push" && target_branch == "$$TARGET_BRANCH$$" &&
+       ("bundle/**".pathChanged() || "Dockerfiles/bundle.Dockerfile".pathChanged() ||
+        ".tekton/odh-operator-bundle-release-push.yaml".pathChanged())) ||
+      (event == "test-comment" && target_branch == "$$TARGET_BRANCH$$")
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: opendatahub-builds
+    appstudio.openshift.io/component: odh-operator-bundle-ci
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-operator-bundle-release-on-push
+  namespace: open-data-hub-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/opendatahub/opendatahub-operator-bundle:$$OUTPUT_IMAGE_TAG$$
+  - name: dockerfile
+    value: Dockerfiles/bundle.Dockerfile
+  - name: path-context
+    value: .
+  - name: rebuild
+    value: "true"
+  - name: skip-checks
+    value: "false"
+  - name: hermetic
+    value: "false"
+  - name: prefetch-input
+    value: ""
+  - name: image-expires-after
+    value: "7d"
+  - name: build-source-image
+    value: "false"
+  - name: build-image-index
+    value: "false"
+  - name: buildah-format
+    value: "docker"
+  - name: enable-cache-proxy
+    value: "false"
+  - name: privileged-nested
+    value: "false"
+  - name: build-args-file
+    value: ""
+  - name: build-args
+    value:
+    - OPERATOR_VERSION=$$VERSION$$
+    - IMG_TAG=$$OUTPUT_IMAGE_TAG$$
+    - IMAGE_TAG_BASE=quay.io/opendatahub/opendatahub-operator
+    - BUNDLE_IMG=quay.io/opendatahub/opendatahub-operator-bundle:$$OUTPUT_IMAGE_TAG$$
+    - GOLANG_VERSION=1.25
+    - BUILD_TYPE=$$BUILD_TYPE$$
+  - name: additional-labels
+    value:
+    - version=$$VERSION$$
+    - release=$$TARGET_BRANCH$$
+    - git.url={{source_url}}
+    - git.commit={{revision}}
+    - git.branch={{target_branch}}
+  - name: enable-slack-failure-notification
+    value: "true"
+  - name: pipeline-type
+    value: "push"
+  - name: expected-cluster
+    value: ""
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/opendatahub-io/odh-konflux-central.git
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipeline/bundle-build.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-odh-operator-bundle-ci
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/pipelineruns/opendatahub-operator/release/odh-operator-fbc-release-push.yaml
+++ b/pipelineruns/opendatahub-operator/release/odh-operator-fbc-release-push.yaml
@@ -1,0 +1,97 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/opendatahub-operator?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    # Trigger on catalog file changes, FBC Dockerfile changes, or manual test comments
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      (event == "push" && target_branch == "$$TARGET_BRANCH$$" &&
+       ("catalog/**".pathChanged() || "Dockerfiles/catalog.Dockerfile".pathChanged() ||
+        ".tekton/odh-operator-fbc-release-push.yaml".pathChanged())) ||
+      (event == "test-comment" && target_branch == "$$TARGET_BRANCH$$")
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: opendatahub-builds
+    appstudio.openshift.io/component: odh-fbc-fragment-ci
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-operator-fbc-release-on-push
+  namespace: open-data-hub-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/opendatahub/opendatahub-operator-catalog:$$OUTPUT_IMAGE_TAG$$
+  - name: dockerfile
+    value: Dockerfiles/catalog.Dockerfile
+  - name: path-context
+    value: .
+  - name: rebuild
+    value: "true"
+  - name: skip-checks
+    value: "true"
+  - name: skip-fips
+    value: "true"
+  - name: hermetic
+    value: "false"
+  - name: prefetch-input
+    value: ""
+  - name: image-expires-after
+    value: "30d"
+  - name: build-source-image
+    value: "false"
+  - name: buildah-format
+    value: "docker"
+  - name: enable-cache-proxy
+    value: "false"
+  - name: privileged-nested
+    value: "false"
+  - name: build-args-file
+    value: ""
+  - name: build-args
+    value:
+    - CATALOG_VERSION=$$VERSION$$
+    - OPERATOR_VERSION=$$VERSION$$
+    - BUNDLE_VERSION=$$OUTPUT_IMAGE_TAG$$
+    - BUNDLE_IMAGE=quay.io/opendatahub/opendatahub-operator-bundle:$$OUTPUT_IMAGE_TAG$$
+    - BUILD_TYPE=$$BUILD_TYPE$$
+  - name: additional-labels
+    value:
+    - version=$$VERSION$$
+    - release=$$TARGET_BRANCH$$
+    - git.url={{source_url}}
+    - git.commit={{revision}}
+    - git.branch={{target_branch}}
+  - name: build-platforms
+    value:
+    - linux/x86_64
+  - name: build-image-index
+    value: "true"
+  - name: enable-slack-failure-notification
+    value: "true"
+  - name: pipeline-type
+    value: "push"
+  - name: expected-cluster
+    value: ""
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/opendatahub-io/odh-konflux-central.git
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipeline/multi-arch-catalog-build.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-odh-fbc-fragment-ci
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}


### PR DESCRIPTION
Extend the onboarder workflow to support bundle and FBC (File-Based Catalog) pipelines specifically for opendatahub-operator release builds. This enables complete ODH release workflows while preserving existing CI functionality.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD to support dynamic BUILD_TYPE substitution and release-only processing paths.
  * Tightened final-step conditions to skip or alter tasks for Release builds.
  * Standardized BUILD_TYPE casing and updated prerequisite checks to recognize ODH release branch patterns.

* **New Features**
  * Added automated release pipelines for operator bundle and catalog builds with configurable triggers, build arguments, and run controls.
  * Added conditional post-run workflow dispatch for Release branches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->