### PR TITLE
fix trainer ITS check-test-exit-code step

### DIFF
--- a/integration-tests/trainer/pr-testing-pipeline.yaml
+++ b/integration-tests/trainer/pr-testing-pipeline.yaml
@@ -163,6 +163,8 @@ spec:
           volumes:
             - name: credentials
               emptyDir: {}
+            - name: test-status
+              emptyDir: {}
           steps:
             - name: get-kubeconfig
               ref:
@@ -202,9 +204,13 @@ spec:
               volumeMounts:
                 - name: credentials
                   mountPath: /credentials
+                - name: test-status
+                  mountPath: /test-status
               script: |
                 #!/bin/bash
                 set -e
+                STATUS_FILE="/test-status/deploy-and-e2e-status"
+                echo "failed" > "$STATUS_FILE"
                 oc whoami
                 oc get pods -A
 
@@ -332,16 +338,9 @@ spec:
                 echo "Running RHOAI e2e tests..."
                 make ginkgo
                 mkdir -p "${ARTIFACT_DIR}"
-                set +e
                 ./bin/ginkgo -v --junit-report=junit.xml --output-dir="${ARTIFACT_DIR}" ./test/e2e/rhai/...
-                TEST_EXIT_CODE=$?
-                set -e
 
-
-                if [ "${TEST_EXIT_CODE}" -ne 0 ]; then
-                  oc logs -n opendatahub -l app.kubernetes.io/name=trainer || true
-                  exit "${TEST_EXIT_CODE}"
-                fi
+                echo "success" > "$STATUS_FILE"
             - name: must-gather
               onError: continue
               image: quay.io/rhoai/rhoai-task-toolset:trainer
@@ -384,14 +383,17 @@ spec:
                 - name: pipelinerun-name
                   value: $(context.pipelineRun.name)
             - name: check-test-exit-code
-              image: quay.io/konflux-ci/konflux-test:stable
+              image: alpine
+              volumeMounts:
+                - name: test-status
+                  mountPath: /test-status
               script: |
-                #!/bin/bash
-                EXIT_CODE=$(cat $(steps.deploy-and-e2e.exitCode.path))
-                if [ "${EXIT_CODE}" != "0" ]; then
-                  echo "Tests failed with exit code ${EXIT_CODE}"
-                  exit "${EXIT_CODE}"
+                STATUS_FILE="/test-status/deploy-and-e2e-status"
+                if ! [ -f "$STATUS_FILE" ] || [ "$(cat "$STATUS_FILE")" != "success" ]; then
+                  echo "Failing pipeline because deploy-and-e2e step failed"
+                  exit 1
                 fi
+                echo "deploy-and-e2e step succeeded"
 
     finally:
     - name: push-ci-artifacts-and-update-pr


### PR DESCRIPTION
## Summary
- The `check-test-exit-code` step used invalid Tekton syntax `$(steps.deploy-and-e2e.exitCode.path)` which Tekton did not resolve, causing bash to interpret it as a command (`command not found`)
- Switched to the STATUS_FILE pattern (shared `emptyDir` volume with success/failed sentinel) used by kserve, feast, and template ITS

## Test plan
- [ ] Trigger a trainer PR test and verify the `check-test-exit-code` step runs without errors
- [ ] Verify a failing ginkgo run correctly fails the pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced testing pipeline status tracking mechanism to improve reliability of test execution verification across pipeline steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->