### PR TITLE
fix(maas): harden MaaS PR integration pipeline

### DIFF
--- a/integration-tests/models-as-a-service/pr-test-pipelinerun.yaml
+++ b/integration-tests/models-as-a-service/pr-test-pipelinerun.yaml
@@ -221,7 +221,7 @@ spec:
             operator: notin
             values: ["push"]
       - name: e2e-maas-api-openshift
-        timeout: 1h
+        timeout: 1h30m
         runAfter:
           - provision-cluster
         params:
@@ -313,10 +313,6 @@ spec:
                   mountPath: /credentials
               script: |
                 #!/bin/bash
-                # models-as-a-service must-gather
-                mkdir -p "${ARTIFACT_DIR}/gather-models-as-a-service"
-                oc adm must-gather --image=quay.io/chkulkar/must-gather:maas-test-v3 --dest-dir "${ARTIFACT_DIR}/gather-models-as-a-service" -- "export COMPONENT=maas; /usr/bin/gather"
-
                 # openshift-must-gather
                 mkdir -p "${ARTIFACT_DIR}/gather-openshift"
                 oc adm must-gather --dest-dir "${ARTIFACT_DIR}/gather-openshift"
@@ -343,15 +339,6 @@ spec:
                   value: 'test-artifacts/$(context.pipelineRun.name)'
                 - name: pipelinerun-name
                   value: $(context.pipelineRun.name)
-            - name: check-test-exit-code
-              image: quay.io/konflux-ci/konflux-test:stable
-              script: |
-                #!/bin/bash
-                EXIT_CODE=$(cat $(steps.e2e-maas-api-openshift.exitCode.path))
-                if [ "${EXIT_CODE}" != "0" ]; then
-                  echo "Tests failed with exit code ${EXIT_CODE}"
-                  exit "${EXIT_CODE}"
-                fi
         when:
           - input: "$(tasks.check-prerequisites.results.event-type)"
             operator: notin
@@ -364,6 +351,8 @@ spec:
           value: $(params.oci-artifacts-repo)
         - name: pipeline-status
           value: $(tasks.status)
+        - name: artifact-browser-url
+          value: $(params.artifact-browser-url)
       taskSpec:
         volumes:
           - name: odh-registry-secret-volume
@@ -377,6 +366,9 @@ spec:
             description: oci-artifacts-repo
           - name: pipeline-status
             type: string
+          - name: artifact-browser-url
+            type: string
+            description: url for browsing oci test artifacts
         steps:
           - name: pull-ci-artifacts
             ref:


### PR DESCRIPTION
## summary

Updates the Models-as-a-service PR `PipelineRun` for reliable failures, artifacts, and longer e2e runs.

## description

- Remove the broken `check-test-exit-code` step (invalid Tekton substitution for step exit paths); pipeline and finally `$(tasks.status)` still reflect e2e outcome.
- Keep only default `oc adm must-gather`; drop the RHOAI odh-must-gather-rhel9 MaaS-specific image gather.
- Increase `e2e-maas-api-openshift` task timeout to `1h30m`.
- Pass `artifact-browser-url` from the pipeline into the finally `taskSpec` so `pull-request-comment` gets a defined parameter.
- Tidy the must-gather step script (no stray blank line).

## how it was tested

- Not executed in-cluster; YAML reviewed locally. Recommend exercising a PAC PR run and confirming finally PR comment includes the artifact browser link and e2e respects the new timeout.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Increased test pipeline timeout from 1 hour to 1.5 hours for improved reliability.
  * Removed diagnostic data collection step from test execution.
  * Enhanced artifact reporting with new browser URL parameter for test results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->