### PR TITLE
fix(maas): fail MaaS PR e2e task when pytest fails

### DIFF
--- a/integration-tests/models-as-a-service/pr-test-pipelinerun.yaml
+++ b/integration-tests/models-as-a-service/pr-test-pipelinerun.yaml
@@ -339,6 +339,17 @@ spec:
                   value: 'test-artifacts/$(context.pipelineRun.name)'
                 - name: pipelinerun-name
                   value: $(context.pipelineRun.name)
+            - name: check-test-exit-code
+              image: quay.io/konflux-ci/konflux-test:stable
+              script: |
+                #!/bin/bash
+                set -euo pipefail
+                EXIT_CODE=$(cat $(steps.step-e2e-maas-api-openshift.exitCode.path))
+                if [ "${EXIT_CODE}" != "0" ]; then
+                  echo "e2e tests failed with exit code ${EXIT_CODE}"
+                  exit "${EXIT_CODE}"
+                fi
+                echo "e2e tests passed"
         when:
           - input: "$(tasks.check-prerequisites.results.event-type)"
             operator: notin


### PR DESCRIPTION
## summary

Restores a `check-test-exit-code` step using Tekton's documented `step-` step id so the e2e task does not report success when tests fail under `onError: continue`.

## description

- `onError: continue` on the e2e step allows `must-gather` and `git-push-artifacts` to run after pytest failures, but without a follow-up failure the task could still succeed.
- Add `check-test-exit-code` after `git-push-artifacts` and read `$(steps.step-e2e-maas-api-openshift.exitCode.path)` (not `steps.e2e-maas-api-openshift`, which is invalid).

## how it was tested

- Not run in-cluster; validated against Tekton task docs and `ignore-step-error` example. Recommend re-running the MaaS integration ITS and confirming a failing pytest run marks the pipeline failed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed end-to-end test pipeline to properly report and fail on test failures, ensuring failed tests are no longer masked and pipeline execution terminates appropriately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->