### PR TITLE
feat(trainer): add main branch support for PR builds and ITS

### DIFF
--- a/integration-tests/trainer/pr-testing-pipeline.yaml
+++ b/integration-tests/trainer/pr-testing-pipeline.yaml
@@ -5,7 +5,7 @@ metadata:
   name: odh-pr-test-trainer
   annotations:
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
-    pipelinesascode.tekton.dev/on-target-branch: "[stable]"
+    pipelinesascode.tekton.dev/on-target-branch: "[main, stable]"
 spec:
   timeouts:
     pipeline: 1h

--- a/pipelineruns/trainer/trainer-pull-request.yaml
+++ b/pipelineruns/trainer/trainer-pull-request.yaml
@@ -9,8 +9,8 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "stable"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && (target_branch
+      == "main" || target_branch == "stable")
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: opendatahub-builds


### PR DESCRIPTION
## Summary
- Update trainer PR build PipelineRun CEL expression to trigger on both `main` and `stable` branches
- Update trainer Integration Test Scenario target branch to `[main, stable]`
- Push builds remain `stable`-only (producing `odh-stable` tag)

## Test plan
- [ ] Verify PR builds trigger on PRs targeting `main` branch in the trainer repo
- [ ] Verify PR builds still trigger on PRs targeting `stable` branch
- [ ] Verify push builds only trigger on merges to `stable`
- [ ] Verify ITS runs for both `main` and `stable` PR builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded test pipeline triggers to run against both `main` and `stable` branches instead of only the `stable` branch, improving testing coverage across additional development branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->