### PR TITLE
fix: align kserve E2E ARTIFACT_DIR with artifact collection path

### DIFF
--- a/integration-tests/kserve/pr-group-testing-pipeline.yaml
+++ b/integration-tests/kserve/pr-group-testing-pipeline.yaml
@@ -812,7 +812,7 @@ spec:
             - name: ERROR_404_ISVC_IMAGE
               value: quay.io/opendatahub/error-404-isvc:$(tasks.rhoai-init.results.mandatory-tag) #$(tasks.build-error-404-isvc.results.IMAGE_REF)
             - name: ARTIFACT_DIR
-              value: /workspace/artifact-dir
+              value: /workspace/artifacts-dir
           workingDir: /workspace/source
           volumeMounts:
             - name: credentials
@@ -1050,7 +1050,7 @@ spec:
             - name: ERROR_404_ISVC_IMAGE
               value: quay.io/opendatahub/error-404-isvc:$(tasks.rhoai-init.results.mandatory-tag) #$(tasks.build-error-404-isvc.results.IMAGE_REF)
             - name: ARTIFACT_DIR
-              value: /workspace/artifact-dir
+              value: /workspace/artifacts-dir
           workingDir: /workspace/source
           volumeMounts:
             - name: credentials
@@ -1285,7 +1285,7 @@ spec:
             - name: ERROR_404_ISVC_IMAGE
               value: quay.io/opendatahub/error-404-isvc:$(tasks.rhoai-init.results.mandatory-tag) #$(tasks.build-error-404-isvc.results.IMAGE_REF)
             - name: ARTIFACT_DIR
-              value: /workspace/artifact-dir
+              value: /workspace/artifacts-dir
           workingDir: /workspace/source
           volumeMounts:
             - name: credentials
@@ -1526,7 +1526,7 @@ spec:
             - name: ERROR_404_ISVC_IMAGE
               value: quay.io/opendatahub/error-404-isvc:$(tasks.rhoai-init.results.mandatory-tag) #$(tasks.build-error-404-isvc.results.IMAGE_REF)
             - name: ARTIFACT_DIR
-              value: /workspace/artifact-dir
+              value: /workspace/artifacts-dir
           workingDir: /workspace/source
           volumeMounts:
             - name: credentials


### PR DESCRIPTION
## Summary

- Fix path mismatch in kserve group test pipeline: E2E steps used `/workspace/artifact-dir` (singular) while must-gather and git-push-artifacts used `/workspace/artifacts-dir` (plural)
- Any files written by E2E steps to `$ARTIFACT_DIR` were silently lost because the collection step reads from a different path

## What changed

Changed 4 E2E step `ARTIFACT_DIR` values from `/workspace/artifact-dir` to `/workspace/artifacts-dir` in all four task groups (e2e-graph, e2e-raw, e2e-predictor, e2e-llm-inference-service).

No conflict with must-gather, which writes to subdirectories (`gather-kserve/`, `gather-openshift/`).

## Why

Prerequisite for collecting structured test results (JUnit XML + JSON) from E2E runs. See companion PR: https://github.com/opendatahub-io/kserve/pull/1396


Made with [Cursor](https://cursor.com)