### PR TITLE
fix: make pipeline-logs workspace optional

### DIFF
--- a/integration-tests/kserve/pr-group-testing-pipeline.yaml
+++ b/integration-tests/kserve/pr-group-testing-pipeline.yaml
@@ -1758,3 +1758,4 @@ spec:
   - name: netrc
     optional: true
   - name: pipeline-logs
+    optional: true


### PR DESCRIPTION
## Summary
- Makes the `pipeline-logs` workspace optional in the kserve group test pipeline
- The PipelineRun in `opendatahub-io/kserve` `.tekton/kserve-group-test.yaml` does not bind this workspace yet, so requiring it causes the PipelineRun to fail at admission before any tasks start

## Context
PR #240 added the `export-pipeline-logs` task but the workspace was merged as required. A companion PR to `opendatahub-io/kserve` will add the workspace binding, after which this can be reverted back to required.

## Test plan
- [ ] Trigger `/group-test` on a kserve PR and verify the PipelineRun starts successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Made the pipeline-logs workspace optional, enabling more flexible pipeline execution without mandatory workspace configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->