### PR TITLE
Revert "fix: make pipeline-logs workspace optional"

### DIFF
--- a/integration-tests/kserve/pr-group-testing-pipeline.yaml
+++ b/integration-tests/kserve/pr-group-testing-pipeline.yaml
@@ -1758,4 +1758,3 @@ spec:
   - name: netrc
     optional: true
   - name: pipeline-logs
-    optional: true


### PR DESCRIPTION
Reverts opendatahub-io/odh-konflux-central#259

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pipeline configuration to enforce the pipeline-logs workspace requirement during pipeline execution and finalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->