### PR TITLE
fix: log PR-tagged image refs in MaaS group test pipeline

### DIFF
--- a/integration-tests/models-as-a-service/pr-group-testing-pipeline.yaml
+++ b/integration-tests/models-as-a-service/pr-group-testing-pipeline.yaml
@@ -255,8 +255,13 @@ spec:
               export MAAS_API_IMAGE=$(jq -r '."odh-maas-api-ci".image' <<< "${SNAPSHOT}")
               export MAAS_CONTROLLER_IMAGE=$(jq -r '."odh-maas-controller-ci".image' <<< "${SNAPSHOT}")
 
+              MAAS_API_TAG=$(jq -r '."odh-maas-api-ci".image_tag' <<< "${SNAPSHOT}")
+              MAAS_CONTROLLER_TAG=$(jq -r '."odh-maas-controller-ci".image_tag' <<< "${SNAPSHOT}")
+
               echo "MAAS_API_IMAGE=${MAAS_API_IMAGE}"
+              echo "MAAS_API_IMAGE (tag): ${MAAS_API_IMAGE%%@*}:${MAAS_API_TAG}"
               echo "MAAS_CONTROLLER_IMAGE=${MAAS_CONTROLLER_IMAGE}"
+              echo "MAAS_CONTROLLER_IMAGE (tag): ${MAAS_CONTROLLER_IMAGE%%@*}:${MAAS_CONTROLLER_TAG}"
 
               ./test/e2e/scripts/prow_run_smoke_test.sh
 

--- a/integration-tests/models-as-a-service/pr-group-testing-pipeline.yaml
+++ b/integration-tests/models-as-a-service/pr-group-testing-pipeline.yaml
@@ -258,6 +258,12 @@ spec:
               MAAS_API_TAG=$(jq -r '."odh-maas-api-ci".image_tag' <<< "${SNAPSHOT}")
               MAAS_CONTROLLER_TAG=$(jq -r '."odh-maas-controller-ci".image_tag' <<< "${SNAPSHOT}")
 
+              if [ -z "${MAAS_API_TAG}" ] || [ "${MAAS_API_TAG}" = "null" ] || \
+                 [ -z "${MAAS_CONTROLLER_TAG}" ] || [ "${MAAS_CONTROLLER_TAG}" = "null" ]; then
+                echo "ERROR: image_tag missing for odh-maas-api-ci or odh-maas-controller-ci in SNAPSHOT" >&2
+                exit 1
+              fi
+
               echo "MAAS_API_IMAGE=${MAAS_API_IMAGE}"
               echo "MAAS_API_IMAGE (tag): ${MAAS_API_IMAGE%%@*}:${MAAS_API_TAG}"
               echo "MAAS_CONTROLLER_IMAGE=${MAAS_CONTROLLER_IMAGE}"


### PR DESCRIPTION
## Summary
- Log both digest-based and `odh-pr-{PR_NUMBER}` tagged image refs in the MaaS group test e2e step for easier identification in CI logs

## Changes
- **`integration-tests/models-as-a-service/pr-group-testing-pipeline.yaml`** — extract `image_tag` from the composite snapshot and echo the tag-based image refs alongside the digest refs

## Test plan
- [x] Verify `image_tag` field is populated by `generate-snapshot-for-group-testing` task
- [ ] Confirm new log lines appear in CI output on next group test run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD pipeline logging to display additional image version details during test execution, improving transparency and traceability of deployed components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->