### PR TITLE
ci: collect tekton logs in kserve group test

### DIFF
--- a/integration-tests/kserve/pr-group-testing-pipeline.yaml
+++ b/integration-tests/kserve/pr-group-testing-pipeline.yaml
@@ -1688,6 +1688,33 @@ spec:
               value: /workspace/odh-ci-artifacts
             - name: artifacts-dir-path
               value: 'test-artifacts/$(context.pipelineRun.name)'
+        - name: collect-tekton-logs
+          image: quay.io/redhat-appstudio/appstudio-utils:latest
+          env:
+            - name: PR_NAME
+              value: $(context.pipelineRun.name)
+            - name: PR_NAMESPACE
+              value: $(context.pipelineRun.namespace)
+          script: |
+            #!/bin/bash
+            # Best-effort log collection — must not block the OCI push or PR comment
+            set +e
+
+            LOGS_DIR="/workspace/odh-ci-artifacts/test-artifacts/${PR_NAME}/tekton-logs"
+            mkdir -p "${LOGS_DIR}"
+
+            kubectl get pr "${PR_NAME}" -n "${PR_NAMESPACE}" -o json \
+              | jq -r '.status.childReferences[].name' \
+              | while read -r taskrun; do
+                  POD_NAME=$(kubectl get tr "${taskrun}" -n "${PR_NAMESPACE}" -o json | jq -r '.status.podName // empty')
+                  if [ -n "${POD_NAME}" ]; then
+                    echo "Collecting logs for ${taskrun} (pod: ${POD_NAME})"
+                    kubectl logs -n "${PR_NAMESPACE}" "pod/${POD_NAME}" --all-containers > "${LOGS_DIR}/${taskrun}.log" 2>&1 || true
+                  fi
+                done
+
+            echo "Collected $(ls "${LOGS_DIR}" 2>/dev/null | wc -l) task log files"
+            exit 0
         - name: secure-push-oci
           ref:
             resolver: git


### PR DESCRIPTION
## Summary
- Adds a `collect-tekton-logs` step to the `push-ci-artifacts-and-update-pr` finally task
- Collects Tekton task logs (setup scripts, image builds, test runner output) and bundles them alongside existing must-gather artifacts in a single OCI push
- Logs are written to `tekton-logs/` within the artifacts directory, one file per TaskRun
- Step is best-effort (`set +e`, `exit 0`) so failures cannot block the OCI push or PR comment

## Context
After PipelineRun pruning (`max-keep-runs: 3`), Tekton task logs are lost. This makes it difficult to debug failures in setup/provisioning steps that happen before must-gather runs. By collecting logs in the existing artifacts task, they're downloadable via the same `oras pull` command — no extra workspace, SA permissions, or external task needed.

## Test plan
- [ ] Trigger `/group-test` on a kserve PR
- [ ] Verify `tekton-logs/` directory appears in the OCI artifact alongside must-gather
- [ ] Verify pipeline completes normally if log collection fails (best-effort)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced test pipeline logging infrastructure to automatically collect and archive detailed diagnostic information from test executions, improving visibility and debugging capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->