### PR TITLE
ci: collect tekton logs in group test artifacts

### DIFF
--- a/integration-tests/kserve/pr-group-testing-pipeline.yaml
+++ b/integration-tests/kserve/pr-group-testing-pipeline.yaml
@@ -1689,7 +1689,7 @@ spec:
             - name: artifacts-dir-path
               value: 'test-artifacts/$(context.pipelineRun.name)'
         - name: collect-tekton-logs
-          image: quay.io/redhat-appstudio/appstudio-utils:latest
+          image: quay.io/konflux-ci/tekton-integration-catalog/utils:latest
           env:
             - name: PR_NAME
               value: $(context.pipelineRun.name)
@@ -1697,8 +1697,7 @@ spec:
               value: $(context.pipelineRun.namespace)
           script: |
             #!/bin/bash
-            # Best-effort log collection — must not block the OCI push or PR comment
-            set +e
+            set -euo pipefail
 
             LOGS_DIR="/workspace/odh-ci-artifacts/test-artifacts/${PR_NAME}/tekton-logs"
             mkdir -p "${LOGS_DIR}"


### PR DESCRIPTION
## Summary
- Adds a `collect-tekton-logs` step to the `push-ci-artifacts-and-update-pr` finally task
- Collects Tekton task logs and bundles them alongside existing must-gather artifacts in a single OCI push
- Logs are written to `tekton-logs/` within the artifacts directory, one file per TaskRun
- Uses `quay.io/konflux-ci/tekton-integration-catalog/utils:latest` (same image as the upstream `export-pipeline-logs` task — has `kubectl` and `jq`)

## Problem
After PipelineRun pruning (`max-keep-runs: 3`), Tekton task logs are lost. This makes it difficult to debug failures in setup/provisioning steps that happen before must-gather runs.

## Test plan
- [ ] Trigger `/group-test` on a kserve PR
- [ ] Verify `tekton-logs/` directory appears in the OCI artifact alongside must-gather
- [ ] Verify logs are captured on a failing run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated testing infrastructure for improved reliability and stricter error handling in log collection processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->