### PR TITLE
Add odh-llm-d-batch-gateway-apiserver-ci PipelineRuns for odh-llm-d-batch-gateway-apiserver

### DIFF
--- a/pipelineruns/batch-gateway/odh-llm-d-batch-gateway-apiserver-pull-request.yaml
+++ b/pipelineruns/batch-gateway/odh-llm-d-batch-gateway-apiserver-pull-request.yaml
@@ -1,0 +1,52 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/batch-gateway?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
+      == "main"
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: opendatahub-builds
+    appstudio.openshift.io/component: odh-llm-d-batch-gateway-apiserver-ci
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-llm-d-batch-gateway-apiserver-on-pull-request
+  namespace: open-data-hub-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/opendatahub/odh-llm-d-batch-gateway-apiserver:odh-pr
+  - name: dockerfile
+    value: docker/Dockerfile.apiserver.konflux
+  - name: path-context
+    value: .
+  # additional params
+  - name: additional-tags
+    value:
+    - 'odh-pr-{{revision}}'
+  - name: pipeline-type
+    value: pull-request
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/opendatahub-io/odh-konflux-central.git
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipeline/multi-arch-container-build.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-odh-llm-d-batch-gateway-apiserver
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/pipelineruns/batch-gateway/odh-llm-d-batch-gateway-apiserver-pull-request.yaml
+++ b/pipelineruns/batch-gateway/odh-llm-d-batch-gateway-apiserver-pull-request.yaml
@@ -44,7 +44,7 @@ spec:
     - name: pathInRepo
       value: pipeline/multi-arch-container-build.yaml
   taskRunTemplate:
-    serviceAccountName: build-pipeline-odh-llm-d-batch-gateway-apiserver
+    serviceAccountName: build-pipeline-odh-llm-d-batch-gateway-apiserver-ci
   workspaces:
   - name: git-auth
     secret:

--- a/pipelineruns/batch-gateway/odh-llm-d-batch-gateway-apiserver-push.yaml
+++ b/pipelineruns/batch-gateway/odh-llm-d-batch-gateway-apiserver-push.yaml
@@ -1,0 +1,47 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+#
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/batch-gateway?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "main"
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: opendatahub-builds
+    appstudio.openshift.io/component: odh-llm-d-batch-gateway-apiserver-ci
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-llm-d-batch-gateway-apiserver-on-push
+  namespace: open-data-hub-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/opendatahub/odh-llm-d-batch-gateway-apiserver:odh-stable
+  - name: dockerfile
+    value: docker/Dockerfile.apiserver.konflux
+  - name: path-context
+    value: .
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/opendatahub-io/odh-konflux-central.git
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipeline/multi-arch-container-build.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-odh-llm-d-batch-gateway-apiserver
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/pipelineruns/batch-gateway/odh-llm-d-batch-gateway-apiserver-push.yaml
+++ b/pipelineruns/batch-gateway/odh-llm-d-batch-gateway-apiserver-push.yaml
@@ -39,7 +39,7 @@ spec:
     - name: pathInRepo
       value: pipeline/multi-arch-container-build.yaml
   taskRunTemplate:
-    serviceAccountName: build-pipeline-odh-llm-d-batch-gateway-apiserver
+    serviceAccountName: build-pipeline-odh-llm-d-batch-gateway-apiserver-ci
   workspaces:
   - name: git-auth
     secret:


### PR DESCRIPTION
Add Konflux CI PipelineRuns for 'odh-llm-d-batch-gateway-apiserver' from repo 'batch-gateway'.

Product: ODH
Application: opendatahub-builds
Output image: quay.io/opendatahub/odh-llm-d-batch-gateway-apiserver:odh-stable
Source repo: https://github.com/opendatahub-io/batch-gateway @ main
Jira: https://redhat.atlassian.net/browse/RHOAIENG-55217

**Files changed:**
- `pipelineruns/batch-gateway/odh-llm-d-batch-gateway-apiserver-push.yaml` (new)
- `pipelineruns/batch-gateway/odh-llm-d-batch-gateway-apiserver-pull-request.yaml` (new)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added CI/CD pipeline configurations for automated container builds of the batch-gateway API server on pull requests and production deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->