### PR TITLE
Add stable branch PipelineRuns for DW th06 training images

### DIFF
--- a/pipelineruns/distributed-workloads/odh-th06-cpu-torch291-py312-stable-pull-request.yaml
+++ b/pipelineruns/distributed-workloads/odh-th06-cpu-torch291-py312-stable-pull-request.yaml
@@ -1,0 +1,53 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/distributed-workloads?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
+      == "stable" && ( "images/universal/training/th06-cpu-torch291-py312/***".pathChanged()
+      || ".tekton/odh-th06-cpu-torch291-py312-stable-pull-request.yaml".pathChanged() )
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: opendatahub-builds
+    appstudio.openshift.io/component: odh-th06-cpu-torch291-py312-ci
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-th06-cpu-torch291-py312-ci-on-stable-pull-request
+  namespace: open-data-hub-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/opendatahub/odh-th06-cpu-torch291-py312:odh-pr
+  - name: dockerfile
+    value: Dockerfile
+  - name: path-context
+    value: images/universal/training/th06-cpu-torch291-py312
+  - name: pipeline-type
+    value: pull-request
+  - name: additional-tags
+    value:
+    - 'odh-pr-{{revision}}'
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/opendatahub-io/odh-konflux-central.git
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipeline/multi-arch-container-build.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-odh-th06-cpu-torch291-py312-ci
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/pipelineruns/distributed-workloads/odh-th06-cpu-torch291-py312-stable-push.yaml
+++ b/pipelineruns/distributed-workloads/odh-th06-cpu-torch291-py312-stable-push.yaml
@@ -1,0 +1,48 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+#
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/distributed-workloads?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "stable" && ( "images/universal/training/th06-cpu-torch291-py312/***".pathChanged()
+      || ".tekton/odh-th06-cpu-torch291-py312-stable-push.yaml".pathChanged() )
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: opendatahub-builds
+    appstudio.openshift.io/component: odh-th06-cpu-torch291-py312-ci
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-th06-cpu-torch291-py312-ci-on-stable-push
+  namespace: open-data-hub-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/opendatahub/odh-th06-cpu-torch291-py312:odh-stable
+  - name: dockerfile
+    value: Dockerfile
+  - name: path-context
+    value: images/universal/training/th06-cpu-torch291-py312
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/opendatahub-io/odh-konflux-central.git
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipeline/multi-arch-container-build.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-odh-th06-cpu-torch291-py312-ci
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/pipelineruns/distributed-workloads/odh-th06-cuda130-torch291-py312-stable-pull-request.yaml
+++ b/pipelineruns/distributed-workloads/odh-th06-cuda130-torch291-py312-stable-pull-request.yaml
@@ -1,0 +1,60 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/distributed-workloads?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
+      == "stable" && ( "images/universal/training/th06-cuda130-torch291-py312/***".pathChanged()
+      || ".tekton/odh-th06-cuda130-torch291-py312-stable-pull-request.yaml".pathChanged()
+      )
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: opendatahub-builds
+    appstudio.openshift.io/component: odh-th06-cuda130-torch291-py312-ci
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-th06-cuda130-torch291-py312-ci-on-stable-pull-request
+  namespace: open-data-hub-tenant
+spec:
+  timeouts:
+    pipeline: 10h
+    tasks: 8h
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/opendatahub/odh-th06-cuda130-torch291-py312:odh-pr
+  - name: dockerfile
+    value: Dockerfile
+  - name: path-context
+    value: images/universal/training/th06-cuda130-torch291-py312
+  - name: pipeline-type
+    value: pull-request
+  - name: additional-tags
+    value:
+    - 'odh-pr-{{revision}}'
+  - name: build-platforms
+    value:
+    - linux-extra-fast/amd64
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/opendatahub-io/odh-konflux-central.git
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipeline/multi-arch-container-build.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-odh-th06-cuda130-torch291-py312-ci
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/pipelineruns/distributed-workloads/odh-th06-cuda130-torch291-py312-stable-push.yaml
+++ b/pipelineruns/distributed-workloads/odh-th06-cuda130-torch291-py312-stable-push.yaml
@@ -1,0 +1,54 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+#
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/distributed-workloads?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "stable" && ( "images/universal/training/th06-cuda130-torch291-py312/***".pathChanged()
+      || ".tekton/odh-th06-cuda130-torch291-py312-stable-push.yaml".pathChanged() )
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: opendatahub-builds
+    appstudio.openshift.io/component: odh-th06-cuda130-torch291-py312-ci
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-th06-cuda130-torch291-py312-ci-on-stable-push
+  namespace: open-data-hub-tenant
+spec:
+  timeouts:
+    pipeline: 10h
+    tasks: 8h
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/opendatahub/odh-th06-cuda130-torch291-py312:odh-stable
+  - name: dockerfile
+    value: Dockerfile
+  - name: path-context
+    value: images/universal/training/th06-cuda130-torch291-py312
+  - name: build-platforms
+    value:
+    - linux-extra-fast/amd64
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/opendatahub-io/odh-konflux-central.git
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipeline/multi-arch-container-build.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-odh-th06-cuda130-torch291-py312-ci
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/pipelineruns/distributed-workloads/odh-th06-rocm64-torch291-py312-stable-pull-request.yaml
+++ b/pipelineruns/distributed-workloads/odh-th06-rocm64-torch291-py312-stable-pull-request.yaml
@@ -1,0 +1,60 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/distributed-workloads?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
+      == "stable" && ( "images/universal/training/th06-rocm64-torch291-py312/***".pathChanged()
+      || ".tekton/odh-th06-rocm64-torch291-py312-stable-pull-request.yaml".pathChanged()
+      )
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: opendatahub-builds
+    appstudio.openshift.io/component: odh-th06-rocm64-torch291-py312-ci
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-th06-rocm64-torch291-py312-ci-on-stable-pull-request
+  namespace: open-data-hub-tenant
+spec:
+  timeouts:
+    pipeline: 10h
+    tasks: 8h
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/opendatahub/odh-th06-rocm64-torch291-py312:odh-pr
+  - name: dockerfile
+    value: Dockerfile
+  - name: path-context
+    value: images/universal/training/th06-rocm64-torch291-py312
+  - name: pipeline-type
+    value: pull-request
+  - name: additional-tags
+    value:
+    - 'odh-pr-{{revision}}'
+  - name: build-platforms
+    value:
+    - linux-extra-fast/amd64
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/opendatahub-io/odh-konflux-central.git
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipeline/multi-arch-container-build.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-odh-th06-rocm64-torch291-py312-ci
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/pipelineruns/distributed-workloads/odh-th06-rocm64-torch291-py312-stable-push.yaml
+++ b/pipelineruns/distributed-workloads/odh-th06-rocm64-torch291-py312-stable-push.yaml
@@ -1,0 +1,54 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+#
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/distributed-workloads?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "stable" && ( "images/universal/training/th06-rocm64-torch291-py312/***".pathChanged()
+      || ".tekton/odh-th06-rocm64-torch291-py312-stable-push.yaml".pathChanged() )
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: opendatahub-builds
+    appstudio.openshift.io/component: odh-th06-rocm64-torch291-py312-ci
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-th06-rocm64-torch291-py312-ci-on-stable-push
+  namespace: open-data-hub-tenant
+spec:
+  timeouts:
+    pipeline: 10h
+    tasks: 8h
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/opendatahub/odh-th06-rocm64-torch291-py312:odh-stable
+  - name: dockerfile
+    value: Dockerfile
+  - name: path-context
+    value: images/universal/training/th06-rocm64-torch291-py312
+  - name: build-platforms
+    value:
+    - linux-extra-fast/amd64
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/opendatahub-io/odh-konflux-central.git
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipeline/multi-arch-container-build.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-odh-th06-rocm64-torch291-py312-ci
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}


### PR DESCRIPTION
## Summary
- Add `stable-pull-request` and `stable-push` PipelineRuns for the three th06 training image variants (cpu, cuda130, rocm64)
- Stable pull-request pipelines trigger on `pull_request` events targeting the `stable` branch (Bodies of Water Lake gate)
- Stable push pipelines trigger on `push` events to `stable` and tag images as `odh-stable`

## Test plan
- [ ] Verify PipelineRuns are picked up by PaC on the `stable` branch
- [ ] Validate stable-push produces `odh-stable` tagged images
- [ ] Confirm stable-pull-request triggers on PRs targeting `stable`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added six new pipeline run configurations for distributed workload builds targeting the stable branch, supporting multiple hardware variants (CPU, CUDA 13.0, and ROCm 6.4)
  * Each configuration triggers on pull requests and push events with conditional execution based on relevant file changes
  * Configured with standard build parameters including Git source, output image tagging, build context, and platform specifications

<!-- end of auto-generated comment: release notes by coderabbit.ai -->