### PR TITLE
Add odh-llm-d-batch-gateway-gc-ci PipelineRuns for odh-llm-d-batch-gateway-gc

### DIFF
--- a/pipelineruns/batch-gateway/odh-llm-d-batch-gateway-gc-pull-request.yaml
+++ b/pipelineruns/batch-gateway/odh-llm-d-batch-gateway-gc-pull-request.yaml
@@ -1,0 +1,52 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/batch-gateway?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
+      == "main"
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: opendatahub-builds
+    appstudio.openshift.io/component: odh-llm-d-batch-gateway-gc-ci
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-llm-d-batch-gateway-gc-on-pull-request
+  namespace: open-data-hub-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/opendatahub/odh-llm-d-batch-gateway-gc:odh-pr
+  - name: dockerfile
+    value: docker/Dockerfile.gc.konflux
+  - name: path-context
+    value: ./
+  # additional params
+  - name: additional-tags
+    value:
+    - 'odh-pr-{{revision}}'
+  - name: pipeline-type
+    value: pull-request
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/opendatahub-io/odh-konflux-central.git
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipeline/multi-arch-container-build.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-odh-llm-d-batch-gateway-gc-ci
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/pipelineruns/batch-gateway/odh-llm-d-batch-gateway-gc-push.yaml
+++ b/pipelineruns/batch-gateway/odh-llm-d-batch-gateway-gc-push.yaml
@@ -1,0 +1,47 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+#
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/batch-gateway?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "main"
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: opendatahub-builds
+    appstudio.openshift.io/component: odh-llm-d-batch-gateway-gc-ci
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-llm-d-batch-gateway-gc-on-push
+  namespace: open-data-hub-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/opendatahub/odh-llm-d-batch-gateway-gc:odh-stable
+  - name: dockerfile
+    value: docker/Dockerfile.gc.konflux
+  - name: path-context
+    value: ./
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/opendatahub-io/odh-konflux-central.git
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipeline/multi-arch-container-build.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-odh-llm-d-batch-gateway-gc-ci
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}


### PR DESCRIPTION
Add Konflux CI PipelineRuns for 'odh-llm-d-batch-gateway-gc' from repo 'batch-gateway'.

Product: ODH
Application: opendatahub-builds
Output image: quay.io/opendatahub/odh-llm-d-batch-gateway-gc:odh-stable
Source repo: https://github.com/opendatahub-io/batch-gateway @ main
Jira: https://redhat.atlassian.net/browse/RHOAIENG-57229

**Files changed:**
- `pipelineruns/batch-gateway/odh-llm-d-batch-gateway-gc-push.yaml` (new)
- `pipelineruns/batch-gateway/odh-llm-d-batch-gateway-gc-pull-request.yaml` (new)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated build pipeline configurations triggered on pull requests and push events to the main branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->