### PR TITLE
ci: remove export-pipeline-logs task from group test pipeline

### DIFF
--- a/integration-tests/kserve/pr-group-testing-pipeline.yaml
+++ b/integration-tests/kserve/pr-group-testing-pipeline.yaml
@@ -1619,28 +1619,6 @@ spec:
             echo "deploy-and-e2e step succeeded"
 
   finally:
-  - name: export-pipeline-logs
-    taskRef:
-      resolver: git
-      params:
-      - name: url
-        value: https://github.com/konflux-ci/tekton-integration-catalog.git
-      - name: revision
-        value: main
-      - name: pathInRepo
-        value: tasks/export-logs/0.1/export-logs-to-quay.yaml
-    params:
-    - name: quay-repo
-      value: $(params.oci-artifacts-repo)
-    - name: pipeline-run-name
-      value: $(context.pipelineRun.name)
-    - name: namespace
-      value: $(context.pipelineRun.namespace)
-    - name: artifact-credentials-secret
-      value: odh-registry-secret
-    workspaces:
-    - name: shared-data
-      workspace: pipeline-logs
   - name: push-ci-artifacts-and-update-pr
     workspaces:
     - name: basic-auth
@@ -1783,4 +1761,3 @@ spec:
     optional: true
   - name: netrc
     optional: true
-  - name: pipeline-logs


### PR DESCRIPTION
The export-pipeline-logs task requires a dedicated workspace and RBAC permissions that are not available to the pipeline service account. Log collection is already handled by the collect-tekton-logs step in the push-ci-artifacts-and-update-pr finally task.

Assisted-by: Claude Code (claude.ai/code)

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed log export functionality from the KServe integration testing pipeline, simplifying configuration by eliminating the associated workspace dependency. Pipeline continues with remaining finalization tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->