### PR TITLE
fix(maas): add onError: continue to git-push-artifacts step

### DIFF
--- a/integration-tests/models-as-a-service/pr-group-testing-pipeline.yaml
+++ b/integration-tests/models-as-a-service/pr-group-testing-pipeline.yaml
@@ -288,6 +288,7 @@ spec:
               mkdir -p "${ARTIFACT_DIR}/gather-openshift"
               oc adm must-gather --dest-dir "${ARTIFACT_DIR}/gather-openshift"
           - name: git-push-artifacts
+            onError: continue
             ref:
               resolver: git
               params:


### PR DESCRIPTION
## Summary
- Adds `onError: continue` to the `git-push-artifacts` step in the MaaS group testing pipeline
- Transient git fetch failures (e.g., `fatal: fetch-pack: invalid index-pack output`) in `git-push-artifacts` currently cause the `fail-if-needed` step to be skipped, masking successful e2e test results and failing the entire pipeline
- With this fix, `fail-if-needed` always runs and reports the actual test outcome regardless of artifact push status

## Test plan
- [ ] Trigger a MaaS group test pipeline run and verify `fail-if-needed` executes even if `git-push-artifacts` encounters an error

🤖 Generated with [Claude Code](https://claude.com/claude-code)