### PR TITLE
Add odh-llm-d-batch-gateway-processor-ci PipelineRuns for batch-gateway

### DIFF
--- a/pipelineruns/batch-gateway/odh-llm-d-batch-gateway-processor-pull-request.yaml
+++ b/pipelineruns/batch-gateway/odh-llm-d-batch-gateway-processor-pull-request.yaml
@@ -1,0 +1,52 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/batch-gateway?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
+      == "main"
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: opendatahub-builds
+    appstudio.openshift.io/component: odh-llm-d-batch-gateway-processor-ci
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-llm-d-batch-gateway-processor-on-pull-request
+  namespace: open-data-hub-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/opendatahub/odh-llm-d-batch-gateway-processor:odh-pr
+  - name: dockerfile
+    value: docker/Dockerfile.processor.konflux
+  - name: path-context
+    value: ./
+  # additional params
+  - name: additional-tags
+    value:
+    - 'odh-pr-{{revision}}'
+  - name: pipeline-type
+    value: pull-request
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/opendatahub-io/odh-konflux-central.git
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipeline/multi-arch-container-build.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-odh-llm-d-batch-gateway-processor-ci
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/pipelineruns/batch-gateway/odh-llm-d-batch-gateway-processor-push.yaml
+++ b/pipelineruns/batch-gateway/odh-llm-d-batch-gateway-processor-push.yaml
@@ -1,0 +1,47 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+#
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/batch-gateway?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "main"
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: opendatahub-builds
+    appstudio.openshift.io/component: odh-llm-d-batch-gateway-processor-ci
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-llm-d-batch-gateway-processor-on-push
+  namespace: open-data-hub-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/opendatahub/odh-llm-d-batch-gateway-processor:odh-stable
+  - name: dockerfile
+    value: docker/Dockerfile.processor.konflux
+  - name: path-context
+    value: ./
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/opendatahub-io/odh-konflux-central.git
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipeline/multi-arch-container-build.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-odh-llm-d-batch-gateway-processor-ci
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}


### PR DESCRIPTION
Add Konflux CI PipelineRuns for 'odh-llm-d-batch-gateway-processor' from repo 'batch-gateway'.

Product: ODH
Application: opendatahub-builds
Output image: quay.io/opendatahub/odh-llm-d-batch-gateway-processor:odh-stable
Source repo: https://github.com/opendatahub-io/batch-gateway @ main
Jira: https://redhat.atlassian.net/browse/RHOAIENG-57227

**Files changed:**
- `pipelineruns/batch-gateway/odh-llm-d-batch-gateway-processor-push.yaml` (new)
- `pipelineruns/batch-gateway/odh-llm-d-batch-gateway-processor-pull-request.yaml` (new)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added CI/CD pipeline configurations to enable automated multi-architecture container builds triggered on pull requests and pushes to the main branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->