### PR TITLE
fix(maas): add onError: continue to finally block steps

### DIFF
--- a/integration-tests/models-as-a-service/pr-group-testing-pipeline.yaml
+++ b/integration-tests/models-as-a-service/pr-group-testing-pipeline.yaml
@@ -352,6 +352,7 @@ spec:
           type: string
       steps:
         - name: pull-ci-artifacts
+          onError: continue
           ref:
             resolver: git
             params:
@@ -373,6 +374,7 @@ spec:
             - name: artifacts-dir-path
               value: 'test-artifacts/$(context.pipelineRun.name)'
         - name: secure-push-oci
+          onError: continue
           ref:
             resolver: git
             params:
@@ -419,6 +421,7 @@ spec:
             - name: artifact-browser-url
               value: $(params.artifact-browser-url)
         - name: cleanup-artifacts-from-git
+          onError: continue
           ref:
             resolver: git
             params:


### PR DESCRIPTION
## Summary
- Adds `onError: continue` to `pull-ci-artifacts`, `secure-push-oci`, and `cleanup-artifacts-from-git` steps in the MaaS group testing pipeline's `finally` block
- Transient git fetch failures (e.g., `fatal: fetch-pack: invalid index-pack output`) in `pull-ci-artifacts` currently cascade and skip all subsequent steps, including the PR status comment
- With this fix, `share-status-on-pull-request` always runs and posts the actual pipeline result regardless of artifact handling failures

## Test plan
- [ ] Trigger a MaaS group test pipeline run and verify `share-status-on-pull-request` executes even if `pull-ci-artifacts` encounters an error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced CI/CD pipeline resilience by improving error handling in finalization steps, allowing cleanup operations to continue and complete even if individual steps encounter failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->