### PR TITLE
fix cel expression for training MPI image pull request trigger

### DIFF
--- a/pipelineruns/distributed-workloads/odh-training-cuda130-torch29-py312-openmpi41-ci-on-pull-request.yaml
+++ b/pipelineruns/distributed-workloads/odh-training-cuda130-torch29-py312-openmpi41-ci-on-pull-request.yaml
@@ -12,6 +12,8 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request"
       && target_branch == "$$TARGET_BRANCH$$"
+      && ( "images/runtime/training/py312-cuda130-torch29-openmpi41".pathChanged()
+            || ".tekton/odh-training-cuda130-torch29-py312-openmpi41-ci-on-pull-request.yaml".pathChanged() )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: opendatahub-builds


### PR DESCRIPTION
## Summary
- Add `pathChanged()` filters to the training MPI image pull request CEL expression so it only triggers when relevant files change (`images/runtime/training/py312-cuda130-torch29-openmpi41` or `.tekton/odh-training-cuda130-torch29-py312-openmpi41-ci-on-pull-request.yaml`)
- The push pipeline already had these filters; the pull request pipeline was missing them, causing builds on every PR

## Test plan
- [ ] Verify the PR pipeline no longer triggers on unrelated PRs to the distributed-workloads repo
- [ ] Verify the PR pipeline still triggers when files under `images/runtime/training/py312-cuda130-torch29-openmpi41` are changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline trigger conditions for the ODH Training pipeline to run when specific runtime images or pipeline configuration changes are detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->