### PR TITLE
fix: pick correct DW git commit and use fetch to clone at exact SHA

### DIFF
--- a/integration-tests/distributed-workloads/pr-testing-pipeline.yaml
+++ b/integration-tests/distributed-workloads/pr-testing-pipeline.yaml
@@ -227,10 +227,17 @@ spec:
                   GIT_COMMIT=$(echo "$row" | base64 -d | jq -r '.source.git.revision')
                   GIT_URL=$(echo "$row" | base64 -d | jq -r '.source.git.url')
 
-                  # Store git info from the first DW component for cloning DW repo later
-                  if [ -z "${DW_GIT_COMMIT:-}" ] && echo "${GIT_URL}" | grep -q "distributed-workloads"; then
-                    DW_GIT_COMMIT="${GIT_COMMIT}"
-                    DW_GIT_URL="${GIT_URL}"
+                  # Store git info for cloning DW repo later.
+                  # Prefer the CPU universal image (the ITS trigger component); fall back to any DW component.
+                  if echo "${GIT_URL}" | grep -q "distributed-workloads"; then
+                    if [ -z "${DW_GIT_COMMIT:-}" ]; then
+                      DW_GIT_COMMIT="${GIT_COMMIT}"
+                      DW_GIT_URL="${GIT_URL}"
+                    fi
+                    if [ "${COMPONENT_NAME}" = "odh-th06-cpu-torch291-py312-ci" ]; then
+                      DW_GIT_COMMIT="${GIT_COMMIT}"
+                      DW_GIT_URL="${GIT_URL}"
+                    fi
                   fi
 
                   echo "${COMPONENT_NAME} IMAGE: ${IMAGE}"
@@ -366,10 +373,13 @@ spec:
                 make deploy-rhoai
 
                 echo "Cloning distributed-workloads repo at PR commit..."
+                echo "DW_GIT_URL: ${DW_GIT_URL}"
+                echo "DW_GIT_COMMIT: ${DW_GIT_COMMIT}"
                 cd /workspace/source
-                git clone "${DW_GIT_URL}" dw_src
-                cd dw_src
-                git checkout "${DW_GIT_COMMIT}"
+                mkdir dw_src
+                git -C dw_src init
+                git -C dw_src fetch "${DW_GIT_URL}" "${DW_GIT_COMMIT}" --depth=1
+                git -C dw_src checkout FETCH_HEAD
 
                 echo "Running Smoke and Sanity tests..."
                 mkdir -p "${ARTIFACT_DIR}"


### PR DESCRIPTION
Two bugs fixed in the deploy-and-e2e step:

1. Component selection: the pipeline was picking the first distributed-workloads component in the snapshot (e.g. odh-training-rocm62-torch24-py311-ci) to get the git URL/commit for cloning the DW repo. When odh-th06-cpu-torch291-py312-ci is built from a fork PR, its commit doesn't exist in the first component's history, causing "fatal: unable to read tree". Now the pipeline specifically prefers odh-th06-cpu-torch291-py312-ci (the ITS trigger component) over the first DW component found.

2. Clone command: replaced "git clone + git checkout <sha>" with "git init + git fetch <url> <sha> --depth=1 + git checkout FETCH_HEAD". This fetches exactly the target commit regardless of shallow history or whether the SHA is on the default branch.

Made-with: Cursor

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved distributed workloads testing pipeline infrastructure with enhanced git operations and debug logging for better reliability during component snapshot processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->