### PR TITLE
Fix missing glob in MPI training pipeline CEL expression

### DIFF
--- a/pipelineruns/distributed-workloads/odh-training-cuda130-torch29-py312-openmpi41-ci-on-pull-request.yaml
+++ b/pipelineruns/distributed-workloads/odh-training-cuda130-torch29-py312-openmpi41-ci-on-pull-request.yaml
@@ -12,7 +12,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request"
       && target_branch == "$$TARGET_BRANCH$$"
-      && ( "images/runtime/training/py312-cuda130-torch29-openmpi41".pathChanged()
+      && ( "images/runtime/training/py312-cuda130-torch29-openmpi41/**".pathChanged()
             || ".tekton/odh-training-cuda130-torch29-py312-openmpi41-ci-on-pull-request.yaml".pathChanged() )
   creationTimestamp: null
   labels:

--- a/pipelineruns/distributed-workloads/odh-training-cuda130-torch29-py312-openmpi41-ci-on-push.yaml
+++ b/pipelineruns/distributed-workloads/odh-training-cuda130-torch29-py312-openmpi41-ci-on-push.yaml
@@ -10,7 +10,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "$$TARGET_BRANCH$$"
-      && ( "images/runtime/training/py312-cuda130-torch29-openmpi41".pathChanged()
+      && ( "images/runtime/training/py312-cuda130-torch29-openmpi41/**".pathChanged()
             || ".tekton/odh-training-cuda130-torch29-py312-openmpi41-ci-on-push.yaml".pathChanged() )
   creationTimestamp: null
   labels:


### PR DESCRIPTION
## Summary
- Add missing `/**` glob suffix to `pathChanged()` in the MPI training pipeline CEL expressions
- Without the glob, the pipeline would not trigger on file changes within the `images/runtime/training/py312-cuda130-torch29-openmpi41/` directory
- Aligns with the pattern used by all other distributed-workloads pipelines (e.g. th06-*)

## Test plan
- [ ] Verify MPI training pipeline triggers correctly on PRs that modify files under `images/runtime/training/py312-cuda130-torch29-openmpi41/`
- [ ] Verify push pipeline triggers correctly on merges affecting the same path

🤖 Generated with [Claude Code](https://claude.com/claude-code)