### PR TITLE
Forward Slack thread_ts and channel_id to Jenkins nightly trigger

### DIFF
--- a/integration-tests/CI/trigger-nightly.yaml
+++ b/integration-tests/CI/trigger-nightly.yaml
@@ -53,9 +53,9 @@ spec:
               #!/bin/bash
               set -e
               skopeo_inspect=$(skopeo inspect "docker://$CATALOG_IMAGE" --no-tags)
-              echo "$skopeo_inspect" | jq -r '.Name + "@" + .Digest' | tr -d '\n' | tee "$(results.latest-catalog-ci-image.path)"
-              echo "$skopeo_inspect" | jq -r '.Labels."build-metadata-url"'  | tr -d '\n' | tee "$(results.latest-build-metadata-url.path)"
-              echo "$skopeo_inspect" | jq -r '.Labels."build-url"'  | tr -d '\n' | tee "$(results.latest-catalog-ci-build-url.path)"
+              echo "$skopeo_inspect" | jq -r '.Name + "@" + .Digest' | tr -d '\n' | tee "$(results.latest-catalog-ci-image.path)"; echo
+              echo "$skopeo_inspect" | jq -r '.Labels."build-metadata-url"'  | tr -d '\n' | tee "$(results.latest-build-metadata-url.path)"; echo
+              echo "$skopeo_inspect" | jq -r '.Labels."build-url"'  | tr -d '\n' | tee "$(results.latest-catalog-ci-build-url.path)"; echo
       - name: tag-nightly
         runAfter:
         - choose-ci-build
@@ -158,45 +158,8 @@ spec:
               echo "Bundle: $BUNDLE_IMAGE"
               echo "FBC: $CATALOG_IMAGE"
               echo "Operator: $OPERATOR_IMAGE"
-      - name: trigger-nightly-tests
-        description: trigger nightly tests
-        when:
-        - input: $(params.TRIGGER_NIGHTLY_TESTS)
-          operator: in
-          values:
-          - "true"
-        runAfter:
-        - tag-nightly
-        taskSpec:
-          steps:
-          - image: quay.io/rhoai/rhoai-task-toolset:odh-nightly-runner
-            env:
-            - name: HOME
-              value: /workspace
-            - name: GITHUB_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  name: rhods-ci
-                  key: secret
-            script: |
-              #!/bin/bash
-              set -e
-
-              TARGET=odh-stable
-
-              OWNER="red-hat-data-services"
-              REPO="conforma-reporter"
-              WORKFLOW_FILE="smoke-trigger.yaml"
-
-              echo "Triggering nightly jenkins jobs for: $TARGET"
-
-              curl -f -X POST "https://api.github.com/repos/$OWNER/$REPO/actions/workflows/$WORKFLOW_FILE/dispatches" \
-              -H "Accept: application/vnd.github.v3+json" \
-              -H "Authorization: Bearer $GITHUB_TOKEN" \
-              -H "Content-Type: application/json" \
-              -d '{ "ref": "main", "inputs": { "target_branch": "'"$TARGET"'" } }'
       - name: slack-notification
-        description: notify slack about new nightly
+        description: notify slack about new nightly and persist thread_ts for downstream
         when:
         - input: $(params.TRIGGER_SLACK)
           operator: in
@@ -216,6 +179,8 @@ spec:
             env:
             - name: HOME
               value: /workspace
+            - name: DATA_PATH
+              value: $(workspaces.data.path)
             - name: SLACK_TOKEN
               valueFrom:
                 secretKeyRef:
@@ -254,10 +219,102 @@ spec:
 
               SUBST_VARS='$LATEST_CATALOG_CI_IMAGE $LATEST_BUILD_METADATA_URL $BUILD_URL'
               slack_message=$(echo "$MESSAGE_TEMPLATE" | envsubst "$SUBST_VARS")
-              ./send-slack-message.sh -c "$CHANNEL" -m "$slack_message" -f tracer-output.txt -v
+              SLACK_RC=0
+              OUTPUT=$(./send-slack-message.sh -c "$CHANNEL" -m "$slack_message" -f tracer-output.txt -v 2>&1) || SLACK_RC=$?
+
+              THREAD_TS=$(printf '%s\n' "$OUTPUT" | grep -oP 'Setting new thread id:\s*\K[0-9]+\.[0-9]+' | head -1 || true)
+
+              if [ "$SLACK_RC" -ne 0 ]; then
+                echo "WARNING: send-slack-message.sh exited with $SLACK_RC (non-blocking)"
+                printf '%s\n' "$OUTPUT" | grep -viE 'token|bearer|authorization' || true
+              else
+                echo "Slack message sent (rc=0, thread_ts=${THREAD_TS:-<not captured>})"
+              fi
+              if [ -n "$THREAD_TS" ]; then
+                printf '%s' "$THREAD_TS" > "$DATA_PATH/slack-thread-ts"
+                echo "Saved Slack thread_ts=$THREAD_TS"
+              elif [ "$SLACK_RC" -eq 0 ]; then
+                echo "ERROR: Slack send succeeded but thread_ts could not be parsed; upstream log format may have changed"
+                exit 1
+              else
+                echo "WARNING: Slack send failed (rc=$SLACK_RC); proceeding without thread reply"
+              fi
+      - name: trigger-nightly-tests
+        description: trigger nightly tests via conforma-reporter GitHub Action
+        when:
+        - input: $(params.TRIGGER_NIGHTLY_TESTS)
+          operator: in
+          values:
+          - "true"
+        runAfter:
+        - tag-nightly
+        - slack-notification
+        workspaces:
+        - name: data
+          workspace: data
+        taskSpec:
+          workspaces:
+          - name: data
+            optional: false
+          steps:
+          - image: quay.io/rhoai/rhoai-task-toolset:odh-nightly-runner
+            env:
+            - name: HOME
+              value: /workspace
+            - name: DATA_PATH
+              value: $(workspaces.data.path)
+            - name: GITHUB_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: rhods-ci
+                  key: secret
+            - name: CHANNEL
+              valueFrom:
+                configMapKeyRef:
+                  name: slack-config
+                  key: odh-notification-channel
+            script: |
+              #!/bin/bash
+              set -e
+
+              TARGET=odh-stable
+
+              OWNER="red-hat-data-services"
+              REPO="conforma-reporter"
+              WORKFLOW_FILE="smoke-trigger.yaml"
+
+              THREAD_ID=""
+              if [ -f "$DATA_PATH/slack-thread-ts" ]; then
+                THREAD_ID=$(cat "$DATA_PATH/slack-thread-ts")
+                echo "Forwarding Slack thread: $THREAD_ID, channel: $CHANNEL"
+              fi
+
+              echo "Triggering nightly jenkins jobs for: $TARGET"
+
+              PAYLOAD=$(jq -n \
+                --arg ref "main" \
+                --arg target "$TARGET" \
+                --arg thread "$THREAD_ID" \
+                --arg channel "$CHANNEL" \
+                '{ref: $ref, inputs: {target_branch: $target, thread_id: $thread, channel_id: $channel}}')
+
+              curl --fail-with-body --show-error --silent \
+                --connect-timeout 10 --max-time 30 \
+                --retry 3 --retry-delay 5 --retry-connrefused \
+                -X POST "https://api.github.com/repos/$OWNER/$REPO/actions/workflows/$WORKFLOW_FILE/dispatches" \
+                -H "Accept: application/vnd.github.v3+json" \
+                -H "Authorization: Bearer $GITHUB_TOKEN" \
+                -H "Content-Type: application/json" \
+                -d "$PAYLOAD"
     workspaces:
     - name: data
       optional: false
   workspaces:
   - name: data
-    emptyDir: {}
+    volumeClaimTemplate:
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 100Mi


### PR DESCRIPTION
## Problem

Jenkins nightly test results (TFA) are posted as new Slack messages instead of thread replies under the nightly build notification. The `slack-notification` and `trigger-nightly-tests` tasks ran in parallel, so the Slack thread_ts was never captured or forwarded to Jenkins.

## Fix

Run `slack-notification` before `trigger-nightly-tests`, capture the thread_ts from the Slack API response, and pass it (along with channel_id) through the GitHub dispatch to `conforma-reporter`, which already forwards both to Jenkins as `SLACK_THREAD_ID` and `SLACK_CHANNEL_ID`.

## Changes

- `slack-notification`: capture `thread_ts` to shared workspace file; Slack errors are non-blocking so tests always dispatch.
- `trigger-nightly-tests`: `runAfter: [tag-nightly, slack-notification]`; reads thread file, passes `thread_id` + `channel_id` in `jq`-built dispatch payload.
- Channel ID sourced from the same `slack-config` ConfigMap in both tasks.

## Related to

https://redhat.atlassian.net/browse/RHOAIENG-55832

- Jenkins [!1894](https://gitlab.cee.redhat.com/ods/jenkins/-/merge_requests/1894) (merged) — adds `SLACK_CHANNEL_ID`/`SLACK_THREAD_ID` params and forwarding.
- `conforma-reporter` `smoke-trigger.yaml` already accepts `thread_id`/`channel_id` inputs.

## Output example

In Slack:

<img width="937" height="391" alt="image" src="https://github.com/user-attachments/assets/dd187579-9927-43c7-85ff-f2f9c517c5a5" />

In Jenkins:

<img width="828" height="933" alt="image" src="https://github.com/user-attachments/assets/cbe6f9ac-120f-4ef8-addc-96e29859bd2f" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Slack notification failures no longer block the CI pipeline; they now log a warning and continue.
  * Pipeline will surface an error if Slack reports success but thread information cannot be recorded.

* **Chores**
  * Nightly test trigger now forwards additional context (thread and channel identifiers).
  * Slack thread info is persisted across tasks using durable workspace storage for continuity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->