### PR TITLE
fix(feast): upgrade go-toolset to 1.24 in test container

### DIFF
--- a/integration-tests/feast/Dockerfile.go-its
+++ b/integration-tests/feast/Dockerfile.go-its
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.22.9
+FROM registry.access.redhat.com/ubi9/go-toolset:1.24
 User 0
 RUN yum install -y git jq wget tar python3.12 python3.12-pip python3.12-devel podman skopeo make gcc automake binutils && \
     yum clean all && rm -rf /var/cache/dnf/*


### PR DESCRIPTION
## Summary
- Upgrades `Dockerfile.go-its` base image from `go-toolset:1.22.9` to `go-toolset:1.24`
- `controller-gen v0.18.0` requires Go >= 1.24.0, but the test container (`quay.io/rhoai/rhoai-task-toolset:go-its`) was built with Go 1.22.9, causing both `feast-group-test` and `feast-nightly-test` pipelines to fail at the `deploy-and-e2e` step:
  ```
  sigs.k8s.io/controller-tools@v0.18.0 requires go >= 1.24.0 (running go 1.22.9; GOTOOLCHAIN=local)
  make: *** [Makefile:257: bin/controller-gen] Error 1
  ```
- The operator's own Dockerfile already uses `go-toolset:1.24` (builds succeed), but the **test container** still had `go-toolset:1.22.9`

## Test plan
- [ ] Rebuild `quay.io/rhoai/rhoai-task-toolset:go-its` with this change
- [ ] Run `/group-test` on [feast PR #94](https://github.com/opendatahub-io/feast/pull/94) to verify the fix
- [ ] Run `/nightly-test` to verify end-to-end pipeline succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)