### PR TITLE
ci: improve tekton log collection for kserve group test

### DIFF
--- a/integration-tests/kserve/pr-group-testing-pipeline.yaml
+++ b/integration-tests/kserve/pr-group-testing-pipeline.yaml
@@ -867,6 +867,7 @@ spec:
             mkdir -p ${DEST_DIR}
             oc adm must-gather --dest-dir "${DEST_DIR}"
         - name: git-push-artifacts
+          onError: continue
           ref:
             resolver: git
             params:
@@ -1103,6 +1104,7 @@ spec:
             mkdir -p ${DEST_DIR}
             oc adm must-gather --dest-dir "${DEST_DIR}"
         - name: git-push-artifacts
+          onError: continue
           ref:
             resolver: git
             params:
@@ -1338,6 +1340,7 @@ spec:
             mkdir -p ${DEST_DIR}
             oc adm must-gather --dest-dir "${DEST_DIR}"
         - name: git-push-artifacts
+          onError: continue
           ref:
             resolver: git
             params:
@@ -1583,6 +1586,7 @@ spec:
             oc adm must-gather --dest-dir "${DEST_DIR}"
 
         - name: git-push-artifacts
+          onError: continue
           ref:
             resolver: git
             params:
@@ -1680,14 +1684,14 @@ spec:
             LOGS_DIR="/workspace/odh-ci-artifacts/test-artifacts/${PR_NAME}/tekton-logs"
             mkdir -p "${LOGS_DIR}"
 
+            # Collect logs for each TaskRun using tkn, which preserves step
+            # execution order and prefixes each line with [step-name].
             kubectl get pr "${PR_NAME}" -n "${PR_NAMESPACE}" -o json \
               | jq -r '.status.childReferences[].name' \
               | while read -r taskrun; do
-                  POD_NAME=$(kubectl get tr "${taskrun}" -n "${PR_NAMESPACE}" -o json | jq -r '.status.podName // empty')
-                  if [ -n "${POD_NAME}" ]; then
-                    echo "Collecting logs for ${taskrun} (pod: ${POD_NAME})"
-                    kubectl logs -n "${PR_NAMESPACE}" "pod/${POD_NAME}" --all-containers > "${LOGS_DIR}/${taskrun}.log" 2>&1 || true
-                  fi
+                  echo "Collecting logs for ${taskrun}"
+                  tkn taskrun logs "${taskrun}" -n "${PR_NAMESPACE}" --prefix \
+                    > "${LOGS_DIR}/${taskrun}.log" 2>&1 || true
                 done
 
             echo "Collected $(ls "${LOGS_DIR}" 2>/dev/null | wc -l) task log files"


### PR DESCRIPTION
## Summary
- Switch `collect-tekton-logs` from `kubectl logs --all-containers` to `tkn taskrun logs --prefix` for step-ordered output with `[step-name]` prefixes
- Add `onError: continue` to all `git-push-artifacts` steps so artifact upload failures do not mask passing e2e tests

## Details

### Log collection
`kubectl logs --all-containers` dumps container logs in alphabetical order with no step-name prefixes. `tkn taskrun logs --prefix` preserves the actual step execution order and prefixes each line with `[step-name]`, making it much easier to identify which step produced each log line.

`tkn` is already available in the `quay.io/konflux-ci/tekton-integration-catalog/utils:latest` image.

### Artifact push resilience
The `git-push-artifacts` step runs after e2e tests and must-gather. If it fails (e.g., git push conflict), the entire task fails and `fail-if-needed` never executes — causing the pipeline to report failure even when all tests passed. Adding `onError: continue` allows the pipeline result to reflect actual test outcomes.

## Test plan
- [ ] Trigger a `/group-test` on a kserve PR and verify log files in artifacts have `[step-name]` prefixes
- [ ] Verify step order in log output matches execution order (get-kubeconfig → clone-repo → e2e → must-gather → git-push-artifacts → fail-if-needed)
- [ ] Verify pipeline passes when tests pass but `git-push-artifacts` fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pipeline now continues execution even if artifact push steps fail
  * Updated log collection process for CI testing pipeline

<!-- end of auto-generated comment: release notes by coderabbit.ai -->