### PR TITLE
chore: point smoke-trigger workflow at rhods-devops-infra

### DIFF
--- a/integration-tests/CI/trigger-nightly.yaml
+++ b/integration-tests/CI/trigger-nightly.yaml
@@ -264,7 +264,7 @@ spec:
                 echo "WARNING: Slack send failed (rc=$SLACK_RC); proceeding without thread reply"
               fi
       - name: trigger-nightly-tests
-        description: trigger nightly tests via conforma-reporter GitHub Action
+        description: trigger nightly tests via rhods-devops-infra smoke-trigger workflow
         when:
         - input: $(params.TRIGGER_NIGHTLY_TESTS)
           operator: in
@@ -304,7 +304,7 @@ spec:
               TARGET=odh-stable
 
               OWNER="red-hat-data-services"
-              REPO="conforma-reporter"
+              REPO="rhods-devops-infra"
               WORKFLOW_FILE="smoke-trigger.yaml"
 
               THREAD_ID=""


### PR DESCRIPTION
The smoke-trigger GitHub Actions workflow now lives in red-hat-data-services/rhods-devops-infra.

This updates the nightly integration test pipeline to dispatch that workflow instead of conforma-reporter when triggering Jenkins smoke runs.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal CI/CD configuration for nightly test workflows.

---

**Note:** This release contains internal infrastructure updates with no user-visible changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->