### PR TITLE
add training-cuda130-torch210-py312-openmpi41-ci  pipelinerun

### DIFF
--- a/pipelineruns/distributed-workloads/odh-training-cuda130-torch210-py312-openmpi41-ci-on-pull-request.yaml
+++ b/pipelineruns/distributed-workloads/odh-training-cuda130-torch210-py312-openmpi41-ci-on-pull-request.yaml
@@ -15,7 +15,7 @@ metadata:
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: opendatahub-builds
-    appstudio.openshift.io/component: odh-training-cuda130-torch210-py312-openmpi41-ci-ci
+    appstudio.openshift.io/component: odh-training-cuda130-torch210-py312-openmpi41-ci
     pipelines.appstudio.openshift.io/type: build
   name: odh-training-cuda130-torch210-py312-openmpi41-ci-on-pull-request
   namespace: open-data-hub-tenant

--- a/pipelineruns/distributed-workloads/odh-training-cuda130-torch210-py312-openmpi41-ci-on-pull-request.yaml
+++ b/pipelineruns/distributed-workloads/odh-training-cuda130-torch210-py312-openmpi41-ci-on-pull-request.yaml
@@ -5,19 +5,19 @@ metadata:
     build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/distributed-workloads?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
-    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    pipelinesascode.tekton.dev/on-comment: "^/build-konflux"
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
-      event == "push"
+      event == "pull_request"
       && target_branch == "$$TARGET_BRANCH$$"
-      && ( "images/runtime/training/py312-cuda130-torch29-openmpi41/**".pathChanged()
-            || ".tekton/odh-training-cuda130-torch29-py312-openmpi41-ci-on-push.yaml".pathChanged() )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: opendatahub-builds
-    appstudio.openshift.io/component: odh-training-cuda130-torch29-py312-openmpi41-ci
+    appstudio.openshift.io/component: odh-training-cuda130-torch210-py312-openmpi41-ci-ci
     pipelines.appstudio.openshift.io/type: build
-  name: odh-training-cuda130-torch29-py312-openmpi41-ci-on-push
+  name: odh-training-cuda130-torch210-py312-openmpi41-ci-on-pull-request
   namespace: open-data-hub-tenant
 spec:
   params:
@@ -26,11 +26,16 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/opendatahub/odh-training-cuda130-torch29-py312-openmpi41:$$OUTPUT_IMAGE_TAG$$
+    value: quay.io/opendatahub/odh-training-cuda130-torch210-py312-openmpi41:odh-pr
   - name: dockerfile
     value: Dockerfile
   - name: path-context
-    value: images/runtime/training/py312-cuda130-torch29-openmpi41
+    value: images/runtime/training/py312-cuda130-torch210-openmpi41
+  - name: pipeline-type
+    value: pull-request
+  - name: additional-tags
+    value:
+    - 'odh-pr-{{revision}}'
   pipelineRef:
     resolver: git
     params:
@@ -41,7 +46,7 @@ spec:
     - name: pathInRepo
       value: pipeline/multi-arch-container-build.yaml
   taskRunTemplate:
-    serviceAccountName: build-pipeline-odh-training-cuda130-torch29-py312-openmpi41-ci
+    serviceAccountName: build-pipeline-odh-training-cuda130-torch210-py312-openmpi41-ci
   workspaces:
   - name: git-auth
     secret:

--- a/pipelineruns/distributed-workloads/odh-training-cuda130-torch210-py312-openmpi41-ci-on-push.yaml
+++ b/pipelineruns/distributed-workloads/odh-training-cuda130-torch210-py312-openmpi41-ci-on-push.yaml
@@ -15,7 +15,7 @@ metadata:
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: opendatahub-builds
-    appstudio.openshift.io/component: odh-training-cuda130-torch210-py312-openmpi41-ci-ci
+    appstudio.openshift.io/component: odh-training-cuda130-torch210-py312-openmpi41-ci
     pipelines.appstudio.openshift.io/type: build
   name: odh-training-cuda130-torch210-py312-openmpi41-ci-on-push
   namespace: open-data-hub-tenant

--- a/pipelineruns/distributed-workloads/odh-training-cuda130-torch210-py312-openmpi41-ci-on-push.yaml
+++ b/pipelineruns/distributed-workloads/odh-training-cuda130-torch210-py312-openmpi41-ci-on-push.yaml
@@ -10,7 +10,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "$$TARGET_BRANCH$$"
-      && ( "images/runtime/training/py312-cuda130-torch210-openmpi41".pathChanged()
+      && ( "images/runtime/training/py312-cuda130-torch210*/**".pathChanged()
             || ".tekton/odh-training-cuda130-torch210-py312-openmpi41-ci-on-push.yaml".pathChanged() )
   creationTimestamp: null
   labels:

--- a/pipelineruns/distributed-workloads/odh-training-cuda130-torch210-py312-openmpi41-ci-on-push.yaml
+++ b/pipelineruns/distributed-workloads/odh-training-cuda130-torch210-py312-openmpi41-ci-on-push.yaml
@@ -5,21 +5,19 @@ metadata:
     build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/distributed-workloads?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
-    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
-    pipelinesascode.tekton.dev/on-comment: "^/build-konflux"
-    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
-      event == "pull_request"
+      event == "push"
       && target_branch == "$$TARGET_BRANCH$$"
-      && ( "images/runtime/training/py312-cuda130-torch29-openmpi41/**".pathChanged()
-            || ".tekton/odh-training-cuda130-torch29-py312-openmpi41-ci-on-pull-request.yaml".pathChanged() )
+      && ( "images/runtime/training/py312-cuda130-torch210-openmpi41".pathChanged()
+            || ".tekton/odh-training-cuda130-torch210-py312-openmpi41-ci-on-push.yaml".pathChanged() )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: opendatahub-builds
-    appstudio.openshift.io/component: odh-training-cuda130-torch29-py312-openmpi41-ci
+    appstudio.openshift.io/component: odh-training-cuda130-torch210-py312-openmpi41-ci-ci
     pipelines.appstudio.openshift.io/type: build
-  name: odh-training-cuda130-torch29-py312-openmpi41-ci-on-pull-request
+  name: odh-training-cuda130-torch210-py312-openmpi41-ci-on-push
   namespace: open-data-hub-tenant
 spec:
   params:
@@ -28,16 +26,11 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/opendatahub/odh-training-cuda130-torch29-py312-openmpi41:odh-pr
+    value: quay.io/opendatahub/odh-training-cuda130-torch210-py312-openmpi41:$$OUTPUT_IMAGE_TAG$$
   - name: dockerfile
     value: Dockerfile
   - name: path-context
-    value: images/runtime/training/py312-cuda130-torch29-openmpi41
-  - name: pipeline-type
-    value: pull-request
-  - name: additional-tags
-    value:
-    - 'odh-pr-{{revision}}'
+    value: images/runtime/training/py312-cuda130-torch210-openmpi41
   pipelineRef:
     resolver: git
     params:
@@ -48,7 +41,7 @@ spec:
     - name: pathInRepo
       value: pipeline/multi-arch-container-build.yaml
   taskRunTemplate:
-    serviceAccountName: build-pipeline-odh-training-cuda130-torch29-py312-openmpi41-ci
+    serviceAccountName: build-pipeline-odh-training-cuda130-torch210-py312-openmpi41-ci
   workspaces:
   - name: git-auth
     secret:


### PR DESCRIPTION
add training-cuda130-torch210-py312-openmpi41-ci and remove odh-training-cuda130-torch29-py312-openmpi41-ci

https://redhat.atlassian.net/browse/RHOAIENG-59070

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD training pipelines to use CUDA 13.0 with PyTorch 2.1.0, Python 3.12, and OpenMPI 4.1 (replacing the previous PyTorch 2.9 variant). Pipeline identifiers, build contexts, service account references, and output image tags were aligned with the new runtime/toolchain to ensure builds and triggers target the updated training environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->