### PR TITLE
feat:  Add all runtime image contexts and enable pod log collection

### DIFF
--- a/gitops/integration-testing-prerequisites.yaml
+++ b/gitops/integration-testing-prerequisites.yaml
@@ -178,6 +178,24 @@ spec:
       name: component_odh-training-cuda124-torch25-py311-ci
     - description: execute the integration test when component odh-training-cuda121-torch24-py311-ci updates
       name: component_odh-training-cuda121-torch24-py311-ci
+    - description: execute the integration test when component odh-th06-cuda130-torch291-py312-ci updates
+      name: component_odh-th06-cuda130-torch291-py312-ci
+    - description: execute the integration test when component odh-th06-rocm64-torch291-py312-ci updates
+      name: component_odh-th06-rocm64-torch291-py312-ci
+    - description: execute the integration test when component odh-training-cuda128-torch29-py312-ci updates
+      name: component_odh-training-cuda128-torch29-py312-ci
+    - description: execute the integration test when component odh-training-rocm64-torch29-py312-ci updates
+      name: component_odh-training-rocm64-torch29-py312-ci
+    - description: execute the integration test when component training-cuda updates
+      name: component_training-cuda
+    - description: execute the integration test when component training-rocm updates
+      name: component_training-rocm
+    - description: execute the integration test when component py312-cuda128-torch290 updates
+      name: component_py312-cuda128-torch290
+    - description: execute the integration test when component py312-rocm64-torch290 updates
+      name: component_py312-rocm64-torch290
+    - description: execute the integration test when component odh-training-cuda130-torch210-py312-openmpi41-ci updates
+      name: component_odh-training-cuda130-torch210-py312-openmpi41-ci
   resolverRef:
     params:
       - name: url

--- a/integration-tests/distributed-workloads/pr-testing-pipeline.yaml
+++ b/integration-tests/distributed-workloads/pr-testing-pipeline.yaml
@@ -201,6 +201,8 @@ spec:
                   value: $(params.SNAPSHOT)
                 - name: ARTIFACT_DIR
                   value: /workspace/artifacts-dir
+                - name: TEST_OUTPUT_DIR
+                  value: /workspace/artifacts-dir
                 - name: APPLICATIONS_NAMESPACE
                   value: kubeflow-trainer-system
                 - name: TEST_TIMEOUT_DOUBLE


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Add all distributed-workloads runtime image components as ITS contexts so the pipeline triggers for every image build (CUDA, ROCm, Ray, MPI)
- Set TEST_OUTPUT_DIR to ARTIFACT_DIR so pod logs and namespace events collected by the Go test framework are preserved in artifacts
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Broadened integration test triggers to run for a wider set of component variants, increasing coverage without removing existing triggers.
  * Added an additional environment variable for the test pipeline to align test output location with artifact storage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->