### PR TITLE
ci: pass GOTAGS=distro build-arg in kserve-controller pipeline templates

### DIFF
--- a/pipelineruns/kserve/kserve-agent-pull.yaml
+++ b/pipelineruns/kserve/kserve-agent-pull.yaml
@@ -29,6 +29,9 @@ spec:
     value: agent.Dockerfile
   - name: path-context
     value: .
+  - name: build-args
+    value:
+    - "GOTAGS=distro"
   - name: additional-tags
     value:
     - 'odh-pr-{{revision}}'

--- a/pipelineruns/kserve/kserve-agent-push.yaml
+++ b/pipelineruns/kserve/kserve-agent-push.yaml
@@ -28,6 +28,9 @@ spec:
     value: agent.Dockerfile
   - name: path-context
     value: .
+  - name: build-args
+    value:
+    - "GOTAGS=distro"
   - name: additional-tags
     value:
     - 'odh-stable'

--- a/pipelineruns/kserve/kserve-controller-pull.yaml
+++ b/pipelineruns/kserve/kserve-controller-pull.yaml
@@ -29,6 +29,9 @@ spec:
     value: Dockerfile
   - name: path-context
     value: .
+  - name: build-args
+    value:
+    - "GOTAGS=distro"
   - name: additional-tags
     value:
     - 'odh-pr-{{revision}}'

--- a/pipelineruns/kserve/kserve-controller-push.yaml
+++ b/pipelineruns/kserve/kserve-controller-push.yaml
@@ -28,6 +28,9 @@ spec:
     value: Dockerfile
   - name: path-context
     value: .
+  - name: build-args
+    value:
+    - "GOTAGS=distro"
   - name: additional-tags
     value:
     - 'odh-stable'

--- a/pipelineruns/kserve/kserve-router-pull.yaml
+++ b/pipelineruns/kserve/kserve-router-pull.yaml
@@ -29,6 +29,9 @@ spec:
     value: router.Dockerfile
   - name: path-context
     value: .
+  - name: build-args
+    value:
+    - "GOTAGS=distro"
   - name: additional-tags
     value:
     - 'odh-pr-{{revision}}'

--- a/pipelineruns/kserve/kserve-router-push.yaml
+++ b/pipelineruns/kserve/kserve-router-push.yaml
@@ -28,6 +28,9 @@ spec:
     value: router.Dockerfile
   - name: path-context
     value: .
+  - name: build-args
+    value:
+    - "GOTAGS=distro"
   - name: additional-tags
     value:
     - 'odh-stable'

--- a/pipelineruns/kserve/odh-kserve-localmodel-controller-pull-request.yaml
+++ b/pipelineruns/kserve/odh-kserve-localmodel-controller-pull-request.yaml
@@ -28,6 +28,9 @@ spec:
     value: localmodel.Dockerfile
   - name: path-context
     value: .
+  - name: build-args
+    value:
+    - "GOTAGS=distro"
   - name: additional-tags
     value:
     - 'odh-pr-{{revision}}'

--- a/pipelineruns/kserve/odh-kserve-localmodel-controller-push.yaml
+++ b/pipelineruns/kserve/odh-kserve-localmodel-controller-push.yaml
@@ -29,6 +29,9 @@ spec:
     value: localmodel.Dockerfile
   - name: path-context
     value: .
+  - name: build-args
+    value:
+    - "GOTAGS=distro"
   - name: additional-tags
     value:
     - 'odh-stable'

--- a/pipelineruns/kserve/odh-kserve-localmodelnode-agent-pull-request.yaml
+++ b/pipelineruns/kserve/odh-kserve-localmodelnode-agent-pull-request.yaml
@@ -28,6 +28,9 @@ spec:
     value: localmodel-agent.Dockerfile
   - name: path-context
     value: .
+  - name: build-args
+    value:
+    - "GOTAGS=distro"
   - name: additional-tags
     value:
     - 'odh-pr-{{revision}}'

--- a/pipelineruns/kserve/odh-kserve-localmodelnode-agent-push.yaml
+++ b/pipelineruns/kserve/odh-kserve-localmodelnode-agent-push.yaml
@@ -29,6 +29,9 @@ spec:
     value: localmodel-agent.Dockerfile
   - name: path-context
     value: .
+  - name: build-args
+    value:
+    - "GOTAGS=distro"
   - name: additional-tags
     value:
     - 'odh-stable'


### PR DESCRIPTION
## Summary

- Add `build-args: ["GOTAGS=distro"]` to the kserve-controller push and pull pipeline templates
- The `llmisvc-controller` templates already had this parameter; `kserve-controller` was missed
- Companion to opendatahub-io/kserve#1440 which fixes the same in the in-repo `.tekton/` pipelines

## Files changed

- `pipelineruns/kserve/kserve-controller-push.yaml`
- `pipelineruns/kserve/kserve-controller-pull.yaml`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a build argument (GOTAGS=distro) to KServe pipeline run configurations so container image builds receive the specified build-time tag across controller, agent, router, and local-model pipeline invocations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->