### PR TITLE
add odh-training-cuda130-torch210-py312-openmpi41-ci to gitops/opendatahub-ci-components.yaml

### DIFF
--- a/gitops/opendatahub-ci-components.yaml
+++ b/gitops/opendatahub-ci-components.yaml
@@ -1494,6 +1494,26 @@ metadata:
     build.appstudio.openshift.io/pipeline: '{"name":"docker-build-multi-platform-oci-ta","bundle":"latest"}'
     build.appstudio.openshift.io/request: configure-pac-no-mr
     mintmaker.appstudio.redhat.com/disabled: "true"
+  name: odh-training-cuda130-torch210-py312-openmpi41-ci
+  namespace: open-data-hub-tenant
+spec:
+  application: opendatahub-builds
+  componentName: odh-training-cuda130-torch210-py312-openmpi41-ci
+  containerImage: quay.io/opendatahub/odh-training-cuda130-torch210-py312-openmpi41
+  source:
+    git:
+      context: images/runtime/training/py312-cuda130-torch210-openmpi41
+      dockerfileUrl: Dockerfile
+      revision: stable
+      url: https://github.com/opendatahub-io/distributed-workloads.git
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Component
+metadata:
+  annotations:
+    build.appstudio.openshift.io/pipeline: '{"name":"docker-build-multi-platform-oci-ta","bundle":"latest"}'
+    build.appstudio.openshift.io/request: configure-pac-no-mr
+    mintmaker.appstudio.redhat.com/disabled: "true"
   name: odh-pipeline-runtime-pytorch-llmcompressor-cuda-py312-ci
   namespace: open-data-hub-tenant
 spec:


### PR DESCRIPTION
…endatahub-ci-components.yaml
https://redhat.atlassian.net/browse/RHOAIENG-59070
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new training image variant with CUDA 13.0, PyTorch 2.1, Python 3.12, and OpenMPI 4.1 for distributed workloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->