### PR TITLE
Fix the failed dryRunValidation error

### DIFF
--- a/pipeline/multi-arch-operator-build.yaml
+++ b/pipeline/multi-arch-operator-build.yaml
@@ -736,9 +736,6 @@ spec:
             git push
 
     when:
-    - input: "$(tasks.build-image-index.status)"
-      operator: in
-      values: ["Succeeded"]
     - input: "$(params.build-type)"
       operator: notin
       values: ["Release"]


### PR DESCRIPTION
[User error] Failed dryRunValidation for PipelineRun odh-operator-ci-on-push-w8sjd: failed to read runtime object as Pipeline: validation failed for referenced object operator-build: admission webhook "validation.webhook.pipeline.tekton.dev" denied the request: validation failed: invalid value: pipeline tasks can not refer to execution status of any other pipeline task or aggregate status of tasks: spec.tasks[18].when[0]

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified build pipeline configuration by adjusting task execution conditions to streamline the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->