### PR TITLE
Point odh-operator to main branch

### DIFF
--- a/gitops/opendatahub-ci-components.yaml
+++ b/gitops/opendatahub-ci-components.yaml
@@ -60,7 +60,7 @@ spec:
   source:
     git:
       dockerfileUrl: Dockerfiles/Dockerfile
-      revision: "stable"
+      revision: "main"
       url: https://github.com/opendatahub-io/opendatahub-operator
 ---
 apiVersion: appstudio.redhat.com/v1alpha1


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
With @alexxfan we discussed that it would be good to correct this as ODH Nightlies are in fact [built from main, not stable](https://github.com/opendatahub-io/opendatahub-operator/pull/3212). According to our research it probably just specifies the default branch to use when manually triggering pipelines from UI, but still, it would be good to have this fixed.

@alexxfan you mentioned that this is a copy of a file in GitLab (konflux-release-data), but I am not able to open a PR there and it doesn't seem to be in sync, so if you are able to fix it there, it would be nice.

cc @dchourasia 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI component configuration to use the latest development branch for component builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->