### PR TITLE
Exclude autoscaling from kserve LLMISvc E2E

### DIFF
--- a/integration-tests/kserve/pr-group-testing-pipeline.yaml
+++ b/integration-tests/kserve/pr-group-testing-pipeline.yaml
@@ -1560,7 +1560,7 @@ spec:
             COMPONENT_NAME=odh-kserve-llmisvc-controller-ci
             export LLMISVC_CONTROLLER_IMAGE=$(jq -r --arg component_name "${COMPONENT_NAME}" '.[$component_name].image' <<< "${SNAPSHOT}")
 
-            ./test/scripts/openshift-ci/run-e2e-tests.sh "llminferenceservice and cluster_cpu" 2 "llm-d"
+            ./test/scripts/openshift-ci/run-e2e-tests.sh "llminferenceservice and cluster_cpu and not autoscaling" 2 "llm-d"
             echo "success" > "$STATUS_FILE"
         - name: must-gather
           onError: continue

--- a/integration-tests/odh-model-controller/pr-test-pipelinerun.yaml
+++ b/integration-tests/odh-model-controller/pr-test-pipelinerun.yaml
@@ -535,7 +535,7 @@ spec:
                   echo "LLMD_ROUTING_SIDECAR_IMAGE=${LLMD_ROUTING_SIDECAR_IMAGE}"
                   echo "KUBE_RBAC_PROXY_IMAGE=${KUBE_RBAC_PROXY_IMAGE}"
 
-                  ./test/scripts/openshift-ci/run-e2e-tests.sh "llminferenceservice and (cluster_cpu and cluster_single_node)" 2 "llm-d"
+                  ./test/scripts/openshift-ci/run-e2e-tests.sh "llminferenceservice and (cluster_cpu and cluster_single_node) and not autoscaling" 2 "llm-d"
                 popd
             - name: must-gather
               onError: continue


### PR DESCRIPTION
## Summary

Adds `and not autoscaling` to the pytest marker for the LLMISvc E2E tests in both the kserve and odh-model-controller pipelines.

The WVA (Workload Variant Autoscaler) infrastructure (Prometheus, WVA controller, HPA/KEDA) is not installed in these test clusters. Without it, autoscaling tests fail with `ScalingCRDNotFound` because the `VariantAutoscaling` CRD from `llmd.ai/v1alpha1` is missing.

This matches the pattern already used in the upstream `e2e-test-llmisvc.yaml` GHA workflow, which excludes autoscaling from its basic job and runs dedicated autoscaling jobs with full WVA infrastructure.

### Files changed

- `integration-tests/kserve/pr-group-testing-pipeline.yaml` -- kserve PR group test
- `integration-tests/odh-model-controller/pr-test-pipelinerun.yaml` -- omc PR test

### Companion PRs

- https://github.com/openshift/release/pull/78557 (same fix for Prow)
- opendatahub-io/kserve#1445 (sync PR that introduced the autoscaling feature)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated test pipeline configurations to exclude autoscaling test cases from the integration test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->