### PR TITLE
fix: kuberay - wait for the cert to be injected

### DIFF
--- a/integration-tests/kuberay/pr-testing-pipeline.yaml
+++ b/integration-tests/kuberay/pr-testing-pipeline.yaml
@@ -315,6 +315,15 @@ spec:
                   --server-side --force-conflicts
                 oc rollout status deployment/kuberay-operator -n ${NAMESPACE} --timeout=300s
 
+                echo "Waiting for webhook CA bundle to be injected by OpenShift..."
+                for i in $(seq 1 30); do
+                  CA=$(oc get mutatingwebhookconfiguration kuberay-mutating-webhook-configuration \
+                    -o jsonpath='{.webhooks[0].clientConfig.caBundle}' 2>/dev/null)
+                  [ -n "$CA" ] && echo "CA bundle injected" && break
+                  echo "  attempt $i/30, retrying in 10s..."
+                  sleep 10
+                done
+
                 # Grant anyuid SCC to all service accounts so Ray pods can start in test-ns-* namespaces
                 oc adm policy add-scc-to-group anyuid system:serviceaccounts
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
fix: kuberay - wait for the cert to be injected

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced testing pipeline reliability by adding synchronization logic to wait for webhook configuration initialization before running integration tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->