### PR TITLE
feat(integration-tests): onboard ai-gateway-payload-processing group e2e test

### DIFF
--- a/gitops/integration-testing-prerequisites.yaml
+++ b/gitops/integration-testing-prerequisites.yaml
@@ -84,6 +84,27 @@ spec:
       url: https://github.com/opendatahub-io/models-as-a-service.git
       revision: "main"
 ---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Component
+metadata:
+  annotations:
+    build.appstudio.openshift.io/pipeline: '{"name":"docker-build-oci-ta","bundle":"latest"}'
+    build.appstudio.openshift.io/request: configure-pac-no-mr
+    mintmaker.appstudio.redhat.com/disabled: 'true'
+    git-provider: github
+    git-provider-url: https://github.com
+  name: ai-gateway-group
+  namespace: open-data-hub-tenant
+spec:
+  application: group-testing
+  componentName: ai-gateway-group
+  containerImage: quay.io/redhat-user-workloads/open-data-hub-tenant/ai-gateway-group
+  source:
+    git:
+      dockerfileUrl: Dockerfile
+      url: https://github.com/opendatahub-io/ai-gateway-payload-processing.git
+      revision: "main"
+---
 apiVersion: appstudio.redhat.com/v1beta2
 kind: IntegrationTestScenario
 metadata:

--- a/gitops/opendatahub-ci-components.yaml
+++ b/gitops/opendatahub-ci-components.yaml
@@ -1641,3 +1641,43 @@ spec:
       dockerfileUrl: Dockerfile
       revision: main
       url: https://github.com/opendatahub-io/models-as-a-service.git
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Component
+metadata:
+  annotations:
+    build.appstudio.openshift.io/pipeline: '{"name":"docker-build-multi-platform-oci-ta","bundle":"latest"}'
+    mintmaker.appstudio.redhat.com/disabled: "true"
+    build.appstudio.openshift.io/request: configure-pac-no-mr
+  name: odh-ai-gateway-payload-processing-ci
+  namespace: open-data-hub-tenant
+spec:
+  application: opendatahub-builds
+  componentName: odh-ai-gateway-payload-processing-ci
+  containerImage: quay.io/opendatahub/odh-ai-gateway-payload-processing
+  source:
+    git:
+      context: .
+      dockerfileUrl: Dockerfile
+      revision: main
+      url: https://github.com/opendatahub-io/ai-gateway-payload-processing.git
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Component
+metadata:
+  annotations:
+    build.appstudio.openshift.io/pipeline: '{"name":"docker-build-multi-platform-oci-ta","bundle":"latest"}'
+    mintmaker.appstudio.redhat.com/disabled: "true"
+    build.appstudio.openshift.io/request: configure-pac-no-mr
+  name: ai-gateway-payload-processing-e2e-ci
+  namespace: open-data-hub-tenant
+spec:
+  application: opendatahub-builds
+  componentName: ai-gateway-payload-processing-e2e-ci
+  containerImage: quay.io/opendatahub/ai-gateway-payload-processing-e2e
+  source:
+    git:
+      context: .
+      dockerfileUrl: Dockerfile.e2e
+      revision: main
+      url: https://github.com/opendatahub-io/ai-gateway-payload-processing.git

--- a/integration-tests/ai-gateway-payload-processing/Dockerfile.ai-gateway
+++ b/integration-tests/ai-gateway-payload-processing/Dockerfile.ai-gateway
@@ -1,0 +1,10 @@
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25
+USER 0
+RUN yum install -y --nodocs --allowerasing jq httpd-tools
+RUN curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash
+RUN mv kustomize /usr/local/bin/
+RUN yum clean all && rm -rf /var/cache/yum
+RUN ln -s /usr/bin/python3 /usr/bin/python
+RUN wget https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable/openshift-client-linux.tar.gz && \
+    tar xvf openshift-client-linux.tar.gz && chmod +x oc && mv oc /usr/local/bin/ && chmod +x kubectl && mv kubectl /usr/local/bin/
+RUN curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash

--- a/integration-tests/ai-gateway-payload-processing/README.md
+++ b/integration-tests/ai-gateway-payload-processing/README.md
@@ -1,0 +1,77 @@
+# AI Gateway Payload Processing Integration Test
+
+This directory contains the Konflux **group** integration test **Pipeline** for [ai-gateway-payload-processing](https://github.com/opendatahub-io/ai-gateway-payload-processing).
+
+## Repositories
+
+- **Pipeline config:** [opendatahub-io/odh-konflux-central](https://github.com/opendatahub-io/odh-konflux-central)
+- **Tested project:** [opendatahub-io/ai-gateway-payload-processing](https://github.com/opendatahub-io/ai-gateway-payload-processing)
+
+## Pipelines
+
+### `pr-group-testing-pipeline.yaml`
+
+Tekton **`Pipeline`** (`metadata.name: odh-pr-test-ai-gateway`). It runs ai-gateway-payload-processing e2e tests against an **ephemeral Hypershift** cluster on AWS (EaaS), using **both** `odh-ai-gateway-payload-processing-ci` and `ai-gateway-payload-processing-e2e-ci` images that belong to the **same pull request** (composite snapshot), not a single-component Konflux snapshot.
+
+**How it is triggered**
+
+- PAC `PipelineRun` [`pipelineruns/ai-gateway-payload-processing/ai-gateway-group-test.yaml`](../../pipelineruns/ai-gateway-payload-processing/ai-gateway-group-test.yaml) resolves this file from `odh-konflux-central`.
+- Annotations: `pipelinesascode.tekton.dev/on-cel-expression: event == "group-test"` and optional `on-comment: "^/group-test"` for manual runs.
+
+**Parameters**
+
+| Parameter | Role |
+| --- | --- |
+| `group-components` | JSON map of Konflux component names to repo coordinates; fed into snapshot generation (see default in `ai-gateway-group-test.yaml`). |
+| `oci-artifacts-repo` | OCI artifact repository for collected test output (default `quay.io/opendatahub/odh-ci-artifacts`). |
+| `artifact-browser-url` | Base URL passed into the PR comment stepaction for browsing published artifacts. |
+
+**Workspaces**
+
+- **`git-auth`** — required for `generate-snapshot` (clone/pull private metadata as configured in the `PipelineRun`).
+
+**Konflux component names**
+
+| Component | Image | Built from |
+| --- | --- | --- |
+| `odh-ai-gateway-payload-processing-ci` | `quay.io/opendatahub/odh-ai-gateway-payload-processing:odh-pr` | `Dockerfile` |
+| `ai-gateway-payload-processing-e2e-ci` | `quay.io/opendatahub/ai-gateway-payload-processing-e2e:odh-pr` | `Dockerfile.e2e` |
+
+**Task flow (high level)**
+
+1. **`generate-snapshot`** — builds a **composite snapshot** JSON listing images and git metadata for every component in `group-components` (rhoai-konflux `generate-snapshot-for-group-testing` task).
+2. **`audit-snapshot`** — verifies each component row has non-empty image, `git.commit`, and `git.url`; writes PR fields from PAC annotations/labels (`pipelinesascode.tekton.dev/sender`, `pull-request`, `url-repository`, `url-org`, `sha`, …).
+3. **`provision-eaas-space`** / **`provision-cluster`** — EaaS space + Hypershift cluster (`m5.2xlarge`), same build-definitions stepactions as other ODH integration tests.
+4. **`e2e-ai-gateway-openshift`** (timeout **1h30m**) — fetch kubeconfig, **clone** `ai-gateway-payload-processing` using PAC **source-repo-url** and **source-branch**, export `PAYLOAD_PROCESSING_IMAGE` / `PAYLOAD_PROCESSING_E2E_IMAGE` from the composite snapshot via `jq`, run `./test/e2e/script/e2e-ci.sh`. **`ARTIFACT_DIR`** holds junit/html and must-gather output. The e2e step uses **`onError: continue`** so later steps still run; a **`deploy-and-e2e-status`** file (`success` / `failed`) plus **`fail-if-needed`** re-assert failure after **`git-push-artifacts`**.
+5. **`must-gather`** — `oc adm must-gather` into `ARTIFACT_DIR` (also `onError: continue`).
+6. **`git-push-artifacts`** — stages `ARTIFACT_DIR` into `opendatahub-io/odh-build-metadata` branch `ci-artifacts` under `test-artifacts/<pipelinerun-name>` (`secure-git-push` stepaction).
+7. **`finally` → `push-ci-artifacts-and-update-pr`** — sparse-clone that path, **push OCI** (`secure-push-oci` + `odh-registry-secret`), **comment on the PR** (`pull-request-comment`, inputs from `audit-snapshot` results and `$(tasks.status)`), **delete** the transient directory under `test-artifacts/` (`cleanup-git-repo`).
+
+**E2E script contract**
+
+The pipeline exports the following env vars before calling `./test/e2e/script/e2e-ci.sh`:
+
+| Env var | Source |
+| --- | --- |
+| `PAYLOAD_PROCESSING_IMAGE` | `odh-ai-gateway-payload-processing-ci` image digest from composite snapshot |
+| `PAYLOAD_PROCESSING_E2E_IMAGE` | `ai-gateway-payload-processing-e2e-ci` image digest from composite snapshot |
+| `KUBECONFIG` | Ephemeral cluster credentials mounted from EaaS |
+| `ARTIFACT_DIR` | `/workspace/artifacts-dir` — write junit XML and logs here |
+
+The `e2e-ci.sh` script is responsible for deploying the payload processing component (using `PAYLOAD_PROCESSING_IMAGE`) and running the compiled Ginkgo test binary (packaged inside `PAYLOAD_PROCESSING_E2E_IMAGE` via its `entrypoint.sh`).
+
+### `Dockerfile.ai-gateway`
+
+UBI9-based image with `oc`/`kubectl`, `kustomize`, `helm`, `jq`, and related tooling. Mirrors `Dockerfile.maas` but adds `helm` since the ai-gateway-payload-processing deployment uses Helm charts. Build and publish it as `quay.io/rhoai/rhoai-task-toolset:ai-gateway` — the pipeline YAML references that tag for both the `e2e-ai-gateway` and `must-gather` steps.
+
+## Out-of-band prerequisites (Konflux)
+
+The following must be configured in Konflux before the group test can be triggered:
+
+1. **`ai-gateway-group` component** — create a component named `ai-gateway-group` under the `group-testing` application in Konflux. This component receives the PAC `group-test` event and points at `ai-gateway-group-test.yaml`.
+2. **`konflux-integration-runner` service account** — must have pull access to `quay.io/opendatahub/odh-ai-gateway-payload-processing` and `quay.io/opendatahub/ai-gateway-payload-processing-e2e`.
+3. **`git_auth_secret`** — PAC git auth secret must be present in `open-data-hub-tenant` namespace.
+
+## Metadata
+
+This group pipeline does **not** use [`test_metadata.yaml`](https://github.com/konflux-ci/integration-examples/blob/main/tasks/test_metadata.yaml) from `konflux-ci/integration-examples`. Snapshot and git context come from **`generate-snapshot`**, **`audit-snapshot`**, and **Pipelines-as-Code** annotations on the `PipelineRun`.

--- a/integration-tests/ai-gateway-payload-processing/pr-group-testing-pipeline.yaml
+++ b/integration-tests/ai-gateway-payload-processing/pr-group-testing-pipeline.yaml
@@ -1,0 +1,443 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: odh-pr-test-ai-gateway
+spec:
+  description: |
+    A group integration test which provisions an ephemeral Hypershift cluster and runs the
+    ai-gateway-payload-processing e2e tests using images for both odh-ai-gateway-payload-processing-ci
+    and ai-gateway-payload-processing-e2e-ci built from the same pull request commit.
+  params:
+    - description: List of components in the group
+      name: group-components
+      type: string
+    - name: oci-artifacts-repo
+      default: 'quay.io/opendatahub/odh-ci-artifacts'
+      description: The OCI container used to store all test artifacts.
+    - name: artifact-browser-url
+      default: 'https://app-artifact-browser.apps.rosa.konflux-qe.zmr9.p3.openshiftapps.com'
+      description: The OCI container used to store all test artifacts.
+  tasks:
+    - name: generate-snapshot
+      description: Generate a composite snapshot containing images for all group components
+      params:
+        - name: COMPONENTS
+          value: $(params.group-components)
+      workspaces:
+      - name: basic-auth
+        workspace: git-auth
+      taskRef:
+        resolver: git
+        params:
+        - name: url
+          value: https://github.com/red-hat-data-services/rhoai-konflux-tasks.git
+        - name: revision
+          value: main
+        - name: pathInRepo
+          value: konflux-tekton-tasks/generate-snapshot-for-group-testing/0.1/generate-snapshot-for-group-testing.yaml
+    - name: audit-snapshot
+      runAfter:
+        - generate-snapshot
+      params:
+        - name: COMPONENTS
+          value: $(params.group-components)
+      taskSpec:
+        params:
+          - name: COMPONENTS
+            description: List of components in the group
+        results:
+        - name: pull-request-author
+        - name: pull-request-number
+        - name: git-repo
+        - name: git-org
+        - name: git-revision
+        steps:
+          - name: audit-snapshot
+            image: quay.io/konflux-ci/konflux-test:stable
+            workingDir: /workspace
+            env:
+              - name: SNAPSHOT
+                value: $(tasks.generate-snapshot.results.SNAPSHOT)
+              - name: COMPONENTS
+                value: $(params.COMPONENTS)
+              - name: PR_AUTHOR
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.annotations['pipelinesascode.tekton.dev/sender']
+              - name: PR_NUMBER
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.labels['pipelinesascode.tekton.dev/pull-request']
+              - name: GIT_REPO
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.annotations['pipelinesascode.tekton.dev/url-repository']
+              - name: GIT_ORG
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.annotations['pipelinesascode.tekton.dev/url-org']
+              - name: GIT_REVISION
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.annotations['pipelinesascode.tekton.dev/sha']
+            script: |
+              #!/bin/bash
+              set -e
+              echo "SNAPSHOT=${SNAPSHOT}"
+
+              # Parse JSON and iterate through each component
+              while IFS= read -r row; do
+                  COMPONENT_NAME=$(echo "$row" | base64 -d | jq -r '.key')
+                  IMAGE=$(jq -r --arg component_name "${COMPONENT_NAME}" '.[$component_name].image' <<< "${SNAPSHOT}")
+                  GIT_COMMIT=$(jq -r --arg component_name "${COMPONENT_NAME}" '.[$component_name]."git.commit"' <<< "${SNAPSHOT}")
+                  GIT_URL=$(jq -r --arg component_name "${COMPONENT_NAME}" '.[$component_name]."git.url"' <<< "${SNAPSHOT}")
+                  if [ -z "${IMAGE}" ] || [ "${IMAGE}" = "null" ] || \
+                     [ -z "${GIT_COMMIT}" ] || [ "${GIT_COMMIT}" = "null" ] || \
+                     [ -z "${GIT_URL}" ] || [ "${GIT_URL}" = "null" ]; then
+                      echo "ERROR: snapshot metadata missing for ${COMPONENT_NAME}" >&2
+                      exit 1
+                  fi
+                  echo "${COMPONENT_NAME} IMAGE: ${IMAGE}"
+                  echo "GIT_COMMIT=${GIT_COMMIT}"
+                  echo "GIT_URL=${GIT_URL}"
+              done < <(echo "$COMPONENTS" | jq -r 'to_entries[] | @base64')
+
+              echo -n "${PR_AUTHOR}" > "$(results.pull-request-author.path)"
+              echo -n "${PR_NUMBER}" > "$(results.pull-request-number.path)"
+              echo -n "${GIT_REPO}" > "$(results.git-repo.path)"
+              echo -n "${GIT_ORG}" > "$(results.git-org.path)"
+              echo -n "${GIT_REVISION}" > "$(results.git-revision.path)"
+
+    - name: provision-eaas-space
+      runAfter:
+        - audit-snapshot
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/build-definitions.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: task/eaas-provision-space/0.1/eaas-provision-space.yaml
+      params:
+        - name: ownerName
+          value: $(context.pipelineRun.name)
+        - name: ownerUid
+          value: $(context.pipelineRun.uid)
+    - name: provision-cluster
+      runAfter:
+        - provision-eaas-space
+      taskSpec:
+        results:
+          - name: clusterName
+            value: "$(steps.create-cluster.results.clusterName)"
+        steps:
+          - name: get-supported-versions
+            ref:
+              resolver: git
+              params:
+                - name: url
+                  value: https://github.com/konflux-ci/build-definitions.git
+                - name: revision
+                  value: main
+                - name: pathInRepo
+                  value: stepactions/eaas-get-supported-ephemeral-cluster-versions/0.1/eaas-get-supported-ephemeral-cluster-versions.yaml
+            params:
+              - name: eaasSpaceSecretRef
+                value: $(tasks.provision-eaas-space.results.secretRef)
+          - name: pick-version
+            ref:
+              resolver: git
+              params:
+                - name: url
+                  value: https://github.com/konflux-ci/build-definitions.git
+                - name: revision
+                  value: main
+                - name: pathInRepo
+                  value: stepactions/eaas-get-latest-openshift-version-by-prefix/0.1/eaas-get-latest-openshift-version-by-prefix.yaml
+            params:
+              - name: prefix
+                value: "$(steps.get-supported-versions.results.versions[0])."
+          - name: create-cluster
+            ref:
+              resolver: git
+              params:
+                - name: url
+                  value: https://github.com/konflux-ci/build-definitions.git
+                - name: revision
+                  value: main
+                - name: pathInRepo
+                  value: stepactions/eaas-create-ephemeral-cluster-hypershift-aws/0.1/eaas-create-ephemeral-cluster-hypershift-aws.yaml
+            params:
+              - name: eaasSpaceSecretRef
+                value: $(tasks.provision-eaas-space.results.secretRef)
+              - name: version
+                value: "$(steps.pick-version.results.version)"
+              - name: instanceType
+                value: m5.2xlarge
+    - name: e2e-ai-gateway-openshift
+      timeout: 1h30m
+      workspaces:
+      - name: basic-auth
+        workspace: git-auth
+      runAfter:
+        - provision-cluster
+      taskSpec:
+        volumes:
+          - name: credentials
+            emptyDir: {}
+          - name: test-status
+            emptyDir: {}
+        workspaces:
+          - name: basic-auth
+            optional: true
+        steps:
+          - name: get-kubeconfig
+            ref:
+              resolver: git
+              params:
+                - name: url
+                  value: https://github.com/konflux-ci/build-definitions.git
+                - name: revision
+                  value: main
+                - name: pathInRepo
+                  value: stepactions/eaas-get-ephemeral-cluster-credentials/0.1/eaas-get-ephemeral-cluster-credentials.yaml
+            params:
+              - name: eaasSpaceSecretRef
+                value: $(tasks.provision-eaas-space.results.secretRef)
+              - name: clusterName
+                value: "$(tasks.provision-cluster.results.clusterName)"
+              - name: credentials
+                value: credentials
+          - name: clone-repo
+            image: alpine/git
+            env:
+            - name: source_branch
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.annotations['pipelinesascode.tekton.dev/source-branch']
+            - name: repo_url
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.annotations['pipelinesascode.tekton.dev/source-repo-url']
+            script: |
+              echo "${source_branch}"
+              echo "${repo_url}"
+              git clone --depth 50 --no-single-branch "${repo_url}" /workspace/source
+              git config --global --add safe.directory /workspace/source
+              cd /workspace/source
+              git checkout "${source_branch}"
+          - name: e2e-ai-gateway
+            onError: continue
+            image: quay.io/rhoai/rhoai-task-toolset:ai-gateway
+            env:
+              - name: KUBECONFIG
+                value: "/credentials/$(steps.get-kubeconfig.results.kubeconfig)"
+              - name: ARTIFACT_DIR
+                value: /workspace/artifacts-dir
+              - name: SNAPSHOT
+                value: $(tasks.generate-snapshot.results.SNAPSHOT)
+            workingDir: /workspace/source
+            volumeMounts:
+              - name: credentials
+                mountPath: /credentials
+              - name: test-status
+                mountPath: /test-status
+            script: |
+              set -euxo pipefail
+              bash
+
+              STATUS_FILE="/test-status/deploy-and-e2e-status"
+              echo "failed" > "$STATUS_FILE"
+
+              export PAYLOAD_PROCESSING_IMAGE=$(jq -r '."odh-ai-gateway-payload-processing-ci".image' <<< "${SNAPSHOT}")
+              export PAYLOAD_PROCESSING_E2E_IMAGE=$(jq -r '."ai-gateway-payload-processing-e2e-ci".image' <<< "${SNAPSHOT}")
+
+              PAYLOAD_PROCESSING_TAG=$(jq -r '."odh-ai-gateway-payload-processing-ci".image_tag' <<< "${SNAPSHOT}")
+              PAYLOAD_PROCESSING_E2E_TAG=$(jq -r '."ai-gateway-payload-processing-e2e-ci".image_tag' <<< "${SNAPSHOT}")
+
+              if [ -z "${PAYLOAD_PROCESSING_TAG}" ] || [ "${PAYLOAD_PROCESSING_TAG}" = "null" ] || \
+                 [ -z "${PAYLOAD_PROCESSING_E2E_TAG}" ] || [ "${PAYLOAD_PROCESSING_E2E_TAG}" = "null" ]; then
+                echo "ERROR: image_tag missing for odh-ai-gateway-payload-processing-ci or ai-gateway-payload-processing-e2e-ci in SNAPSHOT" >&2
+                exit 1
+              fi
+
+              echo "PAYLOAD_PROCESSING_IMAGE=${PAYLOAD_PROCESSING_IMAGE}"
+              echo "PAYLOAD_PROCESSING_IMAGE (tag): ${PAYLOAD_PROCESSING_IMAGE%%@*}:${PAYLOAD_PROCESSING_TAG}"
+              echo "PAYLOAD_PROCESSING_E2E_IMAGE=${PAYLOAD_PROCESSING_E2E_IMAGE}"
+              echo "PAYLOAD_PROCESSING_E2E_IMAGE (tag): ${PAYLOAD_PROCESSING_E2E_IMAGE%%@*}:${PAYLOAD_PROCESSING_E2E_TAG}"
+
+              ./test/e2e/script/e2e-ci.sh
+
+              echo "success" > "$STATUS_FILE"
+          - name: must-gather
+            onError: continue
+            image: quay.io/rhoai/rhoai-task-toolset:ai-gateway
+            env:
+              - name: KUBECONFIG
+                value: "/credentials/$(steps.get-kubeconfig.results.kubeconfig)"
+              - name: ARTIFACT_DIR
+                value: /workspace/artifacts-dir
+            workingDir: /workspace/source
+            volumeMounts:
+              - name: credentials
+                mountPath: /credentials
+            script: |
+              mkdir -p "${ARTIFACT_DIR}/gather-openshift"
+              oc adm must-gather --dest-dir "${ARTIFACT_DIR}/gather-openshift"
+          - name: git-push-artifacts
+            onError: continue
+            ref:
+              resolver: git
+              params:
+                - name: url
+                  value: https://github.com/red-hat-data-services/rhoai-konflux-tasks.git
+                - name: revision
+                  value: main
+                - name: pathInRepo
+                  value: stepactions/secure-git-push/0.1/secure-git-push.yaml
+            params:
+              - name: source-path
+                value: /workspace/artifacts-dir
+              - name: repo-path
+                value: 'opendatahub-io/odh-build-metadata'
+              - name: repo-branch
+                value: 'ci-artifacts'
+              - name: sparse-file-path
+                value: 'test-artifacts/docs'
+              - name: dest-path
+                value: 'test-artifacts/$(context.pipelineRun.name)'
+              - name: pipelinerun-name
+                value: $(context.pipelineRun.name)
+          - name: fail-if-needed
+            image: alpine
+            volumeMounts:
+              - name: test-status
+                mountPath: /test-status
+            script: |
+              STATUS_FILE="/test-status/deploy-and-e2e-status"
+              if ! [ -f "$STATUS_FILE" ] || [ "$(cat "$STATUS_FILE")" != "success" ]; then
+                echo "Failing pipeline because deploy-and-e2e step failed"
+                exit 1
+              fi
+              echo "deploy-and-e2e step succeeded"
+
+  finally:
+  - name: push-ci-artifacts-and-update-pr
+    workspaces:
+    - name: basic-auth
+      workspace: git-auth
+    params:
+      - name: oci-artifacts-repo
+        value: $(params.oci-artifacts-repo)
+      - name: pipeline-status
+        value: $(tasks.status)
+    taskSpec:
+      volumes:
+        - name: odh-registry-secret-volume
+          secret:
+            secretName: odh-registry-secret
+            items:
+            - key: .dockerconfigjson
+              path: oci-storage-dockerconfigjson
+      workspaces:
+        - name: basic-auth
+          optional: true
+      params:
+        - name: oci-artifacts-repo
+          description: oci-artifacts-repo
+        - name: pipeline-status
+          type: string
+      steps:
+        - name: pull-ci-artifacts
+          onError: continue
+          ref:
+            resolver: git
+            params:
+              - name: url
+                value: https://github.com/red-hat-data-services/rhoai-konflux-tasks.git
+              - name: revision
+                value: main
+              - name: pathInRepo
+                value: stepactions/git-clone/0.1/git-clone.yaml
+          params:
+            - name: repo-path
+              value: 'opendatahub-io/odh-build-metadata'
+            - name: repo-branch
+              value: 'ci-artifacts'
+            - name: sparse-file-path
+              value: 'test-artifacts/$(context.pipelineRun.name)'
+            - name: dest-path
+              value: /workspace/odh-ci-artifacts
+            - name: artifacts-dir-path
+              value: 'test-artifacts/$(context.pipelineRun.name)'
+        - name: secure-push-oci
+          onError: continue
+          ref:
+            resolver: git
+            params:
+              - name: url
+                value: https://github.com/red-hat-data-services/rhoai-konflux-tasks.git
+              - name: revision
+                value: main
+              - name: pathInRepo
+                value: stepactions/secure-push-oci/0.1/secure-push-oci.yaml
+          params:
+            - name: workdir-path
+              value: '/workspace/odh-ci-artifacts/test-artifacts/$(context.pipelineRun.name)'
+            - name: oci-ref
+              value: $(params.oci-artifacts-repo):$(context.pipelineRun.name)
+            - name: credentials-volume-name
+              value: odh-registry-secret-volume
+        - name: share-status-on-pull-request
+          ref:
+            resolver: git
+            params:
+              - name: url
+                value: https://github.com/red-hat-data-services/rhoai-konflux-tasks.git
+              - name: revision
+                value: main
+              - name: pathInRepo
+                value: stepactions/pull-request-comment/0.1/pull-request-comment.yaml
+          params:
+            - name: test-name
+              value: $(context.pipelineRun.name)
+            - name: oci-container
+              value: $(params.oci-artifacts-repo):$(context.pipelineRun.name)
+            - name: pipeline-aggregate-status
+              value: $(params.pipeline-status)
+            - name: pull-request-author
+              value: $(tasks.audit-snapshot.results.pull-request-author)
+            - name: pull-request-number
+              value: $(tasks.audit-snapshot.results.pull-request-number)
+            - name: git-repo
+              value: $(tasks.audit-snapshot.results.git-repo)
+            - name: git-org
+              value: $(tasks.audit-snapshot.results.git-org)
+            - name: git-revision
+              value: $(tasks.audit-snapshot.results.git-revision)
+            - name: artifact-browser-url
+              value: $(params.artifact-browser-url)
+        - name: cleanup-artifacts-from-git
+          onError: continue
+          ref:
+            resolver: git
+            params:
+              - name: url
+                value: https://github.com/red-hat-data-services/rhoai-konflux-tasks.git
+              - name: revision
+                value: main
+              - name: pathInRepo
+                value: stepactions/cleanup-git-repo/0.1/cleanup-git-repo.yaml
+          params:
+            - name: work-dir
+              value: '/workspace/odh-ci-artifacts'
+            - name: artifacts-dir-path
+              value: 'test-artifacts'
+            - name: dir-to-be-deleted
+              value: '$(context.pipelineRun.name)'
+  workspaces:
+  - name: git-auth
+    optional: true

--- a/pipelineruns/ai-gateway-payload-processing/ai-gateway-group-test.yaml
+++ b/pipelineruns/ai-gateway-payload-processing/ai-gateway-group-test.yaml
@@ -1,0 +1,48 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/ai-gateway-payload-processing?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "group-test"
+    pipelinesascode.tekton.dev/on-comment: "^/group-test"
+  name: ai-gateway-group-test
+  namespace: open-data-hub-tenant
+  labels:
+    appstudio.openshift.io/application: group-testing
+    appstudio.openshift.io/component: ai-gateway-group
+    pipelines.appstudio.openshift.io/type: test
+spec:
+  params:
+  - name: group-components
+    value: '{ "odh-ai-gateway-payload-processing-ci": "opendatahub/ai-gateway-payload-processing", "ai-gateway-payload-processing-e2e-ci": "opendatahub/ai-gateway-payload-processing" }'
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/opendatahub-io/odh-konflux-central.git
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: integration-tests/ai-gateway-payload-processing/pr-group-testing-pipeline.yaml
+  taskRunTemplate:
+    podTemplate:
+      nodeSelector:
+        konflux-ci.dev/workload: konflux-tenants
+      tolerations:
+      - effect: NoSchedule
+        key: konflux-ci.dev/workload
+        operator: Equal
+        value: konflux-tenants
+    serviceAccountName: konflux-integration-runner
+  timeouts:
+    pipeline: 4h0m0s
+    tasks: 3h
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'


### PR DESCRIPTION
## Summary

- Onboards the `ai-gateway-payload-processing` project onto Konflux group integration testing, following the same pattern as `models-as-a-service`.

## Description

Adds all the pieces needed to run group e2e tests for [opendatahub-io/ai-gateway-payload-processing](https://github.com/opendatahub-io/ai-gateway-payload-processing) on every PR via Pipelines-as-Code.

**New files:**
- `integration-tests/ai-gateway-payload-processing/pr-group-testing-pipeline.yaml` — Tekton Pipeline (`odh-pr-test-ai-gateway`) that provisions an ephemeral Hypershift cluster and runs `./test/e2e/script/e2e-ci.sh` with `PAYLOAD_PROCESSING_IMAGE` and `PAYLOAD_PROCESSING_E2E_IMAGE` extracted from the composite snapshot
- `integration-tests/ai-gateway-payload-processing/Dockerfile.ai-gateway` — toolset image recipe for `quay.io/rhoai/rhoai-task-toolset:ai-gateway` (UBI9, oc, kubectl, kustomize, helm, jq); mirrors `Dockerfile.maas` with helm added for chart-based deployments
- `integration-tests/ai-gateway-payload-processing/README.md` — documentation including env var contract and out-of-band prerequisites
- `pipelineruns/ai-gateway-payload-processing/ai-gateway-group-test.yaml` — PAC `PipelineRun` trigger (`event == "group-test"` / `/group-test` comment)

**Updated files:**
- `gitops/integration-testing-prerequisites.yaml` — adds `ai-gateway-group` Component under the `group-testing` application
- `gitops/opendatahub-ci-components.yaml` — adds `odh-ai-gateway-payload-processing-ci` and `ai-gateway-payload-processing-e2e-ci` Components

**Komponents used from snapshot:**

| Konflux component | Image |
|---|---|
| `odh-ai-gateway-payload-processing-ci` | `quay.io/opendatahub/odh-ai-gateway-payload-processing` |
| `ai-gateway-payload-processing-e2e-ci` | `quay.io/opendatahub/ai-gateway-payload-processing-e2e` |

## How it was tested

- Reviewed against the `models-as-a-service` group test setup as the reference implementation.
- Cross-checked component names, image names, and PAC annotations against existing build pipelineruns in `pipelineruns/ai-gateway-payload-processing/`.
- Verified `namespace: open-data-hub-tenant` and annotation formatting are consistent with the rest of `opendatahub-ci-components.yaml`.

**Pre-merge prerequisites (out-of-band):**
1. Build and push `quay.io/rhoai/rhoai-task-toolset:ai-gateway` from `Dockerfile.ai-gateway`.
2. Ensure `ai-gateway-group` Konflux component exists under `group-testing` application.
3. Merge the `e2e-ci.sh` PR in `ai-gateway-payload-processing` repo before triggering the first test run.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added integration test pipeline documentation describing the AI Gateway payload processing workflow, configuration, and execution procedures.

* **Chores**
  * Added CI/CD infrastructure configuration for automated builds and integration testing of AI Gateway payload processing.
  * Configured pipeline orchestration, artifact management, and test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->