### PR TITLE
fix(ai-gateway): correct e2e script path from script/ to scripts/

### DIFF
--- a/integration-tests/ai-gateway-payload-processing/pr-group-testing-pipeline.yaml
+++ b/integration-tests/ai-gateway-payload-processing/pr-group-testing-pipeline.yaml
@@ -269,7 +269,7 @@ spec:
               echo "PAYLOAD_PROCESSING_E2E_IMAGE=${PAYLOAD_PROCESSING_E2E_IMAGE}"
               echo "PAYLOAD_PROCESSING_E2E_IMAGE (tag): ${PAYLOAD_PROCESSING_E2E_IMAGE%%@*}:${PAYLOAD_PROCESSING_E2E_TAG}"
 
-              ./test/e2e/script/e2e-ci.sh
+              ./test/e2e/scripts/e2e-ci.sh
 
               echo "success" > "$STATUS_FILE"
           - name: must-gather


### PR DESCRIPTION
## Summary

Fixes a typo in the ai-gateway-payload-processing group test pipeline introduced in #333.

## Description

The e2e step was calling `./test/e2e/script/e2e-ci.sh` (singular `script`) but the actual directory in the [ai-gateway-payload-processing](https://github.com/opendatahub-io/ai-gateway-payload-processing) repo is `test/e2e/scripts/` (plural). This would cause the pipeline to fail at the e2e step with a "file not found" error.

## How it was tested

- Verified the correct path against the repo structure at `opendatahub-io/ai-gateway-payload-processing/tree/main/test/e2e/scripts/`.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal testing infrastructure path reference to improve CI/CD pipeline reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->