### PR TITLE
fix(ai-gateway): correct quay repo paths in group-components snapshot param

### DIFF
--- a/pipelineruns/ai-gateway-payload-processing/ai-gateway-group-test.yaml
+++ b/pipelineruns/ai-gateway-payload-processing/ai-gateway-group-test.yaml
@@ -19,7 +19,7 @@ metadata:
 spec:
   params:
   - name: group-components
-    value: '{ "odh-ai-gateway-payload-processing-ci": "opendatahub/ai-gateway-payload-processing", "ai-gateway-payload-processing-e2e-ci": "opendatahub/ai-gateway-payload-processing" }'
+    value: '{ "odh-ai-gateway-payload-processing-ci": "opendatahub/odh-ai-gateway-payload-processing", "ai-gateway-payload-processing-e2e-ci": "opendatahub/ai-gateway-payload-processing-e2e" }'
   pipelineRef:
     resolver: git
     params:


### PR DESCRIPTION
## Summary

Fixes the `group-components` param in the ai-gateway-payload-processing group test PipelineRun that caused `audit-snapshot` to fail immediately after merging #333.

## Description

Both components were incorrectly mapped to the same Quay repo path (`opendatahub/ai-gateway-payload-processing`). The `generate-snapshot` task queries Quay by this path to find the PR-built image and its git metadata (commit SHA, git URL). Since both entries resolved to the same wrong repo, neither image had a digest or git metadata, producing:

```
Warning: No digest found for odh-ai-gateway-payload-processing-ci with tag odh-stable
ERROR: snapshot metadata missing for odh-ai-gateway-payload-processing-ci
```

The correct paths match the `output-image` values defined in each component's build PipelineRun:

| Component | Correct Quay path |
|---|---|
| `odh-ai-gateway-payload-processing-ci` | `opendatahub/odh-ai-gateway-payload-processing` |
| `ai-gateway-payload-processing-e2e-ci` | `opendatahub/ai-gateway-payload-processing-e2e` |

## How it was tested

- Verified against the `output-image` values in `pipelineruns/ai-gateway-payload-processing/odh-ai-gateway-payload-processing-ci-on-pull-request.yaml` and `ai-gateway-payload-processing-e2e-ci-on-pull-request.yaml`.
- Same fix must be applied to `.tekton/ai-gateway-group-test.yaml` in the `ai-gateway-payload-processing` repo.

Made with [Cursor](https://cursor.com)