### PR TITLE
Update slack notifier and replace rhoai-task-toolset with devops-images

### DIFF
--- a/integration-tests/CI/trigger-nightly.yaml
+++ b/integration-tests/CI/trigger-nightly.yaml
@@ -44,7 +44,7 @@ spec:
           - name: previous-nightly-sha
             description: "the previous nightly"
           steps:
-          - image: quay.io/rhoai/rhoai-task-toolset:odh-nightly-runner
+          - image: quay.io/rhoai-devops/base-runner:latest
             name: get-latest-catalog-ci-build-sha
             env:
             - name: HOME
@@ -94,7 +94,7 @@ spec:
                 echo "Error: catalog not found"
                 exit 1
               fi
-          - image: quay.io/rhoai/rhoai-task-toolset:odh-nightly-runner
+          - image: quay.io/rhoai-devops/base-runner:latest
             name: tag-nightly-images
             workingDir: /workspace
             env:
@@ -188,7 +188,7 @@ spec:
           - name: data
             optional: false
           steps:
-          - image: quay.io/rhoai/rhoai-task-toolset:odh-nightly-runner
+          - image: quay.io/rhoai-devops/slack-notifier:latest
             env:
             - name: HOME
               value: /workspace
@@ -221,21 +221,10 @@ spec:
             script: |
               #!/bin/bash
               set -eo pipefail
-              mkdir slack && cd slack
-              git init .
-              git remote add origin git@github.com:red-hat-data-services/rhods-devops-infra.git
-              BRANCH=main
-              git fetch origin $BRANCH
-              git show origin/${BRANCH}:tools/send-slack-message/send-slack-message.sh > ./send-slack-message.sh
-              git show origin/${BRANCH}:tools/send-slack-message/tracer-diff.sh > ./tracer-diff.sh
-              git show origin/${BRANCH}:tools/tracer/tracer.sh > ./tracer.sh
-              chmod +x ./send-slack-message.sh
-              chmod +x ./tracer-diff.sh
-              chmod +x ./tracer.sh
 
-              ./tracer.sh --odh -i "$LATEST_CATALOG_CI_IMAGE" --show-commits | tee tracer-output.txt
+              tracer.sh --odh -i "$LATEST_CATALOG_CI_IMAGE" --show-commits | tee tracer-output.txt
 
-              TRACER=./tracer.sh ./tracer-diff.sh --mode 2 --only-changes \
+              tracer-diff.sh --mode 2 --only-changes \
                 --old-label "previous nightly catalog" --new-label "this catalog" \
                 "--odh --digest $PREVIOUS_NIGHTLY_SHA" "--odh -i $LATEST_CATALOG_CI_IMAGE" \
                   | tee tracer-diff.txt
@@ -244,7 +233,7 @@ spec:
               slack_message=$(echo "$MESSAGE_TEMPLATE" | envsubst "$SUBST_VARS")
 
               SLACK_RC=0
-              OUTPUT=$(./send-slack-message.sh -c "$CHANNEL" -m "$slack_message" -m "$(cat tracer-diff.txt)" -f tracer-output.txt -v 2>&1) || SLACK_RC=$?
+              OUTPUT=$(send-slack-message.sh -c "$CHANNEL" -m "$slack_message" -m "$(cat tracer-diff.txt)" -f tracer-output.txt -v 2>&1) || SLACK_RC=$?
 
               THREAD_TS=$(printf '%s\n' "$OUTPUT" | grep -oP 'Setting new thread id:\s*\K[0-9]+\.[0-9]+' | head -1 || true)
 
@@ -281,7 +270,7 @@ spec:
           - name: data
             optional: false
           steps:
-          - image: quay.io/rhoai/rhoai-task-toolset:odh-nightly-runner
+          - image: quay.io/rhoai-devops/base-runner:latest
             env:
             - name: HOME
               value: /workspace

--- a/integration-tests/CI/trigger-nightly.yaml
+++ b/integration-tests/CI/trigger-nightly.yaml
@@ -30,6 +30,10 @@ spec:
         name: TRIGGER_NIGHTLY_TAG
         type: string
         default: "true"
+      - description: Override the Slack channel from the configmap
+        name: OVERRIDE_CHANNEL
+        type: string
+        default: ""
     tasks:
       - name: choose-ci-build
         description: selects the latest ci build to promote to nightly
@@ -212,6 +216,8 @@ spec:
                 configMapKeyRef:
                   name: slack-config
                   key: odh-notification-channel
+            - name: OVERRIDE_CHANNEL
+              value: $(params.OVERRIDE_CHANNEL)
             - name: MESSAGE_TEMPLATE
               valueFrom:
                 configMapKeyRef:
@@ -221,6 +227,10 @@ spec:
             script: |
               #!/bin/bash
               set -eo pipefail
+
+              if [ -n "$OVERRIDE_CHANNEL" ]; then
+                CHANNEL="$OVERRIDE_CHANNEL"
+              fi
 
               tracer.sh --odh -i "$LATEST_CATALOG_CI_IMAGE" --show-commits | tee tracer-output.txt
 
@@ -286,9 +296,15 @@ spec:
                 configMapKeyRef:
                   name: slack-config
                   key: odh-notification-channel
+            - name: OVERRIDE_CHANNEL
+              value: $(params.OVERRIDE_CHANNEL)
             script: |
               #!/bin/bash
               set -e
+
+              if [ -n "$OVERRIDE_CHANNEL" ]; then
+                CHANNEL="$OVERRIDE_CHANNEL"
+              fi
 
               TARGET=odh-stable
 

--- a/pipeline/multi-arch-catalog-build.yaml
+++ b/pipeline/multi-arch-catalog-build.yaml
@@ -525,8 +525,23 @@ spec:
 
           tracer.sh --odh -i "$IMAGE_REF" --show-commits | tee tracer-output.txt
 
+          IMAGE_REPO="${IMAGE_REF%%:*}"
+          NIGHTLY_IMAGE="${IMAGE_REPO}:odh-stable-nightly"
+          NIGHTLY_SHA=$(skopeo inspect --raw "docker://$NIGHTLY_IMAGE" 2>/dev/null | sha256sum | awk '{print "sha256:" $1}' || true)
+
+          DIFF_ARGS=()
+          if [ -n "$NIGHTLY_SHA" ]; then
+            tracer-diff.sh --mode 2 --only-changes \
+              --old-label "latest nightly" --new-label "this ci build" \
+              "--odh --digest $NIGHTLY_SHA" "--odh -i $IMAGE_REF" \
+                | tee tracer-diff.txt
+            DIFF_ARGS=(-m "$(cat tracer-diff.txt)")
+          else
+            echo "No previous nightly found, skipping diff"
+          fi
+
           SLACK_RC=0
-          OUTPUT=$(send-slack-message.sh -c "$CHANNEL" -m "$slack_message" -f tracer-output.txt -v 2>&1) || SLACK_RC=$?
+          OUTPUT=$(send-slack-message.sh -c "$CHANNEL" -m "$slack_message" "${DIFF_ARGS[@]}" -f tracer-output.txt -v 2>&1) || SLACK_RC=$?
 
           THREAD_TS=$(printf '%s\n' "$OUTPUT" | grep -oP 'Setting new thread id:\s*\K[0-9]+\.[0-9]+' | head -1 || true)
 

--- a/pipeline/multi-arch-catalog-build.yaml
+++ b/pipeline/multi-arch-catalog-build.yaml
@@ -430,59 +430,6 @@ spec:
       operator: notin
       values:
       - "true"
-  - name: prepare-slack-message
-    params:
-    taskSpec:
-      results:
-      - description: Notification text to be posted to slack
-        name: slack-message-success-text
-      steps:
-      - image: quay.io/rhoai-devops/base-runner:latest
-        name: prepare-slack-message
-        env:
-        - name: pipelinerun_name
-          value: "$(context.pipelineRun.name)"
-        - name: IMAGE_REF
-          value: $(tasks.build-image-index.results.IMAGE_REF)
-        - name: MESSAGE_TEMPLATE
-          valueFrom:
-            configMapKeyRef:
-              name: slack-config
-              key: catalog-ci-message-template
-        - name: target_branch
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.annotations['build.appstudio.redhat.com/target_branch']
-        - name: BUILD_URL
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.annotations['pipelinesascode.tekton.dev/log-url']
-        - name: COMMIT_URL
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.annotations['pipelinesascode.tekton.dev/sha-url']
-        - name: COMMIT
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.annotations['pipelinesascode.tekton.dev/sha']
-        script: |
-          echo "pipelinerun-name = $pipelinerun_name"
-
-          application_name=${target_branch/rhoai-/}
-          application_name=rhoai-v${application_name/./-}
-          echo "application-name = $application_name"
-          echo "image url = $image_url"
-          echo "image digest = $image_digest"
-
-          component_name=${pipelinerun_name/-on-*/}
-          echo "component-name = $component_name"
-
-          export build_time="$(date +%Y-%m-%dT%H:%M:%S)"
-          export COMMIT_SHORT=$(echo "$COMMIT" | head -c 7)
-          SUBST_VARS='$build_time $IMAGE_REF $COMMIT_URL $COMMIT_SHORT $BUILD_URL $pipelinerun_name'
-          echo "$MESSAGE_TEMPLATE" | envsubst "$SUBST_VARS" | tee "$(results.slack-message-success-text.path)"
-    runAfter:
-    - build-image-index
   - name: pipeline-success-indicator
     runAfter:
     - deprecated-base-image-check
@@ -529,9 +476,6 @@ spec:
       values:
         - "push"
   - name: share-fbc-details
-    workspaces:
-    - name: basic-auth
-      workspace: git-auth
     taskSpec:
       steps:
       - image: quay.io/rhoai-devops/slack-notifier:latest
@@ -543,8 +487,6 @@ spec:
             secretKeyRef:
               name: rhoai-devops-bot-slack-token
               key: SLACK_TOKEN
-        - name: MESSAGE
-          value: $(tasks.prepare-slack-message.results.slack-message-success-text)
         - name: IMAGE_REF
           value: $(tasks.build-image-index.results.IMAGE_REF)
         - name: CHANNEL
@@ -552,13 +494,48 @@ spec:
             configMapKeyRef:
               name: slack-config
               key: odh-notification-channel
+        - name: MESSAGE_TEMPLATE
+          valueFrom:
+            configMapKeyRef:
+              name: slack-config
+              key: catalog-ci-message-template
+        - name: pipelinerun_name
+          value: "$(context.pipelineRun.name)"
+        - name: BUILD_URL
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.annotations['pipelinesascode.tekton.dev/log-url']
+        - name: COMMIT_URL
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.annotations['pipelinesascode.tekton.dev/sha-url']
+        - name: COMMIT
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.annotations['pipelinesascode.tekton.dev/sha']
         workingDir: /workspace
         script: |
           #!/bin/bash
-          set -e
+          set -eo pipefail
+
+          export build_time="$(date +%Y-%m-%dT%H:%M:%S)"
+          export COMMIT_SHORT=$(echo "$COMMIT" | head -c 7)
+          SUBST_VARS='$build_time $IMAGE_REF $COMMIT_URL $COMMIT_SHORT $BUILD_URL $pipelinerun_name'
+          slack_message=$(echo "$MESSAGE_TEMPLATE" | envsubst "$SUBST_VARS")
 
           tracer.sh --odh -i "$IMAGE_REF" --show-commits | tee tracer-output.txt
-          send-slack-message.sh -c "$CHANNEL" -m "$MESSAGE" -f tracer-output.txt -v
+
+          SLACK_RC=0
+          OUTPUT=$(send-slack-message.sh -c "$CHANNEL" -m "$slack_message" -f tracer-output.txt -v 2>&1) || SLACK_RC=$?
+
+          THREAD_TS=$(printf '%s\n' "$OUTPUT" | grep -oP 'Setting new thread id:\s*\K[0-9]+\.[0-9]+' | head -1 || true)
+
+          if [ "$SLACK_RC" -ne 0 ]; then
+            echo "WARNING: send-slack-message.sh exited with $SLACK_RC (non-blocking)"
+            printf '%s\n' "$OUTPUT" | grep -viE 'token|bearer|authorization' || true
+          else
+            echo "Slack message sent (rc=0, thread_ts=${THREAD_TS:-<not captured>})"
+          fi
     when:
     - input: $(tasks.status)
       operator: in

--- a/pipeline/multi-arch-catalog-build.yaml
+++ b/pipeline/multi-arch-catalog-build.yaml
@@ -437,7 +437,7 @@ spec:
       - description: Notification text to be posted to slack
         name: slack-message-success-text
       steps:
-      - image: quay.io/rhoai/rhoai-task-toolset:odh-nightly-runner
+      - image: quay.io/rhoai-devops/base-runner:latest
         name: prepare-slack-message
         env:
         - name: pipelinerun_name
@@ -534,7 +534,7 @@ spec:
       workspace: git-auth
     taskSpec:
       steps:
-      - image: quay.io/rhoai/rhoai-task-toolset:odh-nightly-runner
+      - image: quay.io/rhoai-devops/slack-notifier:latest
         env:
         - name: HOME
           value: /workspace
@@ -556,18 +556,9 @@ spec:
         script: |
           #!/bin/bash
           set -e
-          export GIT_SSH_COMMAND="ssh -F $HOME/.ssh/config -o UserKnownHostsFile=$HOME/.ssh/known_hosts"
-          mkdir slack && cd slack
-          git init .
-          git remote add origin git@github.com:red-hat-data-services/rhods-devops-infra.git
-          git fetch origin main
-          git show origin/main:tools/send-slack-message/send-slack-message.sh > ./send-slack-message.sh
-          git show origin/main:tools/tracer/tracer.sh > ./tracer.sh
-          chmod +x ./send-slack-message.sh
-          chmod +x ./tracer.sh
 
-          ./tracer.sh --odh -i "$IMAGE_REF" --show-commits | tee tracer-output.txt
-          ./send-slack-message.sh -c "$CHANNEL" -m "$MESSAGE" -f tracer-output.txt -v
+          tracer.sh --odh -i "$IMAGE_REF" --show-commits | tee tracer-output.txt
+          send-slack-message.sh -c "$CHANNEL" -m "$MESSAGE" -f tracer-output.txt -v
     when:
     - input: $(tasks.status)
       operator: in


### PR DESCRIPTION
## Summary
- Replace `quay.io/rhoai/rhoai-task-toolset:odh-nightly-runner` with purpose-built images from [`red-hat-data-services/devops-images`](https://github.com/red-hat-data-services/devops-images):
  - [`slack-notifier`](https://github.com/red-hat-data-services/devops-images/tree/main/builds/slack-notifier) for steps using tracer/send-slack-message (bundles the scripts, removing git-clone-at-runtime pattern)
  - [`base-runner`](https://github.com/red-hat-data-services/devops-images/tree/main/builds/base) for steps that only need skopeo/jq/yq/envsubst
- Add `OVERRIDE_CHANNEL` param to trigger-nightly to allow overriding the Slack channel from the configmap
- Consolidate `prepare-slack-message` and `share-fbc-details` into a single step in multi-arch-catalog-build, matching the trigger-nightly pattern:
  - Build message from template inline
  - Add error handling around `send-slack-message.sh` with `thread_ts` capture
  - Add tracer-diff comparing this CI build against the latest nightly

## Test plan
- [x] Trigger a nightly run and verify `slack-notification` sends messages using bundled scripts
- [x] Verify `choose-ci-build`, `tag-nightly`, and `trigger-nightly-tests` work with `base-runner`
- [x] Test `OVERRIDE_CHANNEL` param overrides the configmap channel
- [x] Trigger a catalog build and verify `share-fbc-details` builds the message, runs tracer-diff against nightly, and sends to Slack

🤖 Generated with [Claude Code](https://claude.com/claude-code)