### PR TITLE
Fix trainer push template to use placeholders for release builds

### DIFF
--- a/pipelineruns/trainer/trainer-push.yaml
+++ b/pipelineruns/trainer/trainer-push.yaml
@@ -8,7 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "stable"
+      == "$$TARGET_BRANCH$$"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: opendatahub-builds
@@ -23,7 +23,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/opendatahub/trainer:odh-stable
+    value: quay.io/opendatahub/trainer:$$OUTPUT_IMAGE_TAG$$
   - name: dockerfile
     value: cmd/trainer-controller-manager/Dockerfile.odh
   - name: path-context


### PR DESCRIPTION
## Summary

- Replace hardcoded `stable` and `odh-stable` values in `pipelineruns/trainer/trainer-push.yaml` with `$$TARGET_BRANCH$$` and `$$OUTPUT_IMAGE_TAG$$` placeholders
- This aligns the trainer template with the [standard template format](https://github.com/opendatahub-io/odh-konflux-central/blob/main/pipelineruns/template/odh-component-push.yaml) and allows the onboarder workflow's `sed` substitution to work correctly for Release builds

## Problem

When running the `odh-konflux-onboarder` workflow with `build_type=Release`, the generated Tekton pipeline files retain hardcoded `stable`/`odh-stable` values instead of being substituted with the release version and branch. This results in:
- `target_branch == "stable"` instead of `target_branch == "release/<version>"`
- `output-image: quay.io/opendatahub/trainer:odh-stable` instead of `quay.io/opendatahub/trainer:<version>`

See: https://github.com/opendatahub-io/trainer/pull/165

## CI builds are unaffected

For CI builds, the workflow sets `EFFECTIVE_TAG=odh-stable` and `TARGET_BRANCH=stable`, so the substitution produces the same values as the previously hardcoded ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced pipeline configuration to support dynamic branch targeting and flexible container image tagging, increasing configuration reusability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->