### PR TITLE
docs(olminstall): fix Mermaid diagram rendering on GitHub

### DIFF
--- a/integration-tests/olminstall/README.md
+++ b/integration-tests/olminstall/README.md
@@ -16,13 +16,13 @@ flowchart TD
     classDef pass    fill:#22C55E,stroke:#15803D,color:#fff,font-weight:bold
     classDef fail    fill:#EF4444,stroke:#B91C1C,color:#fff,font-weight:bold
 
-    BUILD[🏗️ Snapshot ready -> ITS creates PipelineRun]:::trigger
-    CLUSTER[☁️ Ephemeral HyperShift cluster (latest supported OCP version) + IDMS mirror]:::infra
-    AUTH[🔐 Three-level credential setup]:::auth
-    HCCO[🤖 HCCO syncs kubelet creds to all nodes]:::hcco
-    OLM[📦 OLM: CatalogSource + Subscription + bundle-unpack + CSV]:::olm
-    PASS[✅ CSV Succeeded - operator version recorded]:::pass
-    FAIL[❌ Failed - oc adm inspect + diagnostics collected]:::fail
+    BUILD["🏗️ Snapshot ready → ITS creates PipelineRun"]:::trigger
+    CLUSTER["☁️ Ephemeral HyperShift cluster (latest supported OCP version) + IDMS mirror"]:::infra
+    AUTH["🔐 Three-level credential setup"]:::auth
+    HCCO["🤖 HCCO syncs kubelet creds to all nodes"]:::hcco
+    OLM["📦 OLM: CatalogSource + Subscription + bundle-unpack + CSV"]:::olm
+    PASS["✅ CSV Succeeded - operator version recorded"]:::pass
+    FAIL["❌ Failed - oc adm inspect + diagnostics collected"]:::fail
 
     BUILD -->|~20 min to provision| CLUSTER
     CLUSTER --> AUTH


### PR DESCRIPTION
## Summary

GitHub fails to render the Pipeline flow Mermaid diagram in integration-tests/olminstall/README.md (parse error around CLUSTER).

## Cause

- Unquoted labels with parentheses confuse GitHub's parser.
- BUILD label used ASCII -> which can parse as edge syntax.

## Fix

- Quote all node labels.
- Use Unicode arrow in BUILD label.

No pipeline changes.

## Output

<img width="730" height="759" alt="image" src="https://github.com/user-attachments/assets/c99929b6-3b89-41bd-aa21-565a067789e2" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated diagram formatting in the installation documentation to improve clarity and visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->