### PR TITLE
fix(ai-gateway): enable automatic group testing on pull requests

### DIFF
--- a/pipelineruns/ai-gateway-payload-processing/ai-gateway-payload-processing-e2e-ci-on-pull-request.yaml
+++ b/pipelineruns/ai-gateway-payload-processing/ai-gateway-payload-processing-e2e-ci-on-pull-request.yaml
@@ -33,6 +33,8 @@ spec:
     value: .
   - name: pipeline-type
     value: pull-request
+  - name: enable-group-testing
+    value: "true"
   - name: additional-tags
     value:
     - 'odh-pr-{{revision}}'

--- a/pipelineruns/ai-gateway-payload-processing/odh-ai-gateway-payload-processing-ci-on-pull-request.yaml
+++ b/pipelineruns/ai-gateway-payload-processing/odh-ai-gateway-payload-processing-ci-on-pull-request.yaml
@@ -33,6 +33,8 @@ spec:
     value: .
   - name: pipeline-type
     value: pull-request
+  - name: enable-group-testing
+    value: "true"
   - name: additional-tags
     value:
     - 'odh-pr-{{revision}}'


### PR DESCRIPTION
## Summary
Enable automatic group e2e test triggering for `ai-gateway-payload-processing` PR builds by adding the missing `enable-group-testing: "true"` parameter.

## Description
The group testing PipelineRun (`ai-gateway-group-test.yaml`) and the integration test pipeline were already in place, but the two PR build PipelineRuns were missing the opt-in parameter that activates the `trigger-group-testing` task in the shared `multi-arch-container-build` pipeline.

Key changes:
- Add `enable-group-testing: "true"` to `odh-ai-gateway-payload-processing-ci-on-pull-request.yaml`
- Add `enable-group-testing: "true"` to `ai-gateway-payload-processing-e2e-ci-on-pull-request.yaml`

Without this parameter, the `trigger-group-testing` task is skipped (its `when` condition requires `enable-group-testing == "true"`), meaning no `/group-test` comment is ever posted automatically — leaving contributors to trigger e2e tests manually. This matches the same pattern already used by MaaS and Kserve.

## How it was tested
- Reviewed the `trigger-group-testing` task `when` conditions in `pipeline/multi-arch-container-build.yaml` to confirm the parameter is the sole gate.
- Cross-referenced with working configurations in `pipelineruns/models-as-a-service/` and `pipelineruns/kserve/` where `enable-group-testing: "true"` is set on all PR builds.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled group testing for pull request CI pipelines to enhance testing coverage during continuous integration processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->