### PR TITLE
Add odh-ogx-k8s-operator-ci PipelineRuns for odh-ogx-k8s-operator

### DIFF
--- a/.github/workflows/odh-konflux-onboarder.yml
+++ b/.github/workflows/odh-konflux-onboarder.yml
@@ -54,6 +54,7 @@ on:
           - odh-kserve-llmisvc-controller
           - odh-model-controller
           - odh-model-metadata-collection
+          - ogx-k8s-operator
           - opendatahub-operator
           - openvino_model_server
           - pipelines-components

--- a/pipelineruns/ogx-k8s-operator/odh-ogx-k8s-operator-pull-request.yaml
+++ b/pipelineruns/ogx-k8s-operator/odh-ogx-k8s-operator-pull-request.yaml
@@ -1,0 +1,52 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/ogx-k8s-operator?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
+      == "odh"
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: opendatahub-builds
+    appstudio.openshift.io/component: odh-ogx-k8s-operator-ci
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-ogx-k8s-operator-on-pull-request
+  namespace: open-data-hub-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/opendatahub/odh-ogx-k8s-operator:odh-pr
+  - name: dockerfile
+    value: Dockerfile
+  - name: path-context
+    value: .
+  # additional params
+  - name: additional-tags
+    value:
+    - 'odh-pr-{{revision}}'
+  - name: pipeline-type
+    value: pull-request
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/opendatahub-io/odh-konflux-central.git
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipeline/multi-arch-container-build.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-odh-ogx-k8s-operator-ci
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/pipelineruns/ogx-k8s-operator/odh-ogx-k8s-operator-push.yaml
+++ b/pipelineruns/ogx-k8s-operator/odh-ogx-k8s-operator-push.yaml
@@ -1,0 +1,47 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+#
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/ogx-k8s-operator?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "odh"
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: opendatahub-builds
+    appstudio.openshift.io/component: odh-ogx-k8s-operator-ci
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-ogx-k8s-operator-on-push
+  namespace: open-data-hub-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/opendatahub/odh-ogx-k8s-operator:odh-stable
+  - name: dockerfile
+    value: Dockerfile
+  - name: path-context
+    value: .
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/opendatahub-io/odh-konflux-central.git
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipeline/multi-arch-container-build.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-odh-ogx-k8s-operator-ci
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}


### PR DESCRIPTION
Add Konflux CI PipelineRuns for 'odh-ogx-k8s-operator' from repo 'ogx-k8s-operator'.

Product: ODH
Application: opendatahub-builds
Output image: quay.io/opendatahub/odh-ogx-k8s-operator:odh-stable
Source repo: https://github.com/opendatahub-io/ogx-k8s-operator @ odh
Jira: https://redhat.atlassian.net/browse/RHOAIENG-61465

**Files changed:**
- `pipelineruns/ogx-k8s-operator/odh-ogx-k8s-operator-push.yaml` (new)
- `pipelineruns/ogx-k8s-operator/odh-ogx-k8s-operator-pull-request.yaml` (new)
- `.github/workflows/odh-konflux-onboarder.yml` (updated: added ogx-k8s-operator to components list)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added continuous integration pipelines for the `ogx-k8s-operator` component to automate builds and testing on pull requests and code pushes
  * Updated configuration to register `ogx-k8s-operator` in deployment workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->