### PR TITLE
Add odh-ogx-core-ci PipelineRuns for odh-ogx-core

### DIFF
--- a/.github/workflows/odh-konflux-onboarder.yml
+++ b/.github/workflows/odh-konflux-onboarder.yml
@@ -54,6 +54,7 @@ on:
           - odh-kserve-llmisvc-controller
           - odh-model-controller
           - odh-model-metadata-collection
+          - ogx-distribution
           - ogx-k8s-operator
           - opendatahub-operator
           - openvino_model_server
@@ -68,7 +69,6 @@ on:
           - vllm-orchestrator-gateway
           - workload-variant-autoscaler
           - rhaii-cluster-validation
-
       pr_target_branch:
         description: 'Target branch for the PR (e.g. main)'
         required: true

--- a/pipelineruns/ogx-distribution/odh-ogx-core-pull-request.yaml
+++ b/pipelineruns/ogx-distribution/odh-ogx-core-pull-request.yaml
@@ -1,0 +1,52 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/ogx-distribution?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
+      == "main"
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: opendatahub-builds
+    appstudio.openshift.io/component: odh-ogx-core-ci
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-ogx-core-on-pull-request
+  namespace: open-data-hub-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/opendatahub/odh-ogx-core:odh-pr
+  - name: dockerfile
+    value: distribution/Containerfile
+  - name: path-context
+    value: .
+  # additional params
+  - name: additional-tags
+    value:
+    - 'odh-pr-{{revision}}'
+  - name: pipeline-type
+    value: pull-request
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/opendatahub-io/odh-konflux-central.git
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipeline/multi-arch-container-build.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-odh-ogx-core-ci
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/pipelineruns/ogx-distribution/odh-ogx-core-push.yaml
+++ b/pipelineruns/ogx-distribution/odh-ogx-core-push.yaml
@@ -1,0 +1,47 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+#
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/ogx-distribution?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "main"
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: opendatahub-builds
+    appstudio.openshift.io/component: odh-ogx-core-ci
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-ogx-core-on-push
+  namespace: open-data-hub-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/opendatahub/odh-ogx-core:odh-stable
+  - name: dockerfile
+    value: distribution/Containerfile
+  - name: path-context
+    value: .
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/opendatahub-io/odh-konflux-central.git
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipeline/multi-arch-container-build.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-odh-ogx-core-ci
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}


### PR DESCRIPTION
Add Konflux CI PipelineRuns for 'odh-ogx-core' from repo 'ogx-distribution'.

Product: ODH
Application: opendatahub-builds
Output image: quay.io/opendatahub/odh-ogx-core:odh-stable
Source repo: https://github.com/opendatahub-io/ogx-distribution @ main
Jira: https://redhat.atlassian.net/browse/RHOAIENG-61528

**Files changed:**
- `pipelineruns/ogx-distribution/odh-ogx-core-push.yaml` (new)
- `pipelineruns/ogx-distribution/odh-ogx-core-pull-request.yaml` (new)
- `.github/workflows/odh-konflux-onboarder.yml` (updated: added ogx-distribution to components list)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended CI/CD workflow configuration to include the ogx-distribution component in automated build pipeline selection.
  * Added automated pipeline configurations for continuous integration: pull request builds for testing and main branch builds for stable releases, both supporting multi-architecture container image builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->