### PR TITLE
Fix ODH Konflux onboarder duplicate .tekton files, dockerfile, and extend bundle image retention to 30 days

### DIFF
--- a/.github/workflows/odh-konflux-onboarder.yml
+++ b/.github/workflows/odh-konflux-onboarder.yml
@@ -259,6 +259,7 @@ jobs:
               sed -i -E 's|\$\$OUTPUT_IMAGE_TAG\$\$|'"${VERSION}"'|g' "$target_file"
               sed -i -E 's|\$\$TARGET_BRANCH\$\$|'"${TARGET_BRANCH}"'|g' "$target_file"
               sed -i -E 's|\$\$BUILD_TYPE\$\$|'"${{ inputs.build_type }}"'|g' "$target_file"
+              sed -i -E 's|Dockerfiles/rhoai\.Dockerfile|Dockerfiles/Dockerfile|g' "$target_file"
 
             done
           fi

--- a/.github/workflows/odh-konflux-onboarder.yml
+++ b/.github/workflows/odh-konflux-onboarder.yml
@@ -242,7 +242,7 @@ jobs:
 
             echo "Release build → ensuring release-push file exists"
 
-            find "$repo_folder" -type f -name "*-push.yaml" | while read src_file; do
+            find "$repo_folder" -type f -name "*-push.yaml" ! -name "*release*" | while read src_file; do
 
               base_name=$(basename "$src_file")
               release_name="${base_name%-push.yaml}-release-push.yaml"

--- a/pipelineruns/opendatahub-operator/release/odh-operator-bundle-release-push.yaml
+++ b/pipelineruns/opendatahub-operator/release/odh-operator-bundle-release-push.yaml
@@ -3,8 +3,8 @@ kind: PipelineRun
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/opendatahub-operator?rev={{revision}}
-    build.appstudio.redhat.com/commit_sha: '{{revision}}'
-    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    build.appstudio.redhat.com/commit_sha: "{{revision}}"
+    build.appstudio.redhat.com/target_branch: "{{target_branch}}"
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     # Trigger on bundle file changes, Dockerfile changes, or manual test comments
@@ -22,72 +22,72 @@ metadata:
   namespace: open-data-hub-tenant
 spec:
   params:
-  - name: git-url
-    value: '{{source_url}}'
-  - name: revision
-    value: '{{revision}}'
-  - name: output-image
-    value: quay.io/opendatahub/opendatahub-operator-bundle:$$OUTPUT_IMAGE_TAG$$
-  - name: dockerfile
-    value: Dockerfiles/bundle.Dockerfile
-  - name: path-context
-    value: .
-  - name: rebuild
-    value: "true"
-  - name: skip-checks
-    value: "false"
-  - name: hermetic
-    value: "false"
-  - name: prefetch-input
-    value: ""
-  - name: image-expires-after
-    value: "7d"
-  - name: build-source-image
-    value: "false"
-  - name: build-image-index
-    value: "false"
-  - name: buildah-format
-    value: "docker"
-  - name: enable-cache-proxy
-    value: "false"
-  - name: privileged-nested
-    value: "false"
-  - name: build-args-file
-    value: ""
-  - name: build-args
-    value:
-    - OPERATOR_VERSION=$$VERSION$$
-    - IMG_TAG=$$OUTPUT_IMAGE_TAG$$
-    - IMAGE_TAG_BASE=quay.io/opendatahub/opendatahub-operator
-    - BUNDLE_IMG=quay.io/opendatahub/opendatahub-operator-bundle:$$OUTPUT_IMAGE_TAG$$
-    - GOLANG_VERSION=1.25
-    - BUILD_TYPE=$$BUILD_TYPE$$
-  - name: additional-labels
-    value:
-    - version=$$VERSION$$
-    - release=$$TARGET_BRANCH$$
-    - git.url={{source_url}}
-    - git.commit={{revision}}
-    - git.branch={{target_branch}}
-  - name: enable-slack-failure-notification
-    value: "true"
-  - name: pipeline-type
-    value: "push"
-  - name: expected-cluster
-    value: ""
+    - name: git-url
+      value: "{{source_url}}"
+    - name: revision
+      value: "{{revision}}"
+    - name: output-image
+      value: quay.io/opendatahub/opendatahub-operator-bundle:$$OUTPUT_IMAGE_TAG$$
+    - name: dockerfile
+      value: Dockerfiles/bundle.Dockerfile
+    - name: path-context
+      value: .
+    - name: rebuild
+      value: "true"
+    - name: skip-checks
+      value: "false"
+    - name: hermetic
+      value: "false"
+    - name: prefetch-input
+      value: ""
+    - name: image-expires-after
+      value: "30d"
+    - name: build-source-image
+      value: "false"
+    - name: build-image-index
+      value: "false"
+    - name: buildah-format
+      value: "docker"
+    - name: enable-cache-proxy
+      value: "false"
+    - name: privileged-nested
+      value: "false"
+    - name: build-args-file
+      value: ""
+    - name: build-args
+      value:
+        - OPERATOR_VERSION=$$VERSION$$
+        - IMG_TAG=$$OUTPUT_IMAGE_TAG$$
+        - IMAGE_TAG_BASE=quay.io/opendatahub/opendatahub-operator
+        - BUNDLE_IMG=quay.io/opendatahub/opendatahub-operator-bundle:$$OUTPUT_IMAGE_TAG$$
+        - GOLANG_VERSION=1.25
+        - BUILD_TYPE=$$BUILD_TYPE$$
+    - name: additional-labels
+      value:
+        - version=$$VERSION$$
+        - release=$$TARGET_BRANCH$$
+        - git.url={{source_url}}
+        - git.commit={{revision}}
+        - git.branch={{target_branch}}
+    - name: enable-slack-failure-notification
+      value: "true"
+    - name: pipeline-type
+      value: "push"
+    - name: expected-cluster
+      value: ""
   pipelineRef:
     resolver: git
     params:
-    - name: url
-      value: https://github.com/opendatahub-io/odh-konflux-central.git
-    - name: revision
-      value: main
-    - name: pathInRepo
-      value: pipeline/bundle-build.yaml
+      - name: url
+        value: https://github.com/opendatahub-io/odh-konflux-central.git
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: pipeline/bundle-build.yaml
   taskRunTemplate:
     serviceAccountName: build-pipeline-odh-operator-bundle-ci
   workspaces:
-  - name: git-auth
-    secret:
-      secretName: '{{ git_auth_secret }}'
+    - name: git-auth
+      secret:
+        secretName: "{{ git_auth_secret }}"
 status: {}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
The ODH Konflux onboarder workflow had multiple issues when processing opendatahub-operator builds that required fixing.

### Problems:

Files like odh-operator-bundle-release-release-push.yaml (double "release") were being created

The same source files were being processed twice by different workflow sections

`$$VERSION$$` placeholders were not being substituted properly in some files

Dockerfile was not being updated from rhoai.Dockerfile to Dockerfile for release builds

Bundle images were expiring after 7 days, insufficient for upgrade testing which happens during next release

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Exclude already-release templates from release preparation to avoid duplicate inputs.
  * Normalize Dockerfile references in generated release templates so release pushes use the expected Dockerfile location.
  * Update pipeline run templates: harmonize parameter templating/quoting and extend image cache retention from 7 days to 30 days.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->