### PR TITLE
update pipelines to parameterize the branch

### DIFF
--- a/pipelineruns/odh-dashboard/mod-arch-maas-pull-request.yaml
+++ b/pipelineruns/odh-dashboard/mod-arch-maas-pull-request.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main"
+      == "$$TARGET_BRANCH$$"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: opendatahub-builds
@@ -24,7 +24,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/opendatahub/mod-arch-maas:odh-pr
+    value: quay.io/opendatahub/mod-arch-maas:$$OUTPUT_IMAGE_TAG$$
   - name: dockerfile
     value: packages/maas/Dockerfile.workspace
   - name: path-context

--- a/pipelineruns/odh-dashboard/mod-arch-maas-push.yaml
+++ b/pipelineruns/odh-dashboard/mod-arch-maas-push.yaml
@@ -8,7 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+      == "$$TARGET_BRANCH$$"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: opendatahub-builds
@@ -23,7 +23,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/opendatahub/mod-arch-maas:odh-stable
+    value: quay.io/opendatahub/mod-arch-maas:$$OUTPUT_IMAGE_TAG$$
   - name: dockerfile
     value: packages/maas/Dockerfile.workspace
   - name: path-context

--- a/pipelineruns/odh-dashboard/odh-dashboard-pull-request.yaml
+++ b/pipelineruns/odh-dashboard/odh-dashboard-pull-request.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main"
+      == "$$TARGET_BRANCH$$"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: opendatahub-builds
@@ -24,7 +24,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/opendatahub/odh-dashboard:odh-pr
+    value: quay.io/opendatahub/odh-dashboard:$$OUTPUT_IMAGE_TAG$$
   - name: dockerfile
     value: Dockerfile
   - name: path-context

--- a/pipelineruns/odh-dashboard/odh-dashboard-push.yaml
+++ b/pipelineruns/odh-dashboard/odh-dashboard-push.yaml
@@ -8,7 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+      == "$$TARGET_BRANCH$$"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: opendatahub-builds
@@ -23,7 +23,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/opendatahub/odh-dashboard:odh-stable  
+    value: quay.io/opendatahub/odh-dashboard:$$OUTPUT_IMAGE_TAG$$
   - name: dockerfile
     value: Dockerfile
   - name: path-context

--- a/pipelineruns/odh-dashboard/odh-mod-arch-automl-ci-pull-request.yaml
+++ b/pipelineruns/odh-dashboard/odh-mod-arch-automl-ci-pull-request.yaml
@@ -27,7 +27,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/opendatahub/odh-mod-arch-automl:odh-pr
+    value: quay.io/opendatahub/odh-mod-arch-automl:$$OUTPUT_IMAGE_TAG$$
   - name: dockerfile
     value: packages/automl/Dockerfile.workspace
   - name: path-context

--- a/pipelineruns/odh-dashboard/odh-mod-arch-autorag-ci-pull-request.yaml
+++ b/pipelineruns/odh-dashboard/odh-mod-arch-autorag-ci-pull-request.yaml
@@ -27,7 +27,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/opendatahub/odh-mod-arch-autorag:odh-pr
+    value: quay.io/opendatahub/odh-mod-arch-autorag:$$OUTPUT_IMAGE_TAG$$
   - name: dockerfile
     value: packages/autorag/Dockerfile.workspace
   - name: path-context

--- a/pipelineruns/odh-dashboard/odh-mod-arch-eval-hub-pull-request.yaml
+++ b/pipelineruns/odh-dashboard/odh-mod-arch-eval-hub-pull-request.yaml
@@ -26,7 +26,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/opendatahub/odh-mod-arch-eval-hub:odh-pr
+    value: quay.io/opendatahub/odh-mod-arch-eval-hub:$$OUTPUT_IMAGE_TAG$$
   - name: image-expires-after
     value: 5d
   - name: dockerfile

--- a/pipelineruns/odh-dashboard/odh-mod-arch-gen-ai-pull-request.yaml
+++ b/pipelineruns/odh-dashboard/odh-mod-arch-gen-ai-pull-request.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main" && ( "packages/gen-ai/**".pathChanged()
+      == "$$TARGET_BRANCH$$" && ( "packages/gen-ai/**".pathChanged()
       || ".tekton/odh-mod-arch-gen-ai-pull-request.yaml".pathChanged() || "Dockerfile.workspace".pathChanged()
       )
   creationTimestamp: null
@@ -26,7 +26,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/opendatahub/odh-mod-arch-gen-ai:odh-pr
+    value: quay.io/opendatahub/odh-mod-arch-gen-ai:$$OUTPUT_IMAGE_TAG$$
   - name: dockerfile
     value: packages/gen-ai/Dockerfile.workspace
   - name: path-context

--- a/pipelineruns/odh-dashboard/odh-mod-arch-gen-ai-push.yaml
+++ b/pipelineruns/odh-dashboard/odh-mod-arch-gen-ai-push.yaml
@@ -8,7 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main" && ( "packages/gen-ai/**".pathChanged()
+      == "$$TARGET_BRANCH$$" && ( "packages/gen-ai/**".pathChanged()
       || ".tekton/odh-mod-arch-gen-ai-push.yaml".pathChanged() || "Dockerfile.workspace".pathChanged()
       )
   creationTimestamp: null
@@ -25,7 +25,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/opendatahub/odh-mod-arch-gen-ai:odh-stable
+    value: quay.io/opendatahub/odh-mod-arch-gen-ai:$$OUTPUT_IMAGE_TAG$$
   - name: dockerfile
     value: packages/gen-ai/Dockerfile.workspace
   - name: path-context

--- a/pipelineruns/odh-dashboard/odh-mod-arch-mlflow-pull-request.yaml
+++ b/pipelineruns/odh-dashboard/odh-mod-arch-mlflow-pull-request.yaml
@@ -26,7 +26,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/opendatahub/odh-mod-arch-mlflow:odh-pr
+    value: quay.io/opendatahub/odh-mod-arch-mlflow:$$OUTPUT_IMAGE_TAG$$
   - name: image-expires-after
     value: 5d
   - name: dockerfile

--- a/pipelineruns/odh-dashboard/odh-mod-arch-modular-architecture-pull-request.yaml
+++ b/pipelineruns/odh-dashboard/odh-mod-arch-modular-architecture-pull-request.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main" && ( "./packages/model-registry/***".pathChanged()
+      == "$$TARGET_BRANCH$$" && ( "./packages/model-registry/***".pathChanged()
       || ".tekton/odh-mod-arch-modular-architecture-pull-request.yaml".pathChanged() || "Dockerfile".pathChanged()
       )
   creationTimestamp: null
@@ -26,7 +26,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/opendatahub/odh-mod-arch-modular-architecture:odh-pr
+    value: quay.io/opendatahub/odh-mod-arch-modular-architecture:$$OUTPUT_IMAGE_TAG$$
   - name: dockerfile
     value: packages/model-registry/Dockerfile.workspace
   - name: path-context

--- a/pipelineruns/odh-dashboard/odh-mod-arch-modular-architecture-push.yaml
+++ b/pipelineruns/odh-dashboard/odh-mod-arch-modular-architecture-push.yaml
@@ -8,7 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main" && ( "./packages/model-registry/***".pathChanged()
+      == "$$TARGET_BRANCH$$" && ( "./packages/model-registry/***".pathChanged()
       || ".tekton/odh-mod-arch-modular-architecture-push.yaml".pathChanged() || "Dockerfile".pathChanged()
       )
   creationTimestamp: null
@@ -25,7 +25,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/opendatahub/odh-mod-arch-modular-architecture:odh-stable
+    value: quay.io/opendatahub/odh-mod-arch-modular-architecture:$$OUTPUT_IMAGE_TAG$$
   - name: dockerfile
     value: packages/model-registry/Dockerfile.workspace
   - name: path-context


### PR DESCRIPTION
## Summary
- Replace hardcoded `"main"` with `$$TARGET_BRANCH$$` in CEL expressions for pipelines that were manually onboarded
- Replace hardcoded `odh-stable` / `odh-pr` image tags with `$$OUTPUT_IMAGE_TAG$$`

adjusted to follow standard parameters as seen in https://github.com/opendatahub-io/odh-konflux-central/blob/main/pipelineruns/NeMo-Guardrails/odh-trustyai-nemo-guardrails-server-push.yaml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pipeline configurations across dashboard and modular architecture components to use parameterized branch conditions instead of hardcoded values.
  * Modified container image reference parameters to use dynamic variables instead of static tags across pull-request and push pipeline workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->