### PR TITLE
Add odh-kserve-module-operator-ci PipelineRuns for odh-kserve-module-operator

### DIFF
--- a/pipelineruns/kserve/odh-kserve-module-operator-pull-request.yaml
+++ b/pipelineruns/kserve/odh-kserve-module-operator-pull-request.yaml
@@ -1,0 +1,52 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/kserve?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
+      == "master"
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: opendatahub-builds
+    appstudio.openshift.io/component: odh-kserve-module-operator-ci
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-kserve-module-operator-on-pull-request
+  namespace: open-data-hub-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/opendatahub/odh-kserve-module-operator:$$OUTPUT_IMAGE_TAG$$
+  - name: dockerfile
+    value: kserve-module-controller.Dockerfile
+  - name: path-context
+    value: .
+  # additional params
+  - name: additional-tags
+    value:
+    - 'odh-pr-{{revision}}'
+  - name: pipeline-type
+    value: pull-request
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/opendatahub-io/odh-konflux-central.git
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipeline/multi-arch-container-build.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-odh-kserve-module-operator-ci
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/pipelineruns/kserve/odh-kserve-module-operator-push.yaml
+++ b/pipelineruns/kserve/odh-kserve-module-operator-push.yaml
@@ -1,0 +1,47 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+#
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/kserve?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "master"
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: opendatahub-builds
+    appstudio.openshift.io/component: odh-kserve-module-operator-ci
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-kserve-module-operator-on-push
+  namespace: open-data-hub-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/opendatahub/odh-kserve-module-operator:$$OUTPUT_IMAGE_TAG$$
+  - name: dockerfile
+    value: kserve-module-controller.Dockerfile
+  - name: path-context
+    value: .
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/opendatahub-io/odh-konflux-central.git
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipeline/multi-arch-container-build.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-odh-kserve-module-operator-ci
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}


### PR DESCRIPTION
Add Konflux CI PipelineRuns for 'odh-kserve-module-operator' from repo 'kserve'.

Product: ODH
Application: opendatahub-builds
Output image: quay.io/opendatahub/odh-kserve-module-operator:odh-stable
Source repo: https://github.com/opendatahub-io/kserve @ master
Jira: https://redhat.atlassian.net/browse/RHOAIENG-62284

**Files changed:**
- `pipelineruns/kserve/odh-kserve-module-operator-push.yaml` (new)
- `pipelineruns/kserve/odh-kserve-module-operator-pull-request.yaml` (new)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added continuous integration pipeline configurations for the KServe module operator supporting automated multi-architecture container builds. Builds are triggered on pull request and push events to the main branch, with support for customizable source control parameters, build contexts, and Docker image tagging for deployment versioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->