### PR TITLE
Exclude autoscaling tests from kserve/omc LLMISvc E2E

### DIFF
--- a/integration-tests/kserve/pr-group-testing-pipeline.yaml
+++ b/integration-tests/kserve/pr-group-testing-pipeline.yaml
@@ -1560,7 +1560,7 @@ spec:
             COMPONENT_NAME=odh-kserve-llmisvc-controller-ci
             export LLMISVC_CONTROLLER_IMAGE=$(jq -r --arg component_name "${COMPONENT_NAME}" '.[$component_name].image' <<< "${SNAPSHOT}")
 
-            ./test/scripts/openshift-ci/run-e2e-tests.sh "llminferenceservice and cluster_cpu" 2 "llm-d"
+            ./test/scripts/openshift-ci/run-e2e-tests.sh "llminferenceservice and cluster_cpu and not autoscaling" 2 "llm-d"
             echo "success" > "$STATUS_FILE"
         - name: must-gather
           onError: continue

--- a/integration-tests/odh-model-controller/pr-test-pipelinerun.yaml
+++ b/integration-tests/odh-model-controller/pr-test-pipelinerun.yaml
@@ -535,7 +535,7 @@ spec:
                   echo "LLMD_ROUTING_SIDECAR_IMAGE=${LLMD_ROUTING_SIDECAR_IMAGE}"
                   echo "KUBE_RBAC_PROXY_IMAGE=${KUBE_RBAC_PROXY_IMAGE}"
 
-                  ./test/scripts/openshift-ci/run-e2e-tests.sh "llminferenceservice and (cluster_cpu and cluster_single_node)" 2 "llm-d"
+                  ./test/scripts/openshift-ci/run-e2e-tests.sh "llminferenceservice and (cluster_cpu and cluster_single_node) and not autoscaling" 2 "llm-d"
                 popd
             - name: must-gather
               onError: continue


### PR DESCRIPTION
## Summary
- Add `and not autoscaling` to the pytest marker expression in the kserve and odh-model-controller LLMISvc E2E steps
- WVA autoscaling tests require Prometheus, WVA controller, and HPA/KEDA infrastructure that is not available in these test clusters
- Aligns with the Prow CI config which already excludes autoscaling via `and not autoscaling`

This is a resubmission of #323, which was merged on 2026-04-29 but lost when `main` was force-pushed the following day.

## Test plan
- [ ] Verify kserve group-test pipeline no longer collects autoscaling tests
- [ ] Verify odh-model-controller pipeline no longer collects autoscaling tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refined KServe integration test pipeline to exclude autoscaling-related tests from the LLM inference service test suite when running on CPU cluster configurations.
  * Updated ODH model controller integration test pipeline to exclude autoscaling tests from test selection criteria for single-node CPU cluster scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->