### PR TITLE
Add odh-agents-operator-ci PipelineRuns for odh-agents-operator

### DIFF
--- a/.github/workflows/odh-konflux-onboarder.yml
+++ b/.github/workflows/odh-konflux-onboarder.yml
@@ -9,6 +9,7 @@ on:
         type: choice
         options:
           # Add all valid components here in alphabetical order
+          - agents-operator
           - ai-gateway-payload-processing
           - batch-gateway
           - caikit-nlp

--- a/pipelineruns/agents-operator/odh-agents-operator-pull-request.yaml
+++ b/pipelineruns/agents-operator/odh-agents-operator-pull-request.yaml
@@ -1,0 +1,52 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/agents-operator?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
+      == "main"
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: opendatahub-builds
+    appstudio.openshift.io/component: odh-agents-operator-ci
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-agents-operator-on-pull-request
+  namespace: open-data-hub-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/opendatahub/odh-agents-operator:odh-pr
+  - name: dockerfile
+    value: Dockerfile
+  - name: path-context
+    value: kagenti-operator/
+  # additional params
+  - name: additional-tags
+    value:
+    - 'odh-pr-{{revision}}'
+  - name: pipeline-type
+    value: pull-request
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/opendatahub-io/odh-konflux-central.git
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipeline/multi-arch-container-build.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-odh-agents-operator-ci
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/pipelineruns/agents-operator/odh-agents-operator-push.yaml
+++ b/pipelineruns/agents-operator/odh-agents-operator-push.yaml
@@ -1,0 +1,47 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+#
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/agents-operator?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "main"
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: opendatahub-builds
+    appstudio.openshift.io/component: odh-agents-operator-ci
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-agents-operator-on-push
+  namespace: open-data-hub-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/opendatahub/odh-agents-operator:odh-stable
+  - name: dockerfile
+    value: Dockerfile
+  - name: path-context
+    value: kagenti-operator/
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/opendatahub-io/odh-konflux-central.git
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipeline/multi-arch-container-build.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-odh-agents-operator-ci
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}


### PR DESCRIPTION
Add Konflux CI PipelineRuns for 'odh-agents-operator' from repo 'agents-operator'.

Product: ODH
Application: opendatahub-builds
Output image: quay.io/opendatahub/odh-agents-operator:odh-stable
Source repo: https://github.com/opendatahub-io/agents-operator @ main
Jira: https://redhat.atlassian.net/browse/RHOAIENG-63283

**Files changed:**
- `pipelineruns/agents-operator/odh-agents-operator-push.yaml` (new)
- `pipelineruns/agents-operator/odh-agents-operator-pull-request.yaml` (new)
- `.github/workflows/odh-konflux-onboarder.yml` (updated: added agents-operator to components list)