### PR TITLE
RHOAIENG-58725: add helm build pipeline to ODH

### DIFF
--- a/pipeline/helm-chart-build.yaml
+++ b/pipeline/helm-chart-build.yaml
@@ -1,0 +1,404 @@
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: helm-chart-build
+spec:
+  description: |
+    This pipeline builds and verifies a Helm chart as an OCI artifact.
+
+    _Uses `helm push` to create an OCI artifact from a Helm chart. It also optionally
+    creates a source image and runs build-time tests._
+  params:
+  - description: Source Repository URL
+    name: git-url
+    type: string
+  - default: ""
+    description: Revision of the Source Repository
+    name: revision
+    type: string
+  - description: Fully Qualified Output Image
+    name: output-image
+    type: string
+  - default: .
+    description: Path to the Helm chart directory
+    name: path-context
+    type: string
+  - default: "false"
+    description: Skip checks against built image
+    name: skip-checks
+    type: string
+  - default: "false"
+    description: Execute the build with network isolation
+    name: hermetic
+    type: string
+  - default: ""
+    description: Build dependencies to be prefetched by Cachi2
+    name: prefetch-input
+    type: string
+  - default: ""
+    description: Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.
+    name: image-expires-after
+    type: string
+  - default: "false"
+    description: Build a source image.
+    name: build-source-image
+    type: string
+  - name: expected-cluster
+    default: ""
+    type: string
+    description: The cluster that this pipeline is expected to be run from
+  - description: Additional tags to push for build image
+    name: additional-tags
+    type: array
+    default: []
+  - description: Fetch all tags for the repo
+    name: fetch-git-tags
+    type: string
+    default: "false"
+  - description: Perform a shallow clone, fetching only the most recent N commits
+    name: clone-depth
+    type: string
+    default: "1"
+  - name: enable-cache-proxy
+    default: 'false'
+    description: Enable cache proxy configuration
+    type: string
+  - name: sast-target-dirs
+    type: string
+    default: .
+    description: Target directories to scan with SAST tools. Multiple values should be separated with commas.
+  results:
+  - description: ""
+    name: IMAGE_URL
+    value: $(tasks.build-helm-chart.results.IMAGE_URL)
+  - description: ""
+    name: IMAGE_DIGEST
+    value: $(tasks.build-helm-chart.results.IMAGE_DIGEST)
+  - description: ""
+    name: CHAINS-GIT_URL
+    value: $(tasks.clone-repository.results.url)
+  - description: ""
+    name: CHAINS-GIT_COMMIT
+    value: $(tasks.clone-repository.results.commit)
+  tasks:
+  - name: rhoai-init
+    params:
+    - name: expected-cluster
+      value: $(params.expected-cluster)
+    - name: image-output
+      value: $(params.output-image)
+    taskRef:
+      resolver: git
+      params:
+      - name: url
+        value: https://github.com/red-hat-data-services/rhoai-konflux-tasks.git
+      - name: revision
+        value: 0ad9c78e5276367cd475f3f8706dd93cf4784b63
+      - name: pathInRepo
+        value: konflux-tekton-tasks/rhoai-init/0.1/rhoai-init.yaml
+  - name: init
+    params:
+    - name: enable-cache-proxy
+      value: $(params.enable-cache-proxy)
+    taskRef:
+      params:
+      - name: name
+        value: init
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-init:0.4@sha256:5a423246792ac501ea279229b42ee57da9927da441c04b5c9ff86817b0856b08
+      - name: kind
+        value: task
+      resolver: bundles
+    runAfter:
+    - rhoai-init
+  - name: clone-repository
+    params:
+    - name: url
+      value: $(params.git-url)
+    - name: revision
+      value: $(params.revision)
+    - name: ociStorage
+      value: $(params.output-image).git
+    - name: ociArtifactExpiresAfter
+      value: $(params.image-expires-after)
+    - name: fetchTags
+      value: $(params.fetch-git-tags)
+    - name: depth
+      value: $(params.clone-depth)
+    runAfter:
+    - init
+    taskRef:
+      params:
+      - name: name
+        value: git-clone-oci-ta
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:13d49df7dc9ae301627e45f95a236011422996152f1bea46cd60217b0f057407
+      - name: kind
+        value: task
+      resolver: bundles
+    workspaces:
+    - name: basic-auth
+      workspace: git-auth
+  - name: prefetch-dependencies
+    params:
+    - name: input
+      value: $(params.prefetch-input)
+    - name: SOURCE_ARTIFACT
+      value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+    - name: ociStorage
+      value: $(params.output-image).prefetch
+    - name: ociArtifactExpiresAfter
+      value: $(params.image-expires-after)
+    runAfter:
+    - clone-repository
+    taskRef: 
+      params:
+      - name: name
+        value: prefetch-dependencies-oci-ta
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.3@sha256:a2efbcdcecfa5293a622eb356a18f5c88e5714046b214fe8730b43b1a7dbb77d
+      - name: kind
+        value: task
+      resolver: bundles
+    workspaces:
+    - name: git-basic-auth
+      workspace: git-auth
+    - name: netrc
+      workspace: netrc
+  - name: build-helm-chart
+    params:
+    - name: IMAGE
+      value: $(params.output-image)
+    - name: CHART_CONTEXT
+      value: $(params.path-context)
+    - name: COMMIT_SHA
+      value: $(tasks.clone-repository.results.commit)
+    - name: SOURCE_ARTIFACT
+      value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+    - name: VERSION_SUFFIX
+      value: ""
+    runAfter:
+    - prefetch-dependencies
+    taskRef:
+      params:
+      - name: name
+        value: build-helm-chart-oci-ta
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-build-helm-chart-oci-ta:0.3@sha256:22e82fa76e4ac98dd6f99776fe4b8cdced273e184d0f0ddd30e3c5986bc803db
+      - name: kind
+        value: task
+      resolver: bundles
+  - name: build-source-image
+    params:
+    - name: BINARY_IMAGE
+      value: $(tasks.build-helm-chart.results.IMAGE_URL)
+    - name: BINARY_IMAGE_DIGEST
+      value: $(tasks.build-helm-chart.results.IMAGE_DIGEST)
+    - name: SOURCE_ARTIFACT
+      value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+    - name: CACHI2_ARTIFACT
+      value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+    runAfter:
+    - build-helm-chart
+    taskRef:
+      params:
+      - name: name
+        value: source-build-oci-ta
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-source-build-oci-ta:0.3@sha256:0917cfc7772e82cb8e74743c2104f43bcf2596aceafe87eec6fce69a8cac5f06
+      - name: kind
+        value: task
+      resolver: bundles
+    when:
+    - input: $(params.build-source-image)
+      operator: in
+      values:
+      - "true"
+  - name: sast-shell-check
+    params:
+    - name: image-digest
+      value: $(tasks.build-helm-chart.results.IMAGE_DIGEST)
+    - name: image-url
+      value: $(tasks.build-helm-chart.results.IMAGE_URL)
+    - name: SOURCE_ARTIFACT
+      value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+    - name: CACHI2_ARTIFACT
+      value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+    - name: TARGET_DIRS
+      value: $(params.sast-target-dirs)
+    runAfter:
+    - build-helm-chart
+    taskRef:
+      params:
+      - name: name
+        value: sast-shell-check-oci-ta
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-sast-shell-check-oci-ta:0.1@sha256:c4ef47e3b4e0508572d266fb745be7e374c29dc02580328cbe9f4d472a8aca57
+      - name: kind
+        value: task
+      resolver: bundles
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+    workspaces: []
+  - name: sast-unicode-check
+    params:
+    - name: image-digest
+      value: $(tasks.build-helm-chart.results.IMAGE_DIGEST)
+    - name: image-url
+      value: $(tasks.build-helm-chart.results.IMAGE_URL)
+    - name: SOURCE_ARTIFACT
+      value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+    - name: CACHI2_ARTIFACT
+      value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+    - name: TARGET_DIRS
+      value: $(params.sast-target-dirs)
+    runAfter:
+    - build-helm-chart
+    taskRef:
+      params:
+      - name: name
+        value: sast-unicode-check-oci-ta
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta:0.3@sha256:5e46c39508dfb8031102ec4e11ba98edabb1299615cafe174166f8df49ea3215
+      - name: kind
+        value: task
+      resolver: bundles
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+    workspaces: []
+  - name: sast-snyk-check
+    params:
+    - name: image-digest
+      value: $(tasks.build-helm-chart.results.IMAGE_DIGEST)
+    - name: image-url
+      value: $(tasks.build-helm-chart.results.IMAGE_URL)
+    - name: SOURCE_ARTIFACT
+      value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+    - name: CACHI2_ARTIFACT
+      value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+    - name: TARGET_DIRS
+      value: $(params.sast-target-dirs)
+    runAfter:
+    - build-helm-chart
+    taskRef:
+      params:
+      - name: name
+        value: sast-snyk-check-oci-ta
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.4@sha256:8f3ecbeaff579e41b8278f82d7fabac27845db17a8e687ea6c510c0c9aceabbb
+      - name: kind
+        value: task
+      resolver: bundles
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+  - name: clamav-scan
+    params:
+    - name: image-digest
+      value: $(tasks.build-helm-chart.results.IMAGE_DIGEST)
+    - name: image-url
+      value: $(tasks.build-helm-chart.results.IMAGE_URL)
+    runAfter:
+    - build-helm-chart
+    
+    taskRef:
+      params:
+      - name: name
+        value: clamav-scan
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.3@sha256:567cb66bd2e1f4b58b9d4d756f3317fc62479e0b40aa0de66094b1f12d296cfc
+      - name: kind
+        value: task
+      resolver: bundles
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+  - name: apply-tags
+    params:
+    - name: IMAGE_URL
+      value: $(tasks.build-helm-chart.results.IMAGE_URL)
+    - name: IMAGE_DIGEST
+      value: $(tasks.build-helm-chart.results.IMAGE_DIGEST)
+    - name: ADDITIONAL_TAGS
+      value:
+      - $(params.additional-tags[*])
+    runAfter:
+    - build-helm-chart
+    taskRef:
+      params:
+      - name: name
+        value: apply-tags
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.3@sha256:a291081de7fb27f832c6fc3c4b078acf7e6162ca4c085db38b118ca87e8b5b66
+      - name: kind
+        value: task
+      resolver: bundles
+  - name: pipeline-success-indicator
+    runAfter:
+    - build-source-image
+    - sast-shell-check
+    - sast-unicode-check
+    - sast-snyk-check
+    - clamav-scan
+    - apply-tags
+    taskSpec:
+      steps:
+      - name: noop
+        image: quay.io/rhoai-konflux/alpine:latest
+        script: |
+          echo "Success"
+  finally:
+  - name: show-sbom
+    params:
+    - name: IMAGE_URL
+      value: $(tasks.build-helm-chart.results.IMAGE_URL)
+    taskRef:
+      params:
+      - name: name
+        value: show-sbom
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-show-sbom:0.1@sha256:a7346ed61237db4f82ff782e0c9e8b30536e0e67b907ad600341a6d192e80012
+      - name: kind
+        value: task
+      resolver: bundles
+  - name: send-slack-notification
+    params:
+    - name: message
+      value: "$(tasks.rhoai-init.results.slack-message-failure-text)"
+    - name: secret-name
+      value: ci-slack-secret
+    - name: key-name
+      value: secret
+    taskRef:
+      params:
+      - name: name
+        value: slack-webhook-notification
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-slack-webhook-notification:0.1@sha256:14766aebbf6f4739e1b7dde0406dcba2d1e300170d3b084f23df9fb074d87dc3
+      - name: kind
+        value: task
+      resolver: bundles
+    when:
+    - input: $(tasks.pipeline-success-indicator.status)
+      operator: notin
+      values:
+      - "Succeeded"
+    - input: $(tasks.rhoai-init.results.skip-slack-message)
+      operator: in
+      values:
+      - "false"
+  workspaces:
+  - name: git-auth
+    optional: true
+  - name: netrc
+    optional: true


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Add build helm charts job into ODH.

## Description
<!--- Describe your changes in detail -->
Add build helm charts job into ODH. I removed any mention/use of rhoai-version as it does not exist on ODH pipeline run files. The slack secret param has also been updated to use ci-slack-secret.

Discussion can be found here: https://redhat.enterprise.slack.com/lists/T027F3GAJ/F07SBP17R7Z?record_id=Rec0B5N9PBATS
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
https://redhat.atlassian.net/browse/RHOAIENG-58725

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced automated Helm chart build pipeline for OCI artifact generation
  * Added configurable security scanning including SAST, Unicode, and malware checks
  * Enabled optional dependency prefetching and source image builds
  * Implemented git authentication support and Slack notifications for build events

<!-- end of auto-generated comment: release notes by coderabbit.ai -->