### PR TITLE
Add odh-observability-ci PipelineRuns for odh-observability

### DIFF
--- a/.github/workflows/odh-konflux-onboarder.yml
+++ b/.github/workflows/odh-konflux-onboarder.yml
@@ -70,6 +70,7 @@ on:
           - vllm-orchestrator-gateway
           - workload-variant-autoscaler
           - rhaii-cluster-validation
+          - odh-observability
       pr_target_branch:
         description: 'Target branch for the PR (e.g. main)'
         required: true

--- a/pipelineruns/odh-observability/odh-observability-pull-request.yaml
+++ b/pipelineruns/odh-observability/odh-observability-pull-request.yaml
@@ -1,0 +1,52 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/odh-observability?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
+      == "main"
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: opendatahub-builds
+    appstudio.openshift.io/component: odh-observability-ci
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-observability-on-pull-request
+  namespace: open-data-hub-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/opendatahub/odh-observability:odh-pr
+  - name: dockerfile
+    value: Dockerfile
+  - name: path-context
+    value: ./
+  # additional params
+  - name: additional-tags
+    value:
+    - 'odh-pr-{{revision}}'
+  - name: pipeline-type
+    value: pull-request
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/opendatahub-io/odh-konflux-central.git
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipeline/multi-arch-container-build.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-odh-observability-ci
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/pipelineruns/odh-observability/odh-observability-push.yaml
+++ b/pipelineruns/odh-observability/odh-observability-push.yaml
@@ -1,0 +1,47 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+#
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/odh-observability?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "main"
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: opendatahub-builds
+    appstudio.openshift.io/component: odh-observability-ci
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-observability-on-push
+  namespace: open-data-hub-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/opendatahub/odh-observability:odh-stable
+  - name: dockerfile
+    value: Dockerfile
+  - name: path-context
+    value: ./
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/opendatahub-io/odh-konflux-central.git
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipeline/multi-arch-container-build.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-odh-observability-ci
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}


### PR DESCRIPTION
Add Konflux CI PipelineRuns for 'odh-observability' from repo 'odh-observability'.

Product: ODH
Application: opendatahub-builds
Output image: quay.io/opendatahub/odh-observability
Source repo: https://github.com/opendatahub-io/odh-observability @ main
Jira: https://redhat.atlassian.net/browse/RHOAIENG-63209

**Files changed:**
- `pipelineruns/odh-observability/odh-observability-push.yaml` (new)
- `pipelineruns/odh-observability/odh-observability-pull-request.yaml` (new)
- `.github/workflows/odh-konflux-onboarder.yml` (updated: added odh-observability to components list)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added `odh-observability` as a new component option in the onboarding workflow
  * Configured automated build pipelines for `odh-observability` triggered on pull requests and push events

<!-- end of auto-generated comment: release notes by coderabbit.ai -->