### PR TITLE
Add odh-mod-arch-agent-ops-ci PipelineRuns for odh-mod-arch-agent-ops

### DIFF
--- a/pipelineruns/odh-dashboard/odh-mod-arch-agent-ops-pull-request.yaml
+++ b/pipelineruns/odh-dashboard/odh-mod-arch-agent-ops-pull-request.yaml
@@ -1,0 +1,52 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/odh-dashboard?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
+      == "main"
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: opendatahub-builds
+    appstudio.openshift.io/component: odh-mod-arch-agent-ops-ci
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-mod-arch-agent-ops-on-pull-request
+  namespace: open-data-hub-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/opendatahub/odh-mod-arch-agent-ops:odh-pr
+  - name: dockerfile
+    value: packages/agent-ops/Dockerfile.workspace
+  - name: path-context
+    value: .
+  # additional params
+  - name: additional-tags
+    value:
+    - 'odh-pr-{{revision}}'
+  - name: pipeline-type
+    value: pull-request
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/opendatahub-io/odh-konflux-central.git
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipeline/multi-arch-container-build.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-odh-mod-arch-agent-ops-ci
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/pipelineruns/odh-dashboard/odh-mod-arch-agent-ops-push.yaml
+++ b/pipelineruns/odh-dashboard/odh-mod-arch-agent-ops-push.yaml
@@ -1,0 +1,47 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+#
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/odh-dashboard?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "main"
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: opendatahub-builds
+    appstudio.openshift.io/component: odh-mod-arch-agent-ops-ci
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-mod-arch-agent-ops-on-push
+  namespace: open-data-hub-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/opendatahub/odh-mod-arch-agent-ops:$$OUTPUT_IMAGE_TAG$$
+  - name: dockerfile
+    value: packages/agent-ops/Dockerfile.workspace
+  - name: path-context
+    value: .
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/opendatahub-io/odh-konflux-central.git
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipeline/multi-arch-container-build.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-odh-mod-arch-agent-ops-ci
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}


### PR DESCRIPTION
Add Konflux CI PipelineRuns for 'odh-mod-arch-agent-ops' from repo 'odh-dashboard'.

Product: ODH
Application: opendatahub-builds
Output image: quay.io/opendatahub/odh-mod-arch-agent-ops:odh-stable
Source repo: https://github.com/opendatahub-io/odh-dashboard @ main
Jira: https://redhat.atlassian.net/browse/RHOAIENG-63302

**Files changed:**
- pipelineruns/odh-dashboard/odh-mod-arch-agent-ops-push.yaml (new)
- pipelineruns/odh-dashboard/odh-mod-arch-agent-ops-pull-request.yaml (new)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured automated container build pipelines triggered on code push and pull request events, enabling continuous integration with multi-architecture container image builds and customizable build parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->