### PR TITLE
Increase scan memory limits for universal training images

### DIFF
--- a/pipelineruns/distributed-workloads/odh-th06-cpu-torch210-py312-pull-request.yaml
+++ b/pipelineruns/distributed-workloads/odh-th06-cpu-torch210-py312-pull-request.yaml
@@ -39,7 +39,24 @@ spec:
     - 'odh-pr-{{revision}}'
   - name: build-platforms
     value:
-    - linux-extra-fast/amd64
+    - linux-d160-m8xlarge/amd64
+  taskRunSpecs:
+  - pipelineTaskName: clair-scan
+    stepSpecs:
+    - name: get-vulnerabilities
+      computeResources:
+        requests:
+          memory: 4Gi
+        limits:
+          memory: 16Gi
+  - pipelineTaskName: clamav-scan
+    stepSpecs:
+    - name: extract-and-scan-image
+      computeResources:
+        requests:
+          memory: 4Gi
+        limits:
+          memory: 16Gi
   pipelineRef:
     resolver: git
     params:

--- a/pipelineruns/distributed-workloads/odh-th06-cpu-torch210-py312-push.yaml
+++ b/pipelineruns/distributed-workloads/odh-th06-cpu-torch210-py312-push.yaml
@@ -35,7 +35,24 @@ spec:
     value: images/universal/training/th06-cpu-torch210-py312
   - name: build-platforms
     value:
-    - linux-extra-fast/amd64
+    - linux-d160-m8xlarge/amd64
+  taskRunSpecs:
+  - pipelineTaskName: clair-scan
+    stepSpecs:
+    - name: get-vulnerabilities
+      computeResources:
+        requests:
+          memory: 4Gi
+        limits:
+          memory: 16Gi
+  - pipelineTaskName: clamav-scan
+    stepSpecs:
+    - name: extract-and-scan-image
+      computeResources:
+        requests:
+          memory: 4Gi
+        limits:
+          memory: 16Gi
   pipelineRef:
     resolver: git
     params:

--- a/pipelineruns/distributed-workloads/odh-th06-cuda130-torch210-py312-pull-request.yaml
+++ b/pipelineruns/distributed-workloads/odh-th06-cuda130-torch210-py312-pull-request.yaml
@@ -39,7 +39,24 @@ spec:
     - 'odh-pr-{{revision}}'
   - name: build-platforms
     value:
-    - linux-extra-fast/amd64
+    - linux-d160-m8xlarge/amd64
+  taskRunSpecs:
+  - pipelineTaskName: clair-scan
+    stepSpecs:
+    - name: get-vulnerabilities
+      computeResources:
+        requests:
+          memory: 4Gi
+        limits:
+          memory: 16Gi
+  - pipelineTaskName: clamav-scan
+    stepSpecs:
+    - name: extract-and-scan-image
+      computeResources:
+        requests:
+          memory: 4Gi
+        limits:
+          memory: 16Gi
   pipelineRef:
     resolver: git
     params:

--- a/pipelineruns/distributed-workloads/odh-th06-cuda130-torch210-py312-push.yaml
+++ b/pipelineruns/distributed-workloads/odh-th06-cuda130-torch210-py312-push.yaml
@@ -35,7 +35,24 @@ spec:
     value: images/universal/training/th06-cuda130-torch210-py312
   - name: build-platforms
     value:
-    - linux-extra-fast/amd64
+    - linux-d160-m8xlarge/amd64
+  taskRunSpecs:
+  - pipelineTaskName: clair-scan
+    stepSpecs:
+    - name: get-vulnerabilities
+      computeResources:
+        requests:
+          memory: 4Gi
+        limits:
+          memory: 16Gi
+  - pipelineTaskName: clamav-scan
+    stepSpecs:
+    - name: extract-and-scan-image
+      computeResources:
+        requests:
+          memory: 4Gi
+        limits:
+          memory: 16Gi
   pipelineRef:
     resolver: git
     params:

--- a/pipelineruns/distributed-workloads/odh-th06-rocm64-torch291-py312-pull-request.yaml
+++ b/pipelineruns/distributed-workloads/odh-th06-rocm64-torch291-py312-pull-request.yaml
@@ -40,7 +40,24 @@ spec:
     - 'odh-pr-{{revision}}'
   - name: build-platforms
     value:
-    - linux-extra-fast/amd64
+    - linux-d160-m8xlarge/amd64
+  taskRunSpecs:
+  - pipelineTaskName: clair-scan
+    stepSpecs:
+    - name: get-vulnerabilities
+      computeResources:
+        requests:
+          memory: 4Gi
+        limits:
+          memory: 16Gi
+  - pipelineTaskName: clamav-scan
+    stepSpecs:
+    - name: extract-and-scan-image
+      computeResources:
+        requests:
+          memory: 4Gi
+        limits:
+          memory: 16Gi
   pipelineRef:
     resolver: git
     params:

--- a/pipelineruns/distributed-workloads/odh-th06-rocm64-torch291-py312-push.yaml
+++ b/pipelineruns/distributed-workloads/odh-th06-rocm64-torch291-py312-push.yaml
@@ -34,7 +34,24 @@ spec:
     value: images/universal/training/th06-rocm64-torch291-py312
   - name: build-platforms
     value:
-    - linux-extra-fast/amd64
+    - linux-d160-m8xlarge/amd64
+  taskRunSpecs:
+  - pipelineTaskName: clair-scan
+    stepSpecs:
+    - name: get-vulnerabilities
+      computeResources:
+        requests:
+          memory: 4Gi
+        limits:
+          memory: 16Gi
+  - pipelineTaskName: clamav-scan
+    stepSpecs:
+    - name: extract-and-scan-image
+      computeResources:
+        requests:
+          memory: 4Gi
+        limits:
+          memory: 16Gi
   pipelineRef:
     resolver: git
     params:


### PR DESCRIPTION
## Summary
- Switch universal training image builds (CPU, CUDA, ROCm) from `linux-extra-fast/amd64` to `linux-d160-m8xlarge/amd64`
- Override clair-scan `get-vulnerabilities` step memory from 6Gi to 16Gi via `taskRunSpecs`
- Override clamav-scan `extract-and-scan-image` step memory from 8Gi to 16Gi via `taskRunSpecs`
- Fixes OOMKilled failures during build, clair-scan, and clamav-scan steps for these large images

## Test plan
- [ ] Verify builds pass on [DW PR #860](https://github.com/opendatahub-io/distributed-workloads/pull/860)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build infrastructure platform configuration across multiple pipeline definitions.
  * Added explicit memory resource constraints for vulnerability scanning processes to optimize resource allocation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->