### PR TITLE
Skip unchanged nightly and add TRIGGER_TESTS param

### DIFF
--- a/integration-tests/CI/trigger-nightly.yaml
+++ b/integration-tests/CI/trigger-nightly.yaml
@@ -152,6 +152,7 @@ spec:
                 TRIGGER_NIGHTLY_TESTS_REASON="smoke tests forced via TRIGGER_NIGHTLY_TESTS=true"
               elif [ "$NIGHTLY_CHANGED" = "true" ]; then
                 SHOULD_TRIGGER_NIGHTLY_TESTS=true
+                TRIGGER_NIGHTLY_TESTS_REASON="smoke tests triggered (catalog changed)"
               else
                 SHOULD_TRIGGER_NIGHTLY_TESTS=false
                 TRIGGER_NIGHTLY_TESTS_REASON="smoke tests skipped (catalog unchanged)"

--- a/integration-tests/CI/trigger-nightly.yaml
+++ b/integration-tests/CI/trigger-nightly.yaml
@@ -336,7 +336,7 @@ spec:
               SLACK_ARGS=(-c "$CHANNEL")
               tracer.sh --odh -i "$LATEST_CATALOG_CI_IMAGE" --show-commits | tee tracer-output.txt
 
-              if [ "$NIGHTLY_CHANGED" = "true" ] && [ "$SHOULD_TAG_NIGHTLY" = "true" ]; then
+              if [ "$SHOULD_TAG_NIGHTLY" = "true" ]; then
                 SUBST_VARS='$LATEST_CATALOG_CI_IMAGE $LATEST_BUILD_METADATA_URL $BUILD_URL'
                 slack_message=$(echo "$MESSAGE_TEMPLATE" | envsubst "$SUBST_VARS")
                 SLACK_ARGS+=(-m "$slack_message")
@@ -350,9 +350,9 @@ spec:
                 fi
 
                 SLACK_ARGS+=(-f tracer-output.txt)
-              elif [ "$NIGHTLY_CHANGED" = "true" ]; then
-                slack_message=":no_entry_sign: Nightly tagging skipped (TRIGGER_NIGHTLY_TAG=false), but new catalog CI builds are available."
-                SLACK_ARGS+=(-m "$slack_message" -f tracer-output.txt)
+              elif [ "$NIGHTLY_CHANGED" = "true" ] ; then
+                slack_message=":no_entry_sign: Nightly tagging skipped due to override (TRIGGER_NIGHTLY_TAG=false)"
+                SLACK_ARGS+=(-m "$slack_message")
               else
                 slack_message=":moon: No new nightly: no new catalog CI builds have run since the previous nightly."
                 SLACK_ARGS+=(-m "$slack_message" -f tracer-output.txt)

--- a/integration-tests/CI/trigger-nightly.yaml
+++ b/integration-tests/CI/trigger-nightly.yaml
@@ -74,7 +74,12 @@ spec:
 
               # Compare with previous nightly
               NIGHTLY_IMAGE="${CATALOG_IMAGE%:*}:odh-stable-nightly"
-              PREVIOUS_SHA=$(skopeo inspect --raw "docker://$NIGHTLY_IMAGE" 2>/dev/null | sha256sum | awk '{print "sha256:" $1}' || true)
+              RAW_OUTPUT=$(skopeo inspect --raw "docker://$NIGHTLY_IMAGE" 2>/dev/null || true)
+              if [ -n "$RAW_OUTPUT" ]; then
+                PREVIOUS_SHA=$(printf '%s' "$RAW_OUTPUT" | sha256sum | awk '{print "sha256:" $1}')
+              else
+                PREVIOUS_SHA=""
+              fi
               if [ -n "$PREVIOUS_SHA" ]; then
                 printf '%s' "$PREVIOUS_SHA" > "$(results.previous-nightly-sha.path)"
                 echo "Previous nightly SHA: $PREVIOUS_SHA"

--- a/integration-tests/CI/trigger-nightly.yaml
+++ b/integration-tests/CI/trigger-nightly.yaml
@@ -334,15 +334,19 @@ spec:
               tracer.sh --odh -i "$LATEST_CATALOG_CI_IMAGE" --show-commits | tee tracer-output.txt
 
               if [ "$NIGHTLY_CHANGED" = "true" ]; then
-                tracer-diff.sh --mode 2 --only-changes \
-                  --old-label "previous nightly catalog" --new-label "this catalog" \
-                  "--odh --digest $PREVIOUS_NIGHTLY_SHA" "--odh -i $LATEST_CATALOG_CI_IMAGE" \
-                    | tee tracer-diff.txt
-
                 SUBST_VARS='$LATEST_CATALOG_CI_IMAGE $LATEST_BUILD_METADATA_URL $BUILD_URL'
                 slack_message=$(echo "$MESSAGE_TEMPLATE" | envsubst "$SUBST_VARS")
+                SLACK_ARGS+=(-m "$slack_message")
 
-                SLACK_ARGS+=(-m "$slack_message" -m "$(cat tracer-diff.txt)" -f tracer-output.txt)
+                if [ -n "$PREVIOUS_NIGHTLY_SHA" ]; then
+                  tracer-diff.sh --mode 2 --only-changes \
+                    --old-label "previous nightly catalog" --new-label "this catalog" \
+                    "--odh --digest $PREVIOUS_NIGHTLY_SHA" "--odh -i $LATEST_CATALOG_CI_IMAGE" \
+                      | tee tracer-diff.txt
+                  SLACK_ARGS+=(-m "$(cat tracer-diff.txt)")
+                fi
+
+                SLACK_ARGS+=(-f tracer-output.txt)
               else
                 slack_message=":moon: No new nightly: no new catalog CI builds have run since the previous nightly."
                 SLACK_ARGS+=(-m "$slack_message" -f tracer-output.txt )

--- a/integration-tests/CI/trigger-nightly.yaml
+++ b/integration-tests/CI/trigger-nightly.yaml
@@ -308,9 +308,9 @@ spec:
               set -eo pipefail
 
               SLACK_ARGS=(-c "$CHANNEL")
+              tracer.sh --odh -i "$LATEST_CATALOG_CI_IMAGE" --show-commits | tee tracer-output.txt
 
               if [ "$NIGHTLY_CHANGED" = "true" ]; then
-                tracer.sh --odh -i "$LATEST_CATALOG_CI_IMAGE" --show-commits | tee tracer-output.txt
 
                 tracer-diff.sh --mode 2 --only-changes \
                   --old-label "previous nightly catalog" --new-label "this catalog" \
@@ -322,7 +322,8 @@ spec:
 
                 SLACK_ARGS+=(-m "$slack_message" -m "$(cat tracer-diff.txt)" -f tracer-output.txt)
               else
-                SLACK_ARGS+=(-m ":moon: No new nightly: no new catalog CI builds have run since the previous nightly.")
+                slack_message=":moon: No new nightly: no new catalog CI builds have run since the previous nightly."
+                SLACK_ARGS+=(-m "$slack_message" -f tracer-output.txt )
               fi
 
               if [ -n "$TRIGGER_TESTS_REASON" ]; then

--- a/integration-tests/CI/trigger-nightly.yaml
+++ b/integration-tests/CI/trigger-nightly.yaml
@@ -18,10 +18,10 @@ spec:
         name: CATALOG_IMAGE
         type: string
         default: quay.io/opendatahub/opendatahub-operator-catalog:odh-stable
-      - description: Trigger Nightly Tests
-        name: TRIGGER_NIGHTLY_TESTS
+      - description: "Trigger nightly tests: true (always), false (never), auto (only if changed)"
+        name: TRIGGER_TESTS
         type: string
-        default: "true"
+        default: "auto"
       - description: Trigger Slack Notification
         name: TRIGGER_SLACK
         type: string
@@ -47,6 +47,8 @@ spec:
             description: "the build url for the latest catalog"
           - name: previous-nightly-sha
             description: "the previous nightly"
+          - name: nightly-changed
+            description: "whether the catalog has changed since the last nightly"
           steps:
           - image: quay.io/rhoai-devops/base-runner:latest
             name: get-latest-catalog-ci-build-sha
@@ -58,11 +60,19 @@ spec:
             script: |
               #!/bin/bash
               set -e
-              skopeo_inspect=$(skopeo inspect "docker://$CATALOG_IMAGE" --no-tags)
+
+              # Pin the floating tag to a digest via --raw (single resolution)
+              CATALOG_SHA=$(skopeo inspect --raw "docker://$CATALOG_IMAGE" | sha256sum | awk '{print "sha256:" $1}')
+              CATALOG_BY_DIGEST="${CATALOG_IMAGE%:*}@${CATALOG_SHA}"
+              echo "Pinned $CATALOG_IMAGE -> $CATALOG_BY_DIGEST"
+
+              # Inspect the pinned image for metadata
+              skopeo_inspect=$(skopeo inspect "docker://$CATALOG_BY_DIGEST" --no-tags)
               echo "$skopeo_inspect" | jq -r '.Name + "@" + .Digest' | tr -d '\n' | tee "$(results.latest-catalog-ci-image.path)"; echo
               echo "$skopeo_inspect" | jq -r '.Labels."build-metadata-url"'  | tr -d '\n' | tee "$(results.latest-build-metadata-url.path)"; echo
               echo "$skopeo_inspect" | jq -r '.Labels."build-url"'  | tr -d '\n' | tee "$(results.latest-catalog-ci-build-url.path)"; echo
 
+              # Compare with previous nightly
               NIGHTLY_IMAGE="${CATALOG_IMAGE%:*}:odh-stable-nightly"
               PREVIOUS_SHA=$(skopeo inspect --raw "docker://$NIGHTLY_IMAGE" 2>/dev/null | sha256sum | awk '{print "sha256:" $1}' || true)
               if [ -n "$PREVIOUS_SHA" ]; then
@@ -72,12 +82,26 @@ spec:
                 echo "No previous nightly found"
                 printf '%s' "" > "$(results.previous-nightly-sha.path)"
               fi
-      - name: resolve-slack-channel
-        description: resolves the Slack channel, applying override if set
+
+              if [ -n "$PREVIOUS_SHA" ] && [ "$CATALOG_SHA" = "$PREVIOUS_SHA" ]; then
+                echo "No changes: catalog SHA matches previous nightly ($CATALOG_SHA)"
+                printf 'false' > "$(results.nightly-changed.path)"
+              else
+                echo "Changes detected (new=$CATALOG_SHA, previous=${PREVIOUS_SHA:-none})"
+                printf 'true' > "$(results.nightly-changed.path)"
+              fi
+      - name: resolve-params
+        description: resolves pipeline parameters for downstream tasks
+        runAfter:
+        - choose-ci-build
         taskSpec:
           results:
           - name: channel
             description: "the resolved Slack channel to use"
+          - name: should-trigger-tests
+            description: "whether smoke tests should be triggered"
+          - name: trigger-tests-reason
+            description: "explanation when tests are forced or disabled"
           steps:
           - image: quay.io/rhoai-devops/base-runner:latest
             name: resolve
@@ -89,15 +113,37 @@ spec:
                   key: odh-notification-channel
             - name: OVERRIDE_CHANNEL
               value: $(params.OVERRIDE_CHANNEL)
+            - name: TRIGGER_TESTS
+              value: $(params.TRIGGER_TESTS)
+            - name: NIGHTLY_CHANGED
+              value: $(tasks.choose-ci-build.results.nightly-changed)
             script: |
               #!/bin/bash
               set -e
+
+              # Resolve Slack channel
               CHANNEL="$DEFAULT_CHANNEL"
               if [ -n "$OVERRIDE_CHANNEL" ]; then
                 CHANNEL="$OVERRIDE_CHANNEL"
               fi
               echo "Resolved channel: $CHANNEL"
               printf '%s' "$CHANNEL" > "$(results.channel.path)"
+
+              # Resolve test trigger decision
+              TRIGGER_TESTS_REASON=""
+              if [ "$TRIGGER_TESTS" = "false" ]; then
+                SHOULD_TRIGGER_TESTS=false
+                TRIGGER_TESTS_REASON="smoke tests disabled via TRIGGER_TESTS=false"
+              elif [ "$TRIGGER_TESTS" = "true" ]; then
+                SHOULD_TRIGGER_TESTS=true
+                TRIGGER_TESTS_REASON="smoke tests forced via TRIGGER_TESTS=true"
+              elif [ "$NIGHTLY_CHANGED" = "true" ]; then
+                SHOULD_TRIGGER_TESTS=true
+              else
+                SHOULD_TRIGGER_TESTS=false
+              fi
+              printf '%s' "$SHOULD_TRIGGER_TESTS" > "$(results.should-trigger-tests.path)"
+              printf '%s' "$TRIGGER_TESTS_REASON" > "$(results.trigger-tests-reason.path)"
       - name: tag-nightly
         runAfter:
         - choose-ci-build
@@ -138,6 +184,8 @@ spec:
               value: /workspace/.docker/config.json
             - name: TRIGGER_NIGHTLY_TAG
               value: $(params.TRIGGER_NIGHTLY_TAG)
+            - name: NIGHTLY_CHANGED
+              value: $(tasks.choose-ci-build.results.nightly-changed)
             script: |
               #!/bin/bash
               set -e
@@ -145,6 +193,11 @@ spec:
               if [[ "$TRIGGER_NIGHTLY_TAG" != "true" ]]; then
                 echo "TRIGGER_NIGHTLY_TAG=$TRIGGER_NIGHTLY_TAG"
                 echo "proceeding without tagging a new nightly"
+                exit 0
+              fi
+
+              if [[ "$NIGHTLY_CHANGED" != "true" ]]; then
+                echo "Catalog unchanged from previous nightly, skipping tag"
                 exit 0
               fi
 
@@ -210,7 +263,7 @@ spec:
           - "true"
         runAfter:
         - tag-nightly
-        - resolve-slack-channel
+        - resolve-params
         workspaces:
         - name: data
           workspace: data
@@ -239,7 +292,11 @@ spec:
             - name: PREVIOUS_NIGHTLY_SHA
               value: $(tasks.choose-ci-build.results.previous-nightly-sha)
             - name: CHANNEL
-              value: $(tasks.resolve-slack-channel.results.channel)
+              value: $(tasks.resolve-params.results.channel)
+            - name: NIGHTLY_CHANGED
+              value: $(tasks.choose-ci-build.results.nightly-changed)
+            - name: TRIGGER_TESTS_REASON
+              value: $(tasks.resolve-params.results.trigger-tests-reason)
             - name: MESSAGE_TEMPLATE
               valueFrom:
                 configMapKeyRef:
@@ -250,18 +307,30 @@ spec:
               #!/bin/bash
               set -eo pipefail
 
-              tracer.sh --odh -i "$LATEST_CATALOG_CI_IMAGE" --show-commits | tee tracer-output.txt
+              SLACK_ARGS=(-c "$CHANNEL")
 
-              tracer-diff.sh --mode 2 --only-changes \
-                --old-label "previous nightly catalog" --new-label "this catalog" \
-                "--odh --digest $PREVIOUS_NIGHTLY_SHA" "--odh -i $LATEST_CATALOG_CI_IMAGE" \
-                  | tee tracer-diff.txt
+              if [ "$NIGHTLY_CHANGED" = "true" ]; then
+                tracer.sh --odh -i "$LATEST_CATALOG_CI_IMAGE" --show-commits | tee tracer-output.txt
 
-              SUBST_VARS='$LATEST_CATALOG_CI_IMAGE $LATEST_BUILD_METADATA_URL $BUILD_URL'
-              slack_message=$(echo "$MESSAGE_TEMPLATE" | envsubst "$SUBST_VARS")
+                tracer-diff.sh --mode 2 --only-changes \
+                  --old-label "previous nightly catalog" --new-label "this catalog" \
+                  "--odh --digest $PREVIOUS_NIGHTLY_SHA" "--odh -i $LATEST_CATALOG_CI_IMAGE" \
+                    | tee tracer-diff.txt
+
+                SUBST_VARS='$LATEST_CATALOG_CI_IMAGE $LATEST_BUILD_METADATA_URL $BUILD_URL'
+                slack_message=$(echo "$MESSAGE_TEMPLATE" | envsubst "$SUBST_VARS")
+
+                SLACK_ARGS+=(-m "$slack_message" -m "$(cat tracer-diff.txt)" -f tracer-output.txt)
+              else
+                SLACK_ARGS+=(-m ":moon: No new nightly: no new catalog CI builds have run since the previous nightly.")
+              fi
+
+              if [ -n "$TRIGGER_TESTS_REASON" ]; then
+                SLACK_ARGS+=(-m "$TRIGGER_TESTS_REASON")
+              fi
 
               SLACK_RC=0
-              OUTPUT=$(send-slack-message.sh -c "$CHANNEL" -m "$slack_message" -m "$(cat tracer-diff.txt)" -f tracer-output.txt -v 2>&1) || SLACK_RC=$?
+              OUTPUT=$(send-slack-message.sh "${SLACK_ARGS[@]}" -v 2>&1) || SLACK_RC=$?
 
               THREAD_TS=$(printf '%s\n' "$OUTPUT" | grep -oP 'Setting new thread id:\s*\K[0-9]+\.[0-9]+' | head -1 || true)
 
@@ -283,14 +352,14 @@ spec:
       - name: trigger-nightly-tests
         description: trigger nightly tests via rhods-devops-infra smoke-trigger workflow
         when:
-        - input: $(params.TRIGGER_NIGHTLY_TESTS)
+        - input: $(tasks.resolve-params.results.should-trigger-tests)
           operator: in
           values:
           - "true"
         runAfter:
         - tag-nightly
         - slack-notification
-        - resolve-slack-channel
+        - resolve-params
         workspaces:
         - name: data
           workspace: data
@@ -311,7 +380,7 @@ spec:
                   name: rhods-ci
                   key: secret
             - name: CHANNEL
-              value: $(tasks.resolve-slack-channel.results.channel)
+              value: $(tasks.resolve-params.results.channel)
             script: |
               #!/bin/bash
               set -e

--- a/integration-tests/CI/trigger-nightly.yaml
+++ b/integration-tests/CI/trigger-nightly.yaml
@@ -19,7 +19,7 @@ spec:
         type: string
         default: quay.io/opendatahub/opendatahub-operator-catalog:odh-stable
       - description: "Trigger nightly tests: true (always), false (never), auto (only if changed)"
-        name: TRIGGER_TESTS
+        name: TRIGGER_NIGHTLY_TESTS
         type: string
         default: "auto"
       - description: Trigger Slack Notification
@@ -113,8 +113,8 @@ spec:
                   key: odh-notification-channel
             - name: OVERRIDE_CHANNEL
               value: $(params.OVERRIDE_CHANNEL)
-            - name: TRIGGER_TESTS
-              value: $(params.TRIGGER_TESTS)
+            - name: TRIGGER_NIGHTLY_TESTS
+              value: $(params.TRIGGER_NIGHTLY_TESTS)
             - name: NIGHTLY_CHANGED
               value: $(tasks.choose-ci-build.results.nightly-changed)
             script: |
@@ -130,20 +130,20 @@ spec:
               printf '%s' "$CHANNEL" > "$(results.channel.path)"
 
               # Resolve test trigger decision
-              TRIGGER_TESTS_REASON=""
-              if [ "$TRIGGER_TESTS" = "false" ]; then
-                SHOULD_TRIGGER_TESTS=false
-                TRIGGER_TESTS_REASON="smoke tests disabled via TRIGGER_TESTS=false"
-              elif [ "$TRIGGER_TESTS" = "true" ]; then
-                SHOULD_TRIGGER_TESTS=true
-                TRIGGER_TESTS_REASON="smoke tests forced via TRIGGER_TESTS=true"
+              TRIGGER_NIGHTLY_TESTS_REASON=""
+              if [ "$TRIGGER_NIGHTLY_TESTS" = "false" ]; then
+                SHOULD_TRIGGER_NIGHTLY_TESTS=false
+                TRIGGER_NIGHTLY_TESTS_REASON="smoke tests disabled via TRIGGER_NIGHTLY_TESTS=false"
+              elif [ "$TRIGGER_NIGHTLY_TESTS" = "true" ]; then
+                SHOULD_TRIGGER_NIGHTLY_TESTS=true
+                TRIGGER_NIGHTLY_TESTS_REASON="smoke tests forced via TRIGGER_NIGHTLY_TESTS=true"
               elif [ "$NIGHTLY_CHANGED" = "true" ]; then
-                SHOULD_TRIGGER_TESTS=true
+                SHOULD_TRIGGER_NIGHTLY_TESTS=true
               else
-                SHOULD_TRIGGER_TESTS=false
+                SHOULD_TRIGGER_NIGHTLY_TESTS=false
               fi
-              printf '%s' "$SHOULD_TRIGGER_TESTS" > "$(results.should-trigger-tests.path)"
-              printf '%s' "$TRIGGER_TESTS_REASON" > "$(results.trigger-tests-reason.path)"
+              printf '%s' "$SHOULD_TRIGGER_NIGHTLY_TESTS" > "$(results.should-trigger-tests.path)"
+              printf '%s' "$TRIGGER_NIGHTLY_TESTS_REASON" > "$(results.trigger-tests-reason.path)"
       - name: tag-nightly
         runAfter:
         - choose-ci-build
@@ -295,7 +295,7 @@ spec:
               value: $(tasks.resolve-params.results.channel)
             - name: NIGHTLY_CHANGED
               value: $(tasks.choose-ci-build.results.nightly-changed)
-            - name: TRIGGER_TESTS_REASON
+            - name: TRIGGER_NIGHTLY_TESTS_REASON
               value: $(tasks.resolve-params.results.trigger-tests-reason)
             - name: MESSAGE_TEMPLATE
               valueFrom:
@@ -326,8 +326,8 @@ spec:
                 SLACK_ARGS+=(-m "$slack_message" -f tracer-output.txt )
               fi
 
-              if [ -n "$TRIGGER_TESTS_REASON" ]; then
-                SLACK_ARGS+=(-m "$TRIGGER_TESTS_REASON")
+              if [ -n "$TRIGGER_NIGHTLY_TESTS_REASON" ]; then
+                SLACK_ARGS+=(-m "$TRIGGER_NIGHTLY_TESTS_REASON")
               fi
 
               SLACK_RC=0

--- a/integration-tests/CI/trigger-nightly.yaml
+++ b/integration-tests/CI/trigger-nightly.yaml
@@ -135,6 +135,10 @@ spec:
               printf '%s' "$CHANNEL" > "$(results.channel.path)"
 
               # Resolve test trigger decision
+              case "$TRIGGER_NIGHTLY_TESTS" in
+                true|false|auto) ;;
+                *) echo "ERROR: invalid TRIGGER_NIGHTLY_TESTS='$TRIGGER_NIGHTLY_TESTS' (must be true/false/auto)"; exit 1 ;;
+              esac
               TRIGGER_NIGHTLY_TESTS_REASON=""
               if [ "$TRIGGER_NIGHTLY_TESTS" = "false" ]; then
                 SHOULD_TRIGGER_NIGHTLY_TESTS=false

--- a/integration-tests/CI/trigger-nightly.yaml
+++ b/integration-tests/CI/trigger-nightly.yaml
@@ -47,8 +47,8 @@ spec:
             description: "the build url for the latest catalog"
           - name: previous-nightly-sha
             description: "the previous nightly"
-          - name: nightly-changed
-            description: "whether the catalog has changed since the last nightly"
+          - name: new-builds-available
+            description: "whether new CI builds are available since the last nightly"
           steps:
           - image: quay.io/rhoai-devops/base-runner:latest
             name: get-latest-catalog-ci-build-sha
@@ -90,10 +90,10 @@ spec:
 
               if [ -n "$PREVIOUS_SHA" ] && [ "$CATALOG_SHA" = "$PREVIOUS_SHA" ]; then
                 echo "No changes: catalog SHA matches previous nightly ($CATALOG_SHA)"
-                printf 'false' > "$(results.nightly-changed.path)"
+                printf 'false' > "$(results.new-builds-available.path)"
               else
                 echo "Changes detected (new=$CATALOG_SHA, previous=${PREVIOUS_SHA:-none})"
-                printf 'true' > "$(results.nightly-changed.path)"
+                printf 'true' > "$(results.new-builds-available.path)"
               fi
       - name: resolve-params
         description: resolves pipeline parameters for downstream tasks
@@ -122,8 +122,8 @@ spec:
               value: $(params.OVERRIDE_CHANNEL)
             - name: TRIGGER_NIGHTLY_TESTS
               value: $(params.TRIGGER_NIGHTLY_TESTS)
-            - name: NIGHTLY_CHANGED
-              value: $(tasks.choose-ci-build.results.nightly-changed)
+            - name: NEW_BUILDS_AVAILABLE
+              value: $(tasks.choose-ci-build.results.new-builds-available)
             - name: TRIGGER_NIGHTLY_TAG
               value: $(params.TRIGGER_NIGHTLY_TAG)
             script: |
@@ -138,6 +138,22 @@ spec:
               echo "Resolved channel: $CHANNEL"
               printf '%s' "$CHANNEL" > "$(results.channel.path)"
 
+              # Resolve tag decision
+              case "$TRIGGER_NIGHTLY_TAG" in
+                true|false|auto) ;;
+                *) echo "ERROR: invalid TRIGGER_NIGHTLY_TAG='$TRIGGER_NIGHTLY_TAG' (must be true/false/auto)"; exit 1 ;;
+              esac
+              if [ "$TRIGGER_NIGHTLY_TAG" = "false" ]; then
+                SHOULD_TAG_NIGHTLY=false
+              elif [ "$TRIGGER_NIGHTLY_TAG" = "true" ]; then
+                SHOULD_TAG_NIGHTLY=true
+              elif [ "$NEW_BUILDS_AVAILABLE" = "true" ]; then
+                SHOULD_TAG_NIGHTLY=true
+              else
+                SHOULD_TAG_NIGHTLY=false
+              fi
+              printf '%s' "$SHOULD_TAG_NIGHTLY" > "$(results.should-tag-nightly.path)"
+
               # Resolve test trigger decision
               case "$TRIGGER_NIGHTLY_TESTS" in
                 true|false|auto) ;;
@@ -150,31 +166,15 @@ spec:
               elif [ "$TRIGGER_NIGHTLY_TESTS" = "true" ]; then
                 SHOULD_TRIGGER_NIGHTLY_TESTS=true
                 TRIGGER_NIGHTLY_TESTS_REASON="smoke tests forced via TRIGGER_NIGHTLY_TESTS=true"
-              elif [ "$NIGHTLY_CHANGED" = "true" ]; then
+              elif [ "$SHOULD_TAG_NIGHTLY" = "true" ] && [ "$NEW_BUILDS_AVAILABLE" = "true" ]; then
                 SHOULD_TRIGGER_NIGHTLY_TESTS=true
-                TRIGGER_NIGHTLY_TESTS_REASON="smoke tests triggered (catalog changed)"
+                TRIGGER_NIGHTLY_TESTS_REASON="smoke tests triggered (new nightly tagged)"
               else
                 SHOULD_TRIGGER_NIGHTLY_TESTS=false
-                TRIGGER_NIGHTLY_TESTS_REASON="smoke tests skipped (catalog unchanged)"
+                TRIGGER_NIGHTLY_TESTS_REASON="smoke tests skipped (no new nightly to test)"
               fi
               printf '%s' "$SHOULD_TRIGGER_NIGHTLY_TESTS" > "$(results.should-trigger-tests.path)"
               printf '%s' "$TRIGGER_NIGHTLY_TESTS_REASON" > "$(results.trigger-tests-reason.path)"
-
-              # Resolve tag decision
-              case "$TRIGGER_NIGHTLY_TAG" in
-                true|false|auto) ;;
-                *) echo "ERROR: invalid TRIGGER_NIGHTLY_TAG='$TRIGGER_NIGHTLY_TAG' (must be true/false/auto)"; exit 1 ;;
-              esac
-              if [ "$TRIGGER_NIGHTLY_TAG" = "false" ]; then
-                SHOULD_TAG_NIGHTLY=false
-              elif [ "$TRIGGER_NIGHTLY_TAG" = "true" ]; then
-                SHOULD_TAG_NIGHTLY=true
-              elif [ "$NIGHTLY_CHANGED" = "true" ]; then
-                SHOULD_TAG_NIGHTLY=true
-              else
-                SHOULD_TAG_NIGHTLY=false
-              fi
-              printf '%s' "$SHOULD_TAG_NIGHTLY" > "$(results.should-tag-nightly.path)"
       - name: tag-nightly
         runAfter:
         - choose-ci-build
@@ -317,8 +317,8 @@ spec:
               value: $(tasks.choose-ci-build.results.previous-nightly-sha)
             - name: CHANNEL
               value: $(tasks.resolve-params.results.channel)
-            - name: NIGHTLY_CHANGED
-              value: $(tasks.choose-ci-build.results.nightly-changed)
+            - name: NEW_BUILDS_AVAILABLE
+              value: $(tasks.choose-ci-build.results.new-builds-available)
             - name: SHOULD_TAG_NIGHTLY
               value: $(tasks.resolve-params.results.should-tag-nightly)
             - name: TRIGGER_NIGHTLY_TESTS_REASON
@@ -350,7 +350,7 @@ spec:
                 fi
 
                 SLACK_ARGS+=(-f tracer-output.txt)
-              elif [ "$NIGHTLY_CHANGED" = "true" ] ; then
+              elif [ "$NEW_BUILDS_AVAILABLE" = "true" ] ; then
                 slack_message=":no_entry_sign: Nightly tagging skipped due to override (TRIGGER_NIGHTLY_TAG=false)"
                 SLACK_ARGS+=(-m "$slack_message")
               else

--- a/integration-tests/CI/trigger-nightly.yaml
+++ b/integration-tests/CI/trigger-nightly.yaml
@@ -319,6 +319,8 @@ spec:
               value: $(tasks.resolve-params.results.channel)
             - name: NIGHTLY_CHANGED
               value: $(tasks.choose-ci-build.results.nightly-changed)
+            - name: SHOULD_TAG_NIGHTLY
+              value: $(tasks.resolve-params.results.should-tag-nightly)
             - name: TRIGGER_NIGHTLY_TESTS_REASON
               value: $(tasks.resolve-params.results.trigger-tests-reason)
             - name: MESSAGE_TEMPLATE
@@ -334,7 +336,7 @@ spec:
               SLACK_ARGS=(-c "$CHANNEL")
               tracer.sh --odh -i "$LATEST_CATALOG_CI_IMAGE" --show-commits | tee tracer-output.txt
 
-              if [ "$NIGHTLY_CHANGED" = "true" ]; then
+              if [ "$NIGHTLY_CHANGED" = "true" ] && [ "$SHOULD_TAG_NIGHTLY" = "true" ]; then
                 SUBST_VARS='$LATEST_CATALOG_CI_IMAGE $LATEST_BUILD_METADATA_URL $BUILD_URL'
                 slack_message=$(echo "$MESSAGE_TEMPLATE" | envsubst "$SUBST_VARS")
                 SLACK_ARGS+=(-m "$slack_message")
@@ -348,6 +350,9 @@ spec:
                 fi
 
                 SLACK_ARGS+=(-f tracer-output.txt)
+              elif [ "$NIGHTLY_CHANGED" = "true" ]; then
+                slack_message=":no_entry_sign: Nightly tagging skipped (TRIGGER_NIGHTLY_TAG=false), but new catalog CI builds are available."
+                SLACK_ARGS+=(-m "$slack_message" -f tracer-output.txt)
               else
                 slack_message=":moon: No new nightly: no new catalog CI builds have run since the previous nightly."
                 SLACK_ARGS+=(-m "$slack_message" -f tracer-output.txt)

--- a/integration-tests/CI/trigger-nightly.yaml
+++ b/integration-tests/CI/trigger-nightly.yaml
@@ -26,10 +26,10 @@ spec:
         name: TRIGGER_SLACK
         type: string
         default: "true"
-      - description: Whether to tag the latest CI build as a nightly
+      - description: "Tag nightly: true (always), false (never), auto (only if changed)"
         name: TRIGGER_NIGHTLY_TAG
         type: string
-        default: "true"
+        default: "auto"
       - description: Override the Slack channel from the configmap
         name: OVERRIDE_CHANNEL
         type: string
@@ -107,6 +107,8 @@ spec:
             description: "whether smoke tests should be triggered"
           - name: trigger-tests-reason
             description: "explanation when tests are forced or disabled"
+          - name: should-tag-nightly
+            description: "whether the nightly tag should be applied"
           steps:
           - image: quay.io/rhoai-devops/base-runner:latest
             name: resolve
@@ -122,6 +124,8 @@ spec:
               value: $(params.TRIGGER_NIGHTLY_TESTS)
             - name: NIGHTLY_CHANGED
               value: $(tasks.choose-ci-build.results.nightly-changed)
+            - name: TRIGGER_NIGHTLY_TAG
+              value: $(params.TRIGGER_NIGHTLY_TAG)
             script: |
               #!/bin/bash
               set -e
@@ -154,9 +158,26 @@ spec:
               fi
               printf '%s' "$SHOULD_TRIGGER_NIGHTLY_TESTS" > "$(results.should-trigger-tests.path)"
               printf '%s' "$TRIGGER_NIGHTLY_TESTS_REASON" > "$(results.trigger-tests-reason.path)"
+
+              # Resolve tag decision
+              case "$TRIGGER_NIGHTLY_TAG" in
+                true|false|auto) ;;
+                *) echo "ERROR: invalid TRIGGER_NIGHTLY_TAG='$TRIGGER_NIGHTLY_TAG' (must be true/false/auto)"; exit 1 ;;
+              esac
+              if [ "$TRIGGER_NIGHTLY_TAG" = "false" ]; then
+                SHOULD_TAG_NIGHTLY=false
+              elif [ "$TRIGGER_NIGHTLY_TAG" = "true" ]; then
+                SHOULD_TAG_NIGHTLY=true
+              elif [ "$NIGHTLY_CHANGED" = "true" ]; then
+                SHOULD_TAG_NIGHTLY=true
+              else
+                SHOULD_TAG_NIGHTLY=false
+              fi
+              printf '%s' "$SHOULD_TAG_NIGHTLY" > "$(results.should-tag-nightly.path)"
       - name: tag-nightly
         runAfter:
         - choose-ci-build
+        - resolve-params
         description: Tags the latest ci build as nightly
         workspaces:
         - name: data
@@ -192,22 +213,14 @@ spec:
               value: $(workspaces.data.path)
             - name: AUTH_PATH
               value: /workspace/.docker/config.json
-            - name: TRIGGER_NIGHTLY_TAG
-              value: $(params.TRIGGER_NIGHTLY_TAG)
-            - name: NIGHTLY_CHANGED
-              value: $(tasks.choose-ci-build.results.nightly-changed)
+            - name: SHOULD_TAG_NIGHTLY
+              value: $(tasks.resolve-params.results.should-tag-nightly)
             script: |
               #!/bin/bash
               set -e
 
-              if [[ "$TRIGGER_NIGHTLY_TAG" != "true" ]]; then
-                echo "TRIGGER_NIGHTLY_TAG=$TRIGGER_NIGHTLY_TAG"
-                echo "proceeding without tagging a new nightly"
-                exit 0
-              fi
-
-              if [[ "$NIGHTLY_CHANGED" != "true" ]]; then
-                echo "Catalog unchanged from previous nightly, skipping tag"
+              if [[ "$SHOULD_TAG_NIGHTLY" != "true" ]]; then
+                echo "Skipping nightly tag (SHOULD_TAG_NIGHTLY=$SHOULD_TAG_NIGHTLY)"
                 exit 0
               fi
 

--- a/integration-tests/CI/trigger-nightly.yaml
+++ b/integration-tests/CI/trigger-nightly.yaml
@@ -150,6 +150,7 @@ spec:
                 SHOULD_TRIGGER_NIGHTLY_TESTS=true
               else
                 SHOULD_TRIGGER_NIGHTLY_TESTS=false
+                TRIGGER_NIGHTLY_TESTS_REASON="smoke tests skipped (catalog unchanged)"
               fi
               printf '%s' "$SHOULD_TRIGGER_NIGHTLY_TESTS" > "$(results.should-trigger-tests.path)"
               printf '%s' "$TRIGGER_NIGHTLY_TESTS_REASON" > "$(results.trigger-tests-reason.path)"
@@ -320,7 +321,6 @@ spec:
               tracer.sh --odh -i "$LATEST_CATALOG_CI_IMAGE" --show-commits | tee tracer-output.txt
 
               if [ "$NIGHTLY_CHANGED" = "true" ]; then
-
                 tracer-diff.sh --mode 2 --only-changes \
                   --old-label "previous nightly catalog" --new-label "this catalog" \
                   "--odh --digest $PREVIOUS_NIGHTLY_SHA" "--odh -i $LATEST_CATALOG_CI_IMAGE" \

--- a/integration-tests/CI/trigger-nightly.yaml
+++ b/integration-tests/CI/trigger-nightly.yaml
@@ -350,7 +350,7 @@ spec:
                 SLACK_ARGS+=(-f tracer-output.txt)
               else
                 slack_message=":moon: No new nightly: no new catalog CI builds have run since the previous nightly."
-                SLACK_ARGS+=(-m "$slack_message" -f tracer-output.txt )
+                SLACK_ARGS+=(-m "$slack_message" -f tracer-output.txt)
               fi
 
               if [ -n "$TRIGGER_NIGHTLY_TESTS_REASON" ]; then

--- a/integration-tests/CI/trigger-nightly.yaml
+++ b/integration-tests/CI/trigger-nightly.yaml
@@ -72,6 +72,32 @@ spec:
                 echo "No previous nightly found"
                 printf '%s' "" > "$(results.previous-nightly-sha.path)"
               fi
+      - name: resolve-slack-channel
+        description: resolves the Slack channel, applying override if set
+        taskSpec:
+          results:
+          - name: channel
+            description: "the resolved Slack channel to use"
+          steps:
+          - image: quay.io/rhoai-devops/base-runner:latest
+            name: resolve
+            env:
+            - name: DEFAULT_CHANNEL
+              valueFrom:
+                configMapKeyRef:
+                  name: slack-config
+                  key: odh-notification-channel
+            - name: OVERRIDE_CHANNEL
+              value: $(params.OVERRIDE_CHANNEL)
+            script: |
+              #!/bin/bash
+              set -e
+              CHANNEL="$DEFAULT_CHANNEL"
+              if [ -n "$OVERRIDE_CHANNEL" ]; then
+                CHANNEL="$OVERRIDE_CHANNEL"
+              fi
+              echo "Resolved channel: $CHANNEL"
+              printf '%s' "$CHANNEL" > "$(results.channel.path)"
       - name: tag-nightly
         runAfter:
         - choose-ci-build
@@ -184,6 +210,7 @@ spec:
           - "true"
         runAfter:
         - tag-nightly
+        - resolve-slack-channel
         workspaces:
         - name: data
           workspace: data
@@ -212,12 +239,7 @@ spec:
             - name: PREVIOUS_NIGHTLY_SHA
               value: $(tasks.choose-ci-build.results.previous-nightly-sha)
             - name: CHANNEL
-              valueFrom:
-                configMapKeyRef:
-                  name: slack-config
-                  key: odh-notification-channel
-            - name: OVERRIDE_CHANNEL
-              value: $(params.OVERRIDE_CHANNEL)
+              value: $(tasks.resolve-slack-channel.results.channel)
             - name: MESSAGE_TEMPLATE
               valueFrom:
                 configMapKeyRef:
@@ -227,10 +249,6 @@ spec:
             script: |
               #!/bin/bash
               set -eo pipefail
-
-              if [ -n "$OVERRIDE_CHANNEL" ]; then
-                CHANNEL="$OVERRIDE_CHANNEL"
-              fi
 
               tracer.sh --odh -i "$LATEST_CATALOG_CI_IMAGE" --show-commits | tee tracer-output.txt
 
@@ -272,6 +290,7 @@ spec:
         runAfter:
         - tag-nightly
         - slack-notification
+        - resolve-slack-channel
         workspaces:
         - name: data
           workspace: data
@@ -292,19 +311,10 @@ spec:
                   name: rhods-ci
                   key: secret
             - name: CHANNEL
-              valueFrom:
-                configMapKeyRef:
-                  name: slack-config
-                  key: odh-notification-channel
-            - name: OVERRIDE_CHANNEL
-              value: $(params.OVERRIDE_CHANNEL)
+              value: $(tasks.resolve-slack-channel.results.channel)
             script: |
               #!/bin/bash
               set -e
-
-              if [ -n "$OVERRIDE_CHANNEL" ]; then
-                CHANNEL="$OVERRIDE_CHANNEL"
-              fi
 
               TARGET=odh-stable
 


### PR DESCRIPTION
## Summary
- **Skip unchanged nightlies**: `choose-ci-build` now pins the floating catalog tag via `--raw` (single resolution to avoid races) and compares its manifest digest with the previous nightly (`new-builds-available` result). If no new builds are available, tagging and tests are skipped while Slack still gets a notification.
- **`resolve-params` task**: Consolidates channel override logic, tag decision (`should-tag-nightly`), and test trigger decision (`should-trigger-tests`, `trigger-tests-reason`) into one task, replacing the old `resolve-slack-channel`. Tag decision is resolved first so the test decision can depend on it. Both `slack-notification` and `trigger-nightly-tests` reference its results instead of duplicating logic.
- **`TRIGGER_NIGHTLY_TESTS` param**: Now supports three modes: `true` (always run), `false` (never run), `auto` (default — run only when a new nightly is tagged and new builds are available). The reason is reported as a Slack thread reply in all cases.
- **`TRIGGER_NIGHTLY_TAG` param**: Also changed to `auto` default and consolidated into `resolve-params` with the same `true`/`false`/`auto` semantics.
- **Consolidated Slack messaging**: The Slack message is gated on `SHOULD_TAG_NIGHTLY` — the full "new nightly available" template only sends when tagging actually happened. When tagging is skipped due to override, a separate `:no_entry_sign:` message is sent. When no new builds are available, the existing "no new nightly" message is sent. The tracer-diff is skipped on the first-ever nightly (no previous digest to compare against).

## Outcome truth table

| TAG param | TESTS param | NEW_BUILDS | Tags? | Tests? | Test reason |
|-----------|-------------|------------|-------|--------|-------------|
| `auto`    | `auto`      | true       | yes   | yes    | new nightly tagged |
| `auto`    | `auto`      | false      | no    | no     | no new nightly to test |
| `auto`    | `true`      | true       | yes   | yes    | forced via param |
| `auto`    | `true`      | false      | no    | yes    | forced via param (tests old nightly) |
| `auto`    | `false`     | true       | yes   | no     | disabled via param |
| `auto`    | `false`     | false      | no    | no     | disabled via param |
| `true`    | `auto`      | true       | yes   | yes    | new nightly tagged |
| `true`    | `auto`      | false      | yes   | no     | no new nightly to test (re-tags same image) |
| `true`    | `true`      | *          | yes   | yes    | forced via param |
| `true`    | `false`     | *          | yes   | no     | disabled via param |
| `false`   | `auto`      | *          | no    | no     | no new nightly to test |
| `false`   | `true`      | *          | no    | yes    | forced via param (tests old nightly) |
| `false`   | `false`     | *          | no    | no     | disabled via param |

## Test plan
- [ ] Run with a changed catalog (defaults) — verify tagging, full Slack notification with tracer diff, and test trigger all fire
- [x] Run with an unchanged catalog (defaults) — verify tagging is skipped, Slack sends "no new nightly" with tracer output, and tests are skipped
- [ ] Run with `TRIGGER_NIGHTLY_TESTS=true` and unchanged catalog — verify tests are forced and Slack thread reply says "smoke tests forced via TRIGGER_NIGHTLY_TESTS=true"
- [x] Run with `TRIGGER_NIGHTLY_TESTS=false` and changed catalog — verify tests are skipped and Slack thread reply says "smoke tests disabled via TRIGGER_NIGHTLY_TESTS=false"
- [x] Run with `TRIGGER_NIGHTLY_TAG=false` and changed catalog — verify tagging is skipped and Slack sends `:no_entry_sign:` message
- [ ] Run with no previous nightly tag — verify tracer-diff is skipped gracefully and notification still sends
- [x] Verify `OVERRIDE_CHANNEL` still works correctly via `resolve-params`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved nightly build detection by comparing catalog versions to identify new builds
  * Enhanced nightly test triggering with configurable control modes
  * Updated notification messaging for nightly promotion workflow with context-aware messages based on build status

<!-- end of auto-generated comment: release notes by coderabbit.ai -->