### PR TITLE
Add odh-batch-gateway-operator-ci PipelineRuns for odh-batch-gateway-operator

### DIFF
--- a/.github/workflows/odh-konflux-onboarder.yml
+++ b/.github/workflows/odh-konflux-onboarder.yml
@@ -33,6 +33,7 @@ on:
           - llama-stack-k8s-operator
           - llama-stack-provider-ragas
           - llama-stack-provider-trustyai-garak
+          - llm-d-batch-gateway-operator
           - llm-d-inference-scheduler
           - llm-d-kv-cache
           - llm-d-routing-sidecar

--- a/pipelineruns/llm-d-batch-gateway-operator/odh-batch-gateway-operator-pull-request.yaml
+++ b/pipelineruns/llm-d-batch-gateway-operator/odh-batch-gateway-operator-pull-request.yaml
@@ -1,0 +1,52 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/llm-d-batch-gateway-operator?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
+      == "$$TARGET_BRANCH$$"
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: opendatahub-builds
+    appstudio.openshift.io/component: odh-batch-gateway-operator-ci
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-batch-gateway-operator-on-pull-request
+  namespace: open-data-hub-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/opendatahub/odh-batch-gateway-operator:$$OUTPUT_IMAGE_TAG$$
+  - name: dockerfile
+    value: Dockerfile.konflux
+  - name: path-context
+    value: .
+  # additional params
+  - name: additional-tags
+    value:
+    - 'odh-pr-{{revision}}'
+  - name: pipeline-type
+    value: pull-request
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/opendatahub-io/odh-konflux-central.git
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipeline/multi-arch-container-build.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-odh-batch-gateway-operator-ci
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/pipelineruns/llm-d-batch-gateway-operator/odh-batch-gateway-operator-push.yaml
+++ b/pipelineruns/llm-d-batch-gateway-operator/odh-batch-gateway-operator-push.yaml
@@ -1,0 +1,47 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+#
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/llm-d-batch-gateway-operator?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "$$TARGET_BRANCH$$"
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: opendatahub-builds
+    appstudio.openshift.io/component: odh-batch-gateway-operator-ci
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-batch-gateway-operator-on-push
+  namespace: open-data-hub-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/opendatahub/odh-batch-gateway-operator:$$OUTPUT_IMAGE_TAG$$
+  - name: dockerfile
+    value: Dockerfile.konflux
+  - name: path-context
+    value: .
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/opendatahub-io/odh-konflux-central.git
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipeline/multi-arch-container-build.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-odh-batch-gateway-operator-ci
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}


### PR DESCRIPTION
Add Konflux CI PipelineRuns for 'odh-batch-gateway-operator' from repo 'llm-d-batch-gateway-operator'.

Product: ODH
Application: opendatahub-builds
Output image: quay.io/opendatahub/odh-batch-gateway-operator
Build type: CI
Source repo: https://github.com/opendatahub-io/llm-d-batch-gateway-operator @ main
Jira: https://redhat.atlassian.net/browse/RHOAIENG-64691

**Files changed:**
- `pipelineruns/llm-d-batch-gateway-operator/odh-batch-gateway-operator-push.yaml` (new)
- `pipelineruns/llm-d-batch-gateway-operator/odh-batch-gateway-operator-pull-request.yaml` (new)
- `.github/workflows/odh-konflux-onboarder.yml` (updated: added llm-d-batch-gateway-operator to components list)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated build pipeline support for the LLM D Batch Gateway Operator, enabling automated builds on pull requests and Git push events.
  * Updated CI workflow inputs to include the new component as a selectable deployment option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->