### PR TITLE
Add odh-llm-d-async-ci PipelineRuns for odh-llm-d-async

### DIFF
--- a/.github/workflows/odh-konflux-onboarder.yml
+++ b/.github/workflows/odh-konflux-onboarder.yml
@@ -33,6 +33,7 @@ on:
           - llama-stack-k8s-operator
           - llama-stack-provider-ragas
           - llama-stack-provider-trustyai-garak
+          - llm-d-async
           - llm-d-inference-scheduler
           - llm-d-kv-cache
           - llm-d-routing-sidecar

--- a/pipelineruns/llm-d-async/odh-llm-d-async-pull-request.yaml
+++ b/pipelineruns/llm-d-async/odh-llm-d-async-pull-request.yaml
@@ -1,0 +1,52 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/llm-d-async?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
+      == "$$TARGET_BRANCH$$"
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: opendatahub-builds
+    appstudio.openshift.io/component: odh-llm-d-async-ci
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-llm-d-async-on-pull-request
+  namespace: open-data-hub-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/opendatahub/odh-llm-d-async:$$OUTPUT_IMAGE_TAG$$
+  - name: dockerfile
+    value: Dockerfile.konflux
+  - name: path-context
+    value: ./
+  # additional params
+  - name: additional-tags
+    value:
+    - 'odh-pr-{{revision}}'
+  - name: pipeline-type
+    value: pull-request
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/opendatahub-io/odh-konflux-central.git
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipeline/multi-arch-container-build.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-odh-llm-d-async-ci
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/pipelineruns/llm-d-async/odh-llm-d-async-push.yaml
+++ b/pipelineruns/llm-d-async/odh-llm-d-async-push.yaml
@@ -1,0 +1,47 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+#
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/llm-d-async?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "$$TARGET_BRANCH$$"
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: opendatahub-builds
+    appstudio.openshift.io/component: odh-llm-d-async-ci
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-llm-d-async-on-push
+  namespace: open-data-hub-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/opendatahub/odh-llm-d-async:$$OUTPUT_IMAGE_TAG$$
+  - name: dockerfile
+    value: Dockerfile.konflux
+  - name: path-context
+    value: ./
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/opendatahub-io/odh-konflux-central.git
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipeline/multi-arch-container-build.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-odh-llm-d-async-ci
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}


### PR DESCRIPTION
Add Konflux CI PipelineRuns for 'odh-llm-d-async' from repo 'llm-d-async'.

Product: ODH
Application: opendatahub-builds
Output image: quay.io/opendatahub/odh-llm-d-async
Build type: CI
Source repo: https://github.com/opendatahub-io/llm-d-async @ main
Jira: https://redhat.atlassian.net/browse/RHOAIENG-64606

**Files changed:**
- `pipelineruns/llm-d-async/odh-llm-d-async-push.yaml` (new)
- `pipelineruns/llm-d-async/odh-llm-d-async-pull-request.yaml` (new)
- `.github/workflows/odh-konflux-onboarder.yml` (updated: added llm-d-async to components list)