### PR TITLE
Add odh-trainer-operator-ci PipelineRuns for odh-trainer-operator

### DIFF
--- a/.github/workflows/odh-konflux-onboarder.yml
+++ b/.github/workflows/odh-konflux-onboarder.yml
@@ -66,6 +66,7 @@ on:
           - spark-operator
           - text-generation-inference
           - trainer
+          - trainer-operator
           - training-operator
           - trustyai-explainability
           - trustyai-service-operator

--- a/pipelineruns/trainer-operator/odh-trainer-operator-pull-request.yaml
+++ b/pipelineruns/trainer-operator/odh-trainer-operator-pull-request.yaml
@@ -1,0 +1,52 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/trainer-operator?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
+      == "$$TARGET_BRANCH$$"
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: opendatahub-builds
+    appstudio.openshift.io/component: odh-trainer-operator-ci
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-trainer-operator-on-pull-request
+  namespace: open-data-hub-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/opendatahub/odh-trainer-operator:$$OUTPUT_IMAGE_TAG$$
+  - name: dockerfile
+    value: Dockerfile
+  - name: path-context
+    value: ./
+  # additional params
+  - name: additional-tags
+    value:
+    - 'odh-pr-{{revision}}'
+  - name: pipeline-type
+    value: pull-request
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/opendatahub-io/odh-konflux-central.git
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipeline/multi-arch-container-build.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-odh-trainer-operator-ci
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/pipelineruns/trainer-operator/odh-trainer-operator-push.yaml
+++ b/pipelineruns/trainer-operator/odh-trainer-operator-push.yaml
@@ -1,0 +1,47 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+#
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/trainer-operator?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "$$TARGET_BRANCH$$"
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: opendatahub-builds
+    appstudio.openshift.io/component: odh-trainer-operator-ci
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-trainer-operator-on-push
+  namespace: open-data-hub-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/opendatahub/odh-trainer-operator:$$OUTPUT_IMAGE_TAG$$
+  - name: dockerfile
+    value: Dockerfile
+  - name: path-context
+    value: ./
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/opendatahub-io/odh-konflux-central.git
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipeline/multi-arch-container-build.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-odh-trainer-operator-ci
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}


### PR DESCRIPTION
Add Konflux CI PipelineRuns for 'odh-trainer-operator' from repo 'trainer-operator'.

Product: ODH
Application: opendatahub-builds
Output image: quay.io/opendatahub/odh-trainer-operator
Build type: CI
Source repo: https://github.com/opendatahub-io/trainer-operator @ main
Jira: https://redhat.atlassian.net/browse/RHOAIENG-65430

**Files changed:**
- `pipelineruns/trainer-operator/odh-trainer-operator-push.yaml` (new)
- `pipelineruns/trainer-operator/odh-trainer-operator-pull-request.yaml` (new)
- `.github/workflows/odh-konflux-onboarder.yml` (updated: added trainer-operator to components list)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended the workflow configuration to include trainer-operator as an available component option.
  * Added automated build pipelines that trigger on pull requests and push events for the trainer-operator component, supporting multi-architecture container builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->