### PR TITLE
Add odh-ai-gateway-operator-ci PipelineRuns for odh-ai-gateway-operator

### DIFF
--- a/.github/workflows/odh-konflux-onboarder.yml
+++ b/.github/workflows/odh-konflux-onboarder.yml
@@ -10,6 +10,7 @@ on:
         options:
           # Add all valid components here in alphabetical order
           - agents-operator
+          - ai-gateway-operator
           - ai-gateway-payload-processing
           - batch-gateway
           - caikit-nlp

--- a/pipelineruns/ai-gateway-operator/odh-ai-gateway-operator-pull-request.yaml
+++ b/pipelineruns/ai-gateway-operator/odh-ai-gateway-operator-pull-request.yaml
@@ -1,0 +1,52 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/ai-gateway-operator?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
+      == "$$TARGET_BRANCH$$"
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: opendatahub-builds
+    appstudio.openshift.io/component: odh-ai-gateway-operator-ci
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-ai-gateway-operator-on-pull-request
+  namespace: open-data-hub-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/opendatahub/odh-ai-gateway-operator:$$OUTPUT_IMAGE_TAG$$
+  - name: dockerfile
+    value: Containerfile.konflux
+  - name: path-context
+    value: ./
+  # additional params
+  - name: additional-tags
+    value:
+    - 'odh-pr-{{revision}}'
+  - name: pipeline-type
+    value: pull-request
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/opendatahub-io/odh-konflux-central.git
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipeline/multi-arch-container-build.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-odh-ai-gateway-operator-ci
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/pipelineruns/ai-gateway-operator/odh-ai-gateway-operator-push.yaml
+++ b/pipelineruns/ai-gateway-operator/odh-ai-gateway-operator-push.yaml
@@ -1,0 +1,47 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+#
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/ai-gateway-operator?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "$$TARGET_BRANCH$$"
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: opendatahub-builds
+    appstudio.openshift.io/component: odh-ai-gateway-operator-ci
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-ai-gateway-operator-on-push
+  namespace: open-data-hub-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/opendatahub/odh-ai-gateway-operator:$$OUTPUT_IMAGE_TAG$$
+  - name: dockerfile
+    value: Containerfile.konflux
+  - name: path-context
+    value: ./
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/opendatahub-io/odh-konflux-central.git
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipeline/multi-arch-container-build.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-odh-ai-gateway-operator-ci
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}


### PR DESCRIPTION
Add Konflux CI PipelineRuns for 'odh-ai-gateway-operator' from repo 'ai-gateway-operator'.

Product: ODH
Application: opendatahub-builds
Output image: quay.io/opendatahub/odh-ai-gateway-operator
Build type: CI
Source repo: https://github.com/opendatahub-io/ai-gateway-operator @ main
Jira: https://redhat.atlassian.net/browse/RHOAIENG-65493

**Files changed:**
- `pipelineruns/ai-gateway-operator/odh-ai-gateway-operator-push.yaml` (new)
- `pipelineruns/ai-gateway-operator/odh-ai-gateway-operator-pull-request.yaml` (new)
- `.github/workflows/odh-konflux-onboarder.yml` (updated: added ai-gateway-operator to components list)