### PR TITLE
Add odh-authbridge-proxy-ci PipelineRuns for odh-authbridge-proxy

### DIFF
--- a/pipelineruns/agents-operator/odh-authbridge-proxy-pull-request.yaml
+++ b/pipelineruns/agents-operator/odh-authbridge-proxy-pull-request.yaml
@@ -1,0 +1,52 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/agents-operator?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
+      == "$$TARGET_BRANCH$$"
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: opendatahub-builds
+    appstudio.openshift.io/component: odh-authbridge-proxy-ci
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-authbridge-proxy-on-pull-request
+  namespace: open-data-hub-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/opendatahub/odh-authbridge-proxy:odh-pr
+  - name: dockerfile
+    value: cmd/authbridge-proxy/Dockerfile
+  - name: path-context
+    value: authbridge/
+  # additional params
+  - name: additional-tags
+    value:
+    - 'odh-pr-{{revision}}'
+  - name: pipeline-type
+    value: pull-request
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/opendatahub-io/odh-konflux-central.git
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipeline/multi-arch-container-build.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-odh-authbridge-proxy-ci
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/pipelineruns/agents-operator/odh-authbridge-proxy-push.yaml
+++ b/pipelineruns/agents-operator/odh-authbridge-proxy-push.yaml
@@ -1,0 +1,47 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+#
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/agents-operator?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "$$TARGET_BRANCH$$"
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: opendatahub-builds
+    appstudio.openshift.io/component: odh-authbridge-proxy-ci
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-authbridge-proxy-on-push
+  namespace: open-data-hub-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/opendatahub/odh-authbridge-proxy:odh-stable
+  - name: dockerfile
+    value: cmd/authbridge-proxy/Dockerfile
+  - name: path-context
+    value: authbridge/
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/opendatahub-io/odh-konflux-central.git
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipeline/multi-arch-container-build.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-odh-authbridge-proxy-ci
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}


### PR DESCRIPTION
Add Konflux CI PipelineRuns for 'odh-authbridge-proxy' from repo 'agents-operator'.

Product: ODH
Application: opendatahub-builds
Output image: quay.io/opendatahub/odh-authbridge-proxy
Build type: CI
Source repo: https://github.com/opendatahub-io/agents-operator @ main
Jira: https://redhat.atlassian.net/browse/RHOAIENG-66069

**Files added:**
- `pipelineruns/agents-operator/odh-authbridge-proxy-push.yaml` (new)
- `pipelineruns/agents-operator/odh-authbridge-proxy-pull-request.yaml` (new)

Note: `agents-operator` is already in the onboarder workflow component list — no workflow update needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated pipeline configurations for multi-architecture container image builds triggered on pull requests and push events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->