### PR TITLE
Disable automatic early-gate test triggering

### DIFF
--- a/early-gate/early-gate-component-pipeline.yaml
+++ b/early-gate/early-gate-component-pipeline.yaml
@@ -143,7 +143,7 @@ spec:
     description: Quay tag used for image lookups by processors
   - name: enable-early-gate-testing
     type: string
-    default: "true"
+    default: "false"
     description: Triggers early gate test pipeline on comment /early-gate-test
 
   results:

--- a/early-gate/early-gate-operator-pipeline.yaml
+++ b/early-gate/early-gate-operator-pipeline.yaml
@@ -143,7 +143,7 @@ spec:
     description: Quay tag used for image lookups by processors
   - name: enable-early-gate-testing
     type: string
-    default: "true"
+    default: "false"
     description: Triggers early gate test pipeline on comment /early-gate-test
 
   results:


### PR DESCRIPTION
Changed enable-early-gate-testing default from "true" to "false" in both component and operator pipelines. This prevents automatic test execution after builds complete.

Tests now only run when explicitly triggered via /early-gate-test comment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Early gate testing is now disabled by default. Teams requiring early gate testing must explicitly enable this setting to restore the previous behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->