### PR TITLE
Bump operator go version to 1.26

### DIFF
--- a/integration-tests/opendatahub-operator/Dockerfile.operator
+++ b/integration-tests/opendatahub-operator/Dockerfile.operator
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.25.7-1772454089
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26
 User 0
 RUN yum install -y git jq wget tar python3 pip podman skopeo make gcc automake binutils && \
     yum clean all && rm -rf /var/cache/dnf/*


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Bumping this, with the assumption that it's what gets used to update the `operator` tag of `quay.io/rhoai/rhoai-task-toolset`. We need that to be 1.26 now, because we've bumped our go.mod to 1.26, and the `Red Hat Konflux / odh-operator-ci-e2e-its-manual / odh-operator-ci` pipeline is failing as a result.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build environment tooling to a newer version to improve build reliability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->