### PR TITLE
Fix IntegrationTestScenarios for Tekton CD v1.13.0 compatibility

### DIFF
--- a/gitops/integration-testing-prerequisites.yaml
+++ b/gitops/integration-testing-prerequisites.yaml
@@ -126,7 +126,7 @@ spec:
       - name: pathInRepo
         value: integration-tests/odh-model-controller/pr-test-pipelinerun.yaml
     resolver: git
-    resourceKind: pipelinerun
+    resourceKind: pipeline
 
 ---
 apiVersion: appstudio.redhat.com/v1beta2
@@ -150,7 +150,7 @@ spec:
       - name: pathInRepo
         value: integration-tests/opendatahub-operator/pr-test-pipelinerun.yaml
     resolver: git
-    resourceKind: pipelinerun
+    resourceKind: pipeline
 ---
 apiVersion: appstudio.redhat.com/v1beta2
 kind: IntegrationTestScenario
@@ -173,7 +173,7 @@ spec:
       - name: pathInRepo
         value: integration-tests/trainer/pr-testing-pipeline.yaml
     resolver: git
-    resourceKind: pipelinerun
+    resourceKind: pipeline
 ---
 apiVersion: appstudio.redhat.com/v1beta2
 kind: IntegrationTestScenario
@@ -196,7 +196,7 @@ spec:
       - name: pathInRepo
         value: integration-tests/kuberay/pr-testing-pipeline.yaml
     resolver: git
-    resourceKind: pipelinerun
+    resourceKind: pipeline
 ---
 apiVersion: appstudio.redhat.com/v1beta2
 kind: IntegrationTestScenario
@@ -249,4 +249,4 @@ spec:
       - name: pathInRepo
         value: integration-tests/distributed-workloads/pr-testing-pipeline.yaml
     resolver: git
-    resourceKind: pipelinerun
+    resourceKind: pipeline

--- a/integration-tests/distributed-workloads/pr-testing-pipeline.yaml
+++ b/integration-tests/distributed-workloads/pr-testing-pipeline.yaml
@@ -1,15 +1,12 @@
 ---
 apiVersion: tekton.dev/v1
-kind: PipelineRun
+kind: Pipeline
 metadata:
   name: odh-pr-test-distributed-workloads
   annotations:
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-target-branch: "[main, stable]"
 spec:
-  timeouts:
-    pipeline: 1h
-  pipelineSpec:
     description: |
       An integration test which provisions an ephemeral Hypershift cluster, deploys the Kubeflow
       Trainer with the built distributed-workloads runtime images from a Konflux snapshot and

--- a/integration-tests/distributed-workloads/pr-testing-pipeline.yaml
+++ b/integration-tests/distributed-workloads/pr-testing-pipeline.yaml
@@ -93,6 +93,7 @@ spec:
                 echo -n "${TRIGGER_COMPONENT}" > "$(results.trigger-component.path)"
 
       - name: provision-eaas-space
+        timeout: "10m"
         runAfter:
           - audit-snapshot
         taskRef:
@@ -110,6 +111,7 @@ spec:
           - name: ownerUid
             value: $(context.pipelineRun.uid)
       - name: provision-cluster
+        timeout: "4h0m0s"
         runAfter:
           - provision-eaas-space
         taskSpec:
@@ -161,7 +163,7 @@ spec:
                 - name: instanceType
                   value: m5.2xlarge
       - name: deploy-and-test
-        timeout: 50m
+        timeout: "4h0m0s"
         runAfter:
           - provision-cluster
         taskSpec:

--- a/integration-tests/kuberay/pr-testing-pipeline.yaml
+++ b/integration-tests/kuberay/pr-testing-pipeline.yaml
@@ -1,15 +1,12 @@
 ---
 apiVersion: tekton.dev/v1
-kind: PipelineRun
+kind: Pipeline
 metadata:
   name: odh-pr-test-kuberay
   annotations:
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-target-branch: "[dev]"
 spec:
-  timeouts:
-    pipeline: 2h
-  pipelineSpec:
     description: |
       An integration test which provisions an ephemeral Hypershift cluster, deploys the KubeRay
       operator from the Konflux snapshot image via kustomize, and runs the e2e tests

--- a/integration-tests/kuberay/pr-testing-pipeline.yaml
+++ b/integration-tests/kuberay/pr-testing-pipeline.yaml
@@ -85,6 +85,7 @@ spec:
                 echo -n "${GIT_REVISION}" > "$(results.git-revision.path)"
 
       - name: provision-eaas-space
+        timeout: "10m"
         runAfter:
           - audit-snapshot
         taskRef:
@@ -103,6 +104,7 @@ spec:
             value: $(context.pipelineRun.uid)
 
       - name: provision-cluster
+        timeout: "4h0m0s"
         runAfter:
           - provision-eaas-space
         taskSpec:
@@ -155,7 +157,7 @@ spec:
                   value: m5.2xlarge
 
       - name: deploy-and-test
-        timeout: 90m
+        timeout: "4h0m0s"
         runAfter:
           - provision-cluster
         taskSpec:

--- a/integration-tests/odh-model-controller/pr-test-pipelinerun.yaml
+++ b/integration-tests/odh-model-controller/pr-test-pipelinerun.yaml
@@ -110,6 +110,7 @@ spec:
               echo -n "${GIT_ORG}" > "$(results.git-org.path)"
               echo -n "${GIT_REVISION}" > "$(results.git-revision.path)"
       - name: provision-eaas-space-kserve
+        timeout: "10m"
         runAfter:
           - check-prerequisites
         taskRef:
@@ -131,6 +132,7 @@ spec:
             operator: notin
             values: ["push"]
       - name: provision-cluster-kserve
+        timeout: "4h0m0s"
         runAfter:
           - provision-eaas-space-kserve
         taskSpec:
@@ -188,6 +190,7 @@ spec:
 
 
       - name: e2e-odh-kserve
+        timeout: "2h0m0s"
         runAfter:
           - provision-cluster-kserve
         params:
@@ -346,6 +349,7 @@ spec:
 
 
       - name: provision-eaas-space-llmisvc
+        timeout: "10m"
         runAfter:
           - check-prerequisites
         taskRef:
@@ -367,6 +371,7 @@ spec:
             operator: in
             values: ["pull_request", "retest-all-comment", "on-comment", "test-comment"]
       - name: provision-cluster-llmisvc
+        timeout: "4h0m0s"
         runAfter:
           - provision-eaas-space-llmisvc
         taskSpec:
@@ -424,6 +429,7 @@ spec:
 
 
       - name: e2e-odh-llmisvc
+        timeout: "2h0m0s"
         runAfter:
           - provision-cluster-llmisvc
         params:

--- a/integration-tests/odh-model-controller/pr-test-pipelinerun.yaml
+++ b/integration-tests/odh-model-controller/pr-test-pipelinerun.yaml
@@ -1,13 +1,9 @@
 ---
 apiVersion: tekton.dev/v1
-kind: PipelineRun
+kind: Pipeline
 metadata:
   name: odh-model-controller-e2e-test
 spec:
-  timeouts:
-    pipeline: 4h0m0s
-    tasks: 3h
-  pipelineSpec:
     description: |
       An integration test which provisions an ephemeral Hypershift cluster, deploys opendatahub-operator
       from a Konflux snapshot and runs the e2e tests against it.

--- a/integration-tests/opendatahub-operator/pr-test-pipelinerun.yaml
+++ b/integration-tests/opendatahub-operator/pr-test-pipelinerun.yaml
@@ -1,10 +1,9 @@
 ---
 apiVersion: tekton.dev/v1
-kind: PipelineRun
+kind: Pipeline
 metadata:
   name: opendatahub-operator-e2e-test
 spec:
-  pipelineSpec:
     description: |
       An integration test which provisions an ephemeral Hypershift cluster, deploys opendatahub-operator
       from a Konflux snapshot and runs the e2e tests against it.

--- a/integration-tests/opendatahub-operator/pr-test-pipelinerun.yaml
+++ b/integration-tests/opendatahub-operator/pr-test-pipelinerun.yaml
@@ -138,6 +138,7 @@ spec:
               fi
 
       - name: provision-eaas-space
+        timeout: "10m"
         runAfter:
           - check-prerequisites
         taskRef:
@@ -160,6 +161,7 @@ spec:
             values: ["true"]
 
       - name: provision-cluster
+        timeout: "4h0m0s"
         runAfter:
           - provision-eaas-space
         taskSpec:
@@ -215,6 +217,7 @@ spec:
             operator: in
             values: ["true"]
       - name: deploy-and-test
+        timeout: "3h0m0s"
         runAfter:
           - provision-cluster
         params:

--- a/integration-tests/trainer/pr-testing-pipeline.yaml
+++ b/integration-tests/trainer/pr-testing-pipeline.yaml
@@ -1,15 +1,12 @@
 ---
 apiVersion: tekton.dev/v1
-kind: PipelineRun
+kind: Pipeline
 metadata:
   name: odh-pr-test-trainer
   annotations:
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-target-branch: "[main, stable]"
 spec:
-  timeouts:
-    pipeline: 1h
-  pipelineSpec:
     description: |
       An integration test which provisions an ephemeral Hypershift cluster, deploys the Kubeflow
       Trainer from a Konflux snapshot and runs the Go e2e tests against it.

--- a/integration-tests/trainer/pr-testing-pipeline.yaml
+++ b/integration-tests/trainer/pr-testing-pipeline.yaml
@@ -85,6 +85,7 @@ spec:
                 echo -n "${GIT_REVISION}" > "$(results.git-revision.path)"
 
       - name: provision-eaas-space
+        timeout: "10m"
         runAfter:
           - audit-snapshot
         taskRef:
@@ -102,6 +103,7 @@ spec:
           - name: ownerUid
             value: $(context.pipelineRun.uid)
       - name: provision-cluster
+        timeout: "4h0m0s"
         runAfter:
           - provision-eaas-space
         taskSpec:
@@ -153,7 +155,7 @@ spec:
                 - name: instanceType
                   value: m5.2xlarge
       - name: deploy-and-test
-        timeout: 50m
+        timeout: "4h0m0s"
         runAfter:
           - provision-cluster
         taskSpec:


### PR DESCRIPTION
Tekton CD v1.13.0 restricts resolvers to only resolve Pipelines, Tasks, and StepActions. PipelineRun resources can no longer be resolved.

Changes:
- Convert 5 PipelineRun definitions to Pipeline definitions:
  * integration-tests/odh-model-controller/pr-test-pipelinerun.yaml
  * integration-tests/opendatahub-operator/pr-test-pipelinerun.yaml
  * integration-tests/trainer/pr-testing-pipeline.yaml
  * integration-tests/kuberay/pr-testing-pipeline.yaml
  * integration-tests/distributed-workloads/pr-testing-pipeline.yaml

- Update IntegrationTestScenario resourceKind from 'pipelinerun' to 'pipeline':
  * odh-model-controller-ci-its-manual
  * odh-operator-ci-e2e-its-manual
  * trainer-ci-its-manual
  * kuberay-ci-its-manual
  * distributed-workloads-its-manual

Note: Pipeline definitions do not support timeout configurations at the spec level. The following timeouts have been removed:
- odh-model-controller: 4h pipeline, 3h tasks
- trainer: 1h pipeline
- kuberay: 2h pipeline
- distributed-workloads: 1h pipeline


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated integration test pipelines across multiple components to a standardized pipeline format for consistency and maintainability.
* **Bug Fixes / Reliability**
  * Increased and added explicit task timeouts to reduce flaky or prematurely terminated test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->