### PR TITLE
Add odh-llm-d-router-endpoint-picker-ci PipelineRuns for odh-llm-d-router-endpoint-picker

### DIFF
--- a/pipelineruns/llm-d-router/odh-llm-d-router-endpoint-picker-pull-request.yaml
+++ b/pipelineruns/llm-d-router/odh-llm-d-router-endpoint-picker-pull-request.yaml
@@ -1,0 +1,52 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/llm-d-router?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
+      == "$$TARGET_BRANCH$$"
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: opendatahub-builds
+    appstudio.openshift.io/component: odh-llm-d-router-endpoint-picker-ci
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-llm-d-router-endpoint-picker-on-pull-request
+  namespace: open-data-hub-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/opendatahub/odh-llm-d-router-endpoint-picker:$$OUTPUT_IMAGE_TAG$$
+  - name: dockerfile
+    value: Dockerfile.epp.konflux
+  - name: path-context
+    value: .
+  # additional params
+  - name: additional-tags
+    value:
+    - 'odh-pr-{{revision}}'
+  - name: pipeline-type
+    value: pull-request
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/opendatahub-io/odh-konflux-central.git
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipeline/multi-arch-container-build.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-odh-llm-d-router-endpoint-picker-ci
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/pipelineruns/llm-d-router/odh-llm-d-router-endpoint-picker-push.yaml
+++ b/pipelineruns/llm-d-router/odh-llm-d-router-endpoint-picker-push.yaml
@@ -1,0 +1,47 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+#
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/llm-d-router?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "$$TARGET_BRANCH$$"
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: opendatahub-builds
+    appstudio.openshift.io/component: odh-llm-d-router-endpoint-picker-ci
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-llm-d-router-endpoint-picker-on-push
+  namespace: open-data-hub-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/opendatahub/odh-llm-d-router-endpoint-picker:$$OUTPUT_IMAGE_TAG$$
+  - name: dockerfile
+    value: Dockerfile.epp.konflux
+  - name: path-context
+    value: .
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/opendatahub-io/odh-konflux-central.git
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipeline/multi-arch-container-build.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-odh-llm-d-router-endpoint-picker-ci
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}


### PR DESCRIPTION
Add Konflux CI PipelineRuns for 'odh-llm-d-router-endpoint-picker' from repo 'llm-d-router'.

Product: ODH
Application: opendatahub-builds
Output image: quay.io/opendatahub/odh-llm-d-router-endpoint-picker
Build type: CI
Source repo: https://github.com/opendatahub-io/llm-d-router @ main
Jira: https://redhat.atlassian.net/browse/RHOAIENG-67194

**Files changed:**
- `pipelineruns/llm-d-router/odh-llm-d-router-endpoint-picker-push.yaml` (new)
- `pipelineruns/llm-d-router/odh-llm-d-router-endpoint-picker-pull-request.yaml` (new)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD pipeline automation for the LLM D Router component, enabling automated multi-architecture container builds triggered on pull requests and push events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->