### PR TITLE
Add odh-latency-predictor-training-ci PipelineRuns for odh-latency-predictor-training

### DIFF
--- a/.github/workflows/odh-konflux-onboarder.yml
+++ b/.github/workflows/odh-konflux-onboarder.yml
@@ -37,6 +37,7 @@ on:
           - llm-d-batch-gateway-operator
           - llm-d-async
           - llm-d-kv-cache
+          - llm-d-latency-predictor
           - llm-d-router
           - lm-evaluation-harness
           - ml-metadata

--- a/pipelineruns/llm-d-latency-predictor/odh-latency-predictor-training-pull-request.yaml
+++ b/pipelineruns/llm-d-latency-predictor/odh-latency-predictor-training-pull-request.yaml
@@ -1,0 +1,52 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/llm-d-latency-predictor?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
+      == "$$TARGET_BRANCH$$"
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: opendatahub-builds
+    appstudio.openshift.io/component: odh-latency-predictor-training-ci
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-latency-predictor-training-on-pull-request
+  namespace: open-data-hub-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/opendatahub/odh-latency-predictor-training:$$OUTPUT_IMAGE_TAG$$
+  - name: dockerfile
+    value: Dockerfile-training
+  - name: path-context
+    value: .
+  # additional params
+  - name: additional-tags
+    value:
+    - 'odh-pr-{{revision}}'
+  - name: pipeline-type
+    value: pull-request
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/opendatahub-io/odh-konflux-central.git
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipeline/multi-arch-container-build.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-odh-latency-predictor-training-ci
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/pipelineruns/llm-d-latency-predictor/odh-latency-predictor-training-push.yaml
+++ b/pipelineruns/llm-d-latency-predictor/odh-latency-predictor-training-push.yaml
@@ -1,0 +1,47 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+#
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/llm-d-latency-predictor?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "$$TARGET_BRANCH$$"
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: opendatahub-builds
+    appstudio.openshift.io/component: odh-latency-predictor-training-ci
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-latency-predictor-training-on-push
+  namespace: open-data-hub-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/opendatahub/odh-latency-predictor-training:$$OUTPUT_IMAGE_TAG$$
+  - name: dockerfile
+    value: Dockerfile-training
+  - name: path-context
+    value: .
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/opendatahub-io/odh-konflux-central.git
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipeline/multi-arch-container-build.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-odh-latency-predictor-training-ci
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}


### PR DESCRIPTION
Add Konflux CI PipelineRuns for 'odh-latency-predictor-training' from repo 'llm-d-latency-predictor'.

Product: ODH
Application: opendatahub-builds
Output image: quay.io/opendatahub/odh-latency-predictor-training
Build type: CI
Source repo: https://github.com/opendatahub-io/llm-d-latency-predictor @ main
Jira: https://redhat.atlassian.net/browse/RHOAIENG-68558

**Files changed:**
- `pipelineruns/llm-d-latency-predictor/odh-latency-predictor-training-push.yaml` (new)
- `pipelineruns/llm-d-latency-predictor/odh-latency-predictor-training-pull-request.yaml` (new)
- `.github/workflows/odh-konflux-onboarder.yml` (updated: added llm-d-latency-predictor to components list)