### PR TITLE
Exclude tracing from kserve LLMISvc E2E

### DIFF
--- a/integration-tests/kserve/pr-group-testing-pipeline.yaml
+++ b/integration-tests/kserve/pr-group-testing-pipeline.yaml
@@ -1560,7 +1560,7 @@ spec:
             COMPONENT_NAME=odh-kserve-llmisvc-controller-ci
             export LLMISVC_CONTROLLER_IMAGE=$(jq -r --arg component_name "${COMPONENT_NAME}" '.[$component_name].image' <<< "${SNAPSHOT}")
 
-            ./test/scripts/openshift-ci/run-e2e-tests.sh "llminferenceservice and cluster_cpu and not autoscaling" 2 "llm-d"
+            ./test/scripts/openshift-ci/run-e2e-tests.sh "llminferenceservice and cluster_cpu and not autoscaling and not tracing" 2 "llm-d"
             echo "success" > "$STATUS_FILE"
         - name: must-gather
           onError: continue

--- a/integration-tests/odh-model-controller/pr-test-pipelinerun.yaml
+++ b/integration-tests/odh-model-controller/pr-test-pipelinerun.yaml
@@ -535,7 +535,7 @@ spec:
                   echo "LLMD_ROUTING_SIDECAR_IMAGE=${LLMD_ROUTING_SIDECAR_IMAGE}"
                   echo "KUBE_RBAC_PROXY_IMAGE=${KUBE_RBAC_PROXY_IMAGE}"
 
-                  ./test/scripts/openshift-ci/run-e2e-tests.sh "llminferenceservice and (cluster_cpu and cluster_single_node) and not autoscaling" 2 "llm-d"
+                  ./test/scripts/openshift-ci/run-e2e-tests.sh "llminferenceservice and (cluster_cpu and cluster_single_node) and not autoscaling and not tracing" 2 "llm-d"
                 popd
             - name: must-gather
               onError: continue


### PR DESCRIPTION
## Summary

Adds `and not tracing` to the pytest marker for the LLMISvc E2E tests in both the kserve and odh-model-controller pipelines.

Jaeger/OpenTelemetry tracing infrastructure is not provisioned in these test clusters. Without it, tracing tests fail because the required collector endpoints are unavailable.

This matches the pattern already used in the upstream `e2e-test-llmisvc.yaml` GHA workflow, which excludes tracing from its basic job and runs a dedicated tracing job with full Jaeger infrastructure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated integration test pipelines to exclude tracing-related test scenarios from LLM inference service and model controller test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->