### PR TITLE
fix: run all feast test suites independently even when one fails

### DIFF
--- a/integration-tests/feast/nightly-testing-pipeline.yaml
+++ b/integration-tests/feast/nightly-testing-pipeline.yaml
@@ -290,24 +290,42 @@ spec:
               cd infra/feast-operator
               make install && make deploy IMG=${FEAST_OPERATOR_CONTROLLER_IMAGE} FS_IMG=${FEAST_FEATURE_SERVER_IMAGE}
               oc wait --for condition=Available -n feast-operator-system deployment feast-operator-controller-manager
-              make test-e2e
+
+              E2E_RC=0
+              REGISTRY_RC=0
+              PREV_RC=0
+              UPGRADE_RC=0
+
+              echo "=== Running: make test-e2e ==="
+              make test-e2e || E2E_RC=$?
 
               cd ../..
-              echo "=== Registry REST API Tests ==="
-              make install-python-dependencies-ci
-              uv run pytest -c sdk/python/pytest.ini sdk/python/tests/integration/rest_api/test_registry_rest_api.py --integration -s --timeout=600
+              echo "=== Running: registry REST API test ==="
+              make install-python-dependencies-ci && \
+              uv run pytest -c sdk/python/pytest.ini sdk/python/tests/integration/rest_api/test_registry_rest_api.py --integration -s --timeout=600 || REGISTRY_RC=$?
 
               cd infra/feast-operator
-              make undeploy IMG=${FEAST_OPERATOR_CONTROLLER_IMAGE} FS_IMG=${FEAST_FEATURE_SERVER_IMAGE}
+              make undeploy IMG=${FEAST_OPERATOR_CONTROLLER_IMAGE} FS_IMG=${FEAST_FEATURE_SERVER_IMAGE} || true
 
-              echo "=== Previous Version Compatibility ==="
-              make test-previous-version
-              oc delete deployment feast-operator-controller-manager -n feast-operator-system
+              echo "=== Running: make test-previous-version ==="
+              make test-previous-version || PREV_RC=$?
 
-              echo "=== Upgrade Test ==="
-              make test-upgrade
+              oc delete deployment feast-operator-controller-manager -n feast-operator-system --ignore-not-found=true
+              oc wait --for=delete deployment/feast-operator-controller-manager -n feast-operator-system --timeout=180s || UPGRADE_RC=$?
 
-              echo "success" > "$STATUS_FILE"
+              echo "=== Running: make test-upgrade ==="
+              make test-upgrade || UPGRADE_RC=$?
+
+              echo ""
+              echo "=== Test Suite Results ==="
+              echo "  test-e2e:              $([ $E2E_RC      -eq 0 ] && echo PASSED || echo FAILED [rc=$E2E_RC])"
+              echo "  registry-rest-api:     $([ $REGISTRY_RC -eq 0 ] && echo PASSED || echo FAILED [rc=$REGISTRY_RC])"
+              echo "  test-previous-version: $([ $PREV_RC     -eq 0 ] && echo PASSED || echo FAILED [rc=$PREV_RC])"
+              echo "  test-upgrade:          $([ $UPGRADE_RC  -eq 0 ] && echo PASSED || echo FAILED [rc=$UPGRADE_RC])"
+
+              if [ $E2E_RC -eq 0 ] && [ $REGISTRY_RC -eq 0 ] && [ $PREV_RC -eq 0 ] && [ $UPGRADE_RC -eq 0 ]; then
+                echo "success" > "$STATUS_FILE"
+              fi
 
           - name: must-gather
             onError: continue

--- a/integration-tests/feast/pr-group-testing-pipeline.yaml
+++ b/integration-tests/feast/pr-group-testing-pipeline.yaml
@@ -272,23 +272,44 @@ spec:
               cd infra/feast-operator
               make install && make deploy IMG=${FEAST_OPERATOR_CONTROLLER_IMAGE} FS_IMG=${FEAST_FEATURE_SERVER_IMAGE}
               oc wait --for condition=Available -n feast-operator-system deployment feast-operator-controller-manager
-              make test-e2e
-            
+              
+              E2E_RC=0
+              REGISTRY_RC=0
+              PREV_RC=0
+              UPGRADE_RC=0
+
+              echo "=== Running: make test-e2e ==="
+              make test-e2e || E2E_RC=$?
+
               cd ../..
-              echo "Registry REST API test run"
-              make install-python-dependencies-ci
-              uv run pytest -c sdk/python/pytest.ini sdk/python/tests/integration/rest_api/test_registry_rest_api.py --integration -s --timeout=600
+              echo "=== Running: registry REST API test ==="
+              make install-python-dependencies-ci && \
+              uv run pytest -c sdk/python/pytest.ini sdk/python/tests/integration/rest_api/test_registry_rest_api.py --integration -s --timeout=600 || REGISTRY_RC=$?
 
               cd infra/feast-operator
-              make undeploy IMG=${FEAST_OPERATOR_CONTROLLER_IMAGE} FS_IMG=${FEAST_FEATURE_SERVER_IMAGE}
+              make undeploy IMG=${FEAST_OPERATOR_CONTROLLER_IMAGE} FS_IMG=${FEAST_FEATURE_SERVER_IMAGE} || true
 
-              make test-previous-version
-              oc delete deployment feast-operator-controller-manager -n feast-operator-system
+              echo "=== Running: make test-previous-version ==="
+              make test-previous-version || PREV_RC=$?
 
-              make test-upgrade
+              oc delete deployment feast-operator-controller-manager -n feast-operator-system --ignore-not-found=true
+              oc wait --for=delete deployment/feast-operator-controller-manager -n feast-operator-system --timeout=180s || UPGRADE_RC=$?
 
-              echo "success" > "$STATUS_FILE"
+              echo "=== Running: make test-upgrade ==="
+              make test-upgrade || UPGRADE_RC=$?
 
+              echo ""
+              echo "=== Test Suite Results ==="
+              echo "  test-e2e:              $([ $E2E_RC      -eq 0 ] && echo PASSED || echo FAILED [rc=$E2E_RC])"
+              echo "  registry-rest-api:     $([ $REGISTRY_RC -eq 0 ] && echo PASSED || echo FAILED [rc=$REGISTRY_RC])"
+              echo "  test-previous-version: $([ $PREV_RC     -eq 0 ] && echo PASSED || echo FAILED [rc=$PREV_RC])"
+              echo "  test-upgrade:          $([ $UPGRADE_RC  -eq 0 ] && echo PASSED || echo FAILED [rc=$UPGRADE_RC])"
+
+              if [ $E2E_RC -eq 0 ] && [ $REGISTRY_RC -eq 0 ] && [ $PREV_RC -eq 0 ] && [ $UPGRADE_RC -eq 0 ]; then
+                echo "success" > "$STATUS_FILE"
+              else
+                exit 1
+              fi
           - name: must-gather
             onError: continue
             image: quay.io/rhoai/rhoai-task-toolset:go-its


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Previously, the deploy-and-e2e step in the Feast integration test pipeline used implicit set -e behavior, which caused the pipeline to abort immediately on the first test suite failure. This meant that if make test-e2e failed, the remaining suites (registry-rest-api, test-previous-version, test-upgrade) were silently skipped — providing no signal about whether those suites were passing or failing.
This change makes all four test suites run independently and always to completion, regardless of individual failures.

**Changes Made**

File: integration-tests/feast/pr-group-testing-pipeline.yaml
deploy-and-e2e step:

- Replaced implicit set -e abort behavior with || RC=$? pattern for each test suite, capturing exit codes without halting the script
- Added per-suite RC variables: E2E_RC, REGISTRY_RC, PREV_RC, UPGRADE_RC
- Added a === Test Suite Results === summary block at the end of the step, printing PASSED/FAILED with rc for each suite — gives immediate human-readable CI output
- STATUS_FILE (/test-status/deploy-and-e2e-status) is initialized to "failed" at the start and only written "success" if all four RCs are 0
- fail-if-needed step (new):
- Reads the STATUS_FILE after deploy-and-e2e completes (which runs with onError: continue)
- Fails the pipeline explicitly if STATUS_FILE is not "success"
- Ensures the pipeline correctly fails even though deploy-and-e2e step itself exits 0 (due to onError: continue)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested here /pipelineruns/feast-group-test-cc7gg
## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved failure detection in the nightly and PR deploy-and-E2E pipelines by capturing and reporting exit codes for each phase (E2E, registry REST API, previous-version compatibility, and upgrade).
  * Pipelines now produce a consolidated pass/fail summary per phase.
  * Status is written as successful only when all phases succeed; otherwise the pipeline is marked failed to avoid false “success” outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->