### PR TITLE
Onboard odh-cypress-ci Konflux build for dashboard Cypress E2E.

### DIFF
--- a/gitops/opendatahub-ci-components.yaml
+++ b/gitops/opendatahub-ci-components.yaml
@@ -90,6 +90,26 @@ metadata:
     build.appstudio.openshift.io/request: configure-pac-no-mr
     mintmaker.appstudio.redhat.com/disabled: true
     build.appstudio.openshift.io/pipeline: '{"name":"docker-build-multi-platform-oci-ta","bundle":"latest"}'
+  name: odh-cypress-ci
+spec:
+  application: opendatahub-builds
+  componentName: odh-cypress-ci
+  containerImage: quay.io/opendatahub/odh-cypress
+  source:
+    git:
+      context: ./
+      dockerfileUrl: scripts/ci/Dockerfile
+      revision: "main"
+      url: https://github.com/opendatahub-io/odh-dashboard
+
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Component
+metadata:
+  annotations:
+    build.appstudio.openshift.io/request: configure-pac-no-mr
+    mintmaker.appstudio.redhat.com/disabled: true
+    build.appstudio.openshift.io/pipeline: '{"name":"docker-build-multi-platform-oci-ta","bundle":"latest"}'
   name: odh-data-science-pipelines-operator-controller-ci
 spec:
   application: opendatahub-builds

--- a/pipelineruns/odh-dashboard/odh-cypress-pull-request.yaml
+++ b/pipelineruns/odh-dashboard/odh-cypress-pull-request.yaml
@@ -1,0 +1,55 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/odh-dashboard?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
+      == "$$TARGET_BRANCH$$"
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: opendatahub-builds
+    appstudio.openshift.io/component: odh-cypress-ci
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-cypress-on-pull-request
+  namespace: open-data-hub-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/opendatahub/odh-cypress:$$OUTPUT_IMAGE_TAG$$
+  - name: dockerfile
+    value: scripts/ci/Dockerfile
+  - name: path-context
+    value: .
+  - name: additional-tags
+    value:
+    - 'odh-pr-{{revision}}'
+  - name: pipeline-type
+    value: pull-request
+  - name: build-platforms
+    value:
+    - linux/x86_64
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/opendatahub-io/odh-konflux-central.git
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipeline/multi-arch-container-build.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-odh-cypress
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/pipelineruns/odh-dashboard/odh-cypress-push.yaml
+++ b/pipelineruns/odh-dashboard/odh-cypress-push.yaml
@@ -1,0 +1,49 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/odh-dashboard?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "$$TARGET_BRANCH$$"
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: opendatahub-builds
+    appstudio.openshift.io/component: odh-cypress-ci
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-cypress-on-push
+  namespace: open-data-hub-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/opendatahub/odh-cypress:$$OUTPUT_IMAGE_TAG$$
+  - name: dockerfile
+    value: scripts/ci/Dockerfile
+  - name: path-context
+    value: .
+  - name: build-platforms
+    value:
+    - linux/x86_64
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/opendatahub-io/odh-konflux-central.git
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipeline/multi-arch-container-build.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-odh-cypress
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}


### PR DESCRIPTION
## Summary
- Add Konflux PAC pipelineruns to build and publish `quay.io/opendatahub/odh-cypress` from `opendatahub-io/odh-dashboard` `scripts/ci/Dockerfile`
- Register `odh-cypress-ci` Component CR in `gitops/opendatahub-ci-components.yaml`
- This is the **dashboard Cypress E2E test image** (Chrome + npm + Cypress), not the main `odh-dashboard` app image
- Unblocks olminstall `dashboard_cypress` smoke once the image is published and pullable

## Build details
- **Source repo:** `opendatahub-io/odh-dashboard`
- **Dockerfile:** `scripts/ci/Dockerfile` (repo root context)
- **Tags:** `:odh-stable` (main push), `:odh-pr` / `:odh-pr-<revision>` (PR)
- **Platforms:** `linux/x86_64` only (Chrome RPM is x86_64)

## Platform prerequisites (not in this PR)
- Quay repo `opendatahub/odh-cypress` does **not** exist yet (404) — DevOps must create it before the first push succeeds
- ServiceAccount `build-pipeline-odh-cypress` + Quay push secret (same pattern as `build-pipeline-odh-dashboard`)
- Pull grants for Konflux test workers (`rhoai-tenant`, worker nodes)

## Post-merge
1. Run **ODH Konflux Onboarder**: component `odh-dashboard`, `build_type: CI`, target `main`
2. Merge the resulting `.tekton/` PR on `opendatahub-io/odh-dashboard`
3. Confirm first green build: `skopeo inspect docker://quay.io/opendatahub/odh-cypress:odh-stable`

## Test plan
- [ ] PR CI / YAML lint green
- [ ] After merge + onboarder + DevOps: first PAC build on `odh-dashboard` main succeeds
- [ ] `skopeo inspect docker://quay.io/opendatahub/odh-cypress:odh-stable`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Established automated CI/CD pipelines for the repository
  * Configured pull request validation pipeline to run automated tests and checks on proposed changes
  * Configured push-to-main build pipeline to automatically build container images

<!-- end of auto-generated comment: release notes by coderabbit.ai -->