### PR TITLE
fix: use rebase with retry for push-build-metadata

### DIFF
--- a/early-gate/tasks/push-build-metadata.yaml
+++ b/early-gate/tasks/push-build-metadata.yaml
@@ -99,5 +99,13 @@ spec:
 
       git add --sparse components/odh-operator/${OUTPUT_IMAGE_DIGEST}
       git commit -m "build-meta for operator image ${OUTPUT_IMAGE_DIGEST}"
-      git pull origin main --depth 1
-      git push
+      MAX_RETRIES=3
+      for i in $(seq 1 $MAX_RETRIES); do
+        git pull --rebase origin main --depth 1 && git push && break
+        if [ "$i" -eq "$MAX_RETRIES" ]; then
+          echo "ERROR: Failed to push after $MAX_RETRIES attempts"
+          exit 1
+        fi
+        echo "Push failed (attempt $i/$MAX_RETRIES), retrying..."
+        sleep $((i * 2))
+      done


### PR DESCRIPTION
## Problem

The `push-build-metadata` task fails when another pipeline run pushes to `odh-build-metadata` between the shallow fetch and the push, creating divergent branches. Git refuses to pull without a merge strategy:

```
fatal: Need to specify how to reconcile divergent branches.
```

This was seen on [models-as-a-service#1017](https://github.com/opendatahub-io/models-as-a-service/pull/1017) (pipeline run `early-gate-ci-build-wh9j4`, task `push-build-metadata`), requiring a manual `/override`.

## Fix

- Add `--rebase` to `git pull` so the local commit is replayed on top of remote `main` instead of requiring a merge
- Wrap pull+push in a retry loop (3 attempts with exponential backoff) to handle push races where another pipeline pushes between our pull and push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced build metadata push reliability with automatic retry logic and exponential backoff to gracefully handle transient failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->