### PR TITLE
Add odh-mcp-lifecycle-module-operator-ci PipelineRuns

### DIFF
--- a/.github/workflows/odh-konflux-onboarder.yml
+++ b/.github/workflows/odh-konflux-onboarder.yml
@@ -76,6 +76,7 @@ on:
           - workload-variant-autoscaler
           - workbenches
           - workbenches-operator
+          - mcp-lifecycle-module-operator
       pr_target_branch:
         description: 'Target branch for the PR (e.g. main)'
         required: true

--- a/pipelineruns/mcp-lifecycle-module-operator/odh-mcp-lifecycle-module-operator-pull-request.yaml
+++ b/pipelineruns/mcp-lifecycle-module-operator/odh-mcp-lifecycle-module-operator-pull-request.yaml
@@ -1,0 +1,52 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/mcp-lifecycle-module-operator?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
+      == "$$TARGET_BRANCH$$"
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: opendatahub-builds
+    appstudio.openshift.io/component: odh-mcp-lifecycle-module-operator-ci
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-mcp-lifecycle-module-operator-on-pull-request
+  namespace: open-data-hub-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/opendatahub/odh-mcp-lifecycle-module-operator:$$OUTPUT_IMAGE_TAG$$
+  - name: dockerfile
+    value: Dockerfile
+  - name: path-context
+    value: .
+  #add these additional params
+  - name: additional-tags
+    value:
+    - 'odh-pr-{{revision}}'
+  - name: pipeline-type
+    value: pull-request
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/opendatahub-io/odh-konflux-central.git
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipeline/multi-arch-container-build.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-odh-mcp-lifecycle-module-operator-ci
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/pipelineruns/mcp-lifecycle-module-operator/odh-mcp-lifecycle-module-operator-push.yaml
+++ b/pipelineruns/mcp-lifecycle-module-operator/odh-mcp-lifecycle-module-operator-push.yaml
@@ -1,0 +1,47 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+#
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/mcp-lifecycle-module-operator?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "$$TARGET_BRANCH$$"
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: opendatahub-builds
+    appstudio.openshift.io/component: odh-mcp-lifecycle-module-operator-ci
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-mcp-lifecycle-module-operator-on-push
+  namespace: open-data-hub-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/opendatahub/odh-mcp-lifecycle-module-operator:$$OUTPUT_IMAGE_TAG$$
+  - name: dockerfile
+    value: Dockerfile
+  - name: path-context
+    value: .
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/opendatahub-io/odh-konflux-central.git
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipeline/multi-arch-container-build.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-odh-mcp-lifecycle-module-operator-ci
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}


### PR DESCRIPTION
Adds push and pull-request PipelineRun YAMLs for 'odh-mcp-lifecycle-module-operator-ci'.

Component repo: https://github.com/opendatahub-io/mcp-lifecycle-module-operator
Jira: https://redhat.atlassian.net/browse/RHOAIENG-70904

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extended the onboarding workflow to include `mcp-lifecycle-module-operator` as a selectable component.
  * Added Tekton PipelineRun manifests to automatically start multi-arch container builds for `mcp-lifecycle-module-operator` on pull requests and push events, including image tagging and git authentication wiring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->