### PR TITLE
Add pathChanged() CEL filters to odh-dashboard Konflux pipelines

### DIFF
--- a/pipelineruns/odh-dashboard/mod-arch-maas-pull-request.yaml
+++ b/pipelineruns/odh-dashboard/mod-arch-maas-pull-request.yaml
@@ -8,8 +8,11 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "$$TARGET_BRANCH$$"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "pull_request"
+      && target_branch == "$$TARGET_BRANCH$$"
+      && ( "packages/maas/**".pathChanged()
+            || ".tekton/mod-arch-maas-pull-request.yaml".pathChanged() )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: opendatahub-builds

--- a/pipelineruns/odh-dashboard/mod-arch-maas-push.yaml
+++ b/pipelineruns/odh-dashboard/mod-arch-maas-push.yaml
@@ -7,8 +7,11 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "$$TARGET_BRANCH$$"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "push"
+      && target_branch == "$$TARGET_BRANCH$$"
+      && ( "packages/maas/**".pathChanged()
+            || ".tekton/mod-arch-maas-push.yaml".pathChanged() )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: opendatahub-builds

--- a/pipelineruns/odh-dashboard/odh-dashboard-operator-pull-request.yaml
+++ b/pipelineruns/odh-dashboard/odh-dashboard-operator-pull-request.yaml
@@ -7,8 +7,12 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "$$TARGET_BRANCH$$"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "pull_request"
+      && target_branch == "$$TARGET_BRANCH$$"
+      && ( "dashboard-operator/**".pathChanged()
+            || "manifests/**".pathChanged()
+            || ".tekton/odh-dashboard-operator-pull-request.yaml".pathChanged() )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: opendatahub-builds

--- a/pipelineruns/odh-dashboard/odh-dashboard-operator-push.yaml
+++ b/pipelineruns/odh-dashboard/odh-dashboard-operator-push.yaml
@@ -8,8 +8,12 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "$$TARGET_BRANCH$$"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "push"
+      && target_branch == "$$TARGET_BRANCH$$"
+      && ( "dashboard-operator/**".pathChanged()
+            || "manifests/**".pathChanged()
+            || ".tekton/odh-dashboard-operator-push.yaml".pathChanged() )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: opendatahub-builds

--- a/pipelineruns/odh-dashboard/odh-mod-arch-automl-pull-request.yaml
+++ b/pipelineruns/odh-dashboard/odh-mod-arch-automl-pull-request.yaml
@@ -12,7 +12,7 @@ metadata:
       event == "pull_request"
       && target_branch == "$$TARGET_BRANCH$$"
       && ( "packages/automl/**".pathChanged()
-            || ".tekton/odh-mod-arch-automl-ci-pull-request.yaml".pathChanged() )
+            || ".tekton/odh-mod-arch-automl-pull-request.yaml".pathChanged() )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: opendatahub-builds

--- a/pipelineruns/odh-dashboard/odh-mod-arch-automl-push.yaml
+++ b/pipelineruns/odh-dashboard/odh-mod-arch-automl-push.yaml
@@ -11,7 +11,7 @@ metadata:
       event == "push"
       && target_branch == "$$TARGET_BRANCH$$"
       && ( "packages/automl/**".pathChanged()
-            || ".tekton/odh-mod-arch-automl-ci-on-push.yaml".pathChanged() )
+            || ".tekton/odh-mod-arch-automl-push.yaml".pathChanged() )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: opendatahub-builds

--- a/pipelineruns/odh-dashboard/odh-mod-arch-autorag-pull-request.yaml
+++ b/pipelineruns/odh-dashboard/odh-mod-arch-autorag-pull-request.yaml
@@ -12,7 +12,7 @@ metadata:
       event == "pull_request" 
       && target_branch == "$$TARGET_BRANCH$$"
       && ( "packages/autorag/**".pathChanged()
-            || ".tekton/odh-mod-arch-autorag-ci-pull-request.yaml".pathChanged() )
+            || ".tekton/odh-mod-arch-autorag-pull-request.yaml".pathChanged() )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: opendatahub-builds

--- a/pipelineruns/odh-dashboard/odh-mod-arch-autorag-push.yaml
+++ b/pipelineruns/odh-dashboard/odh-mod-arch-autorag-push.yaml
@@ -12,7 +12,7 @@ metadata:
       event == "push" 
       && target_branch == "$$TARGET_BRANCH$$"
       && ( "packages/autorag/**".pathChanged()
-            || ".tekton/odh-mod-arch-autorag-ci-on-push.yaml".pathChanged() )
+            || ".tekton/odh-mod-arch-autorag-push.yaml".pathChanged() )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: opendatahub-builds


### PR DESCRIPTION
## Summary

Fixes [RHOAIENG-71323](https://issues.redhat.com/browse/RHOAIENG-71323)
https://redhat.atlassian.net/browse/RHOAIENG-71323

Several Tekton pipeline configurations in `pipelineruns/odh-dashboard/` are either missing `pathChanged()` CEL expression filters or have incorrect self-reference paths, causing unnecessary pipeline triggers and wasted Konflux CI resources.

### Changes

**Add missing `pathChanged()` filters (4 files):**

| File | Trigger paths added |
|---|---|
| `mod-arch-maas-pull-request.yaml` | `packages/maas/**`, `.tekton/mod-arch-maas-pull-request.yaml` |
| `mod-arch-maas-push.yaml` | `packages/maas/**`, `.tekton/mod-arch-maas-push.yaml` |
| `odh-dashboard-operator-pull-request.yaml` | `dashboard-operator/**`, `manifests/**`, `.tekton/odh-dashboard-operator-pull-request.yaml` |
| `odh-dashboard-operator-push.yaml` | `dashboard-operator/**`, `manifests/**`, `.tekton/odh-dashboard-operator-push.yaml` |

These pipelines previously triggered on **every** PR/push to `main` regardless of which files changed. Now they follow the same pattern as well-configured pipelines like `odh-mod-arch-agent-ops`.

**Fix incorrect self-reference paths (4 files):**

| File | Wrong self-ref | Correct self-ref |
|---|---|---|
| `odh-mod-arch-automl-pull-request.yaml` | `odh-mod-arch-automl-ci-pull-request.yaml` | `odh-mod-arch-automl-pull-request.yaml` |
| `odh-mod-arch-automl-push.yaml` | `odh-mod-arch-automl-ci-on-push.yaml` | `odh-mod-arch-automl-push.yaml` |
| `odh-mod-arch-autorag-pull-request.yaml` | `odh-mod-arch-autorag-ci-pull-request.yaml` | `odh-mod-arch-autorag-pull-request.yaml` |
| `odh-mod-arch-autorag-push.yaml` | `odh-mod-arch-autorag-ci-on-push.yaml` | `odh-mod-arch-autorag-push.yaml` |

The self-reference `.tekton/` paths pointed to non-existent filenames, so changes to the pipeline YAML itself would not trigger a rebuild.

### Not in scope

- `odh-dashboard-pull-request.yaml` / `odh-dashboard-push.yaml` — intentionally broad (main dashboard image builds the entire app)
- `modular-architecture` → `model-registry` renaming — deferred

## Test plan

- [ ] Verify a PR touching only `packages/gen-ai/` does **not** trigger the `maas` or `dashboard-operator` pipelines
- [ ] Verify a PR touching `packages/maas/` still triggers the `maas` pipeline
- [ ] Verify a PR touching `dashboard-operator/` or `manifests/` still triggers the `dashboard-operator` pipeline
- [ ] Verify modifying any of the 8 pipeline YAML files themselves still triggers the correct pipeline via the `.tekton/` self-reference path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CI trigger accuracy so pipeline runs now start only when relevant files change, reducing unnecessary runs.
  * Updated several pull request and push checks to better match the affected areas of the dashboard and related components.
  * Aligned pipeline configuration updates with the correct trigger paths for automation jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->