### PR TITLE
Align Dockerfile name for MCP Lifecycle Operator & module operator

### DIFF
--- a/pipelineruns/mcp-lifecycle-module-operator/odh-mcp-lifecycle-module-operator-pull-request.yaml
+++ b/pipelineruns/mcp-lifecycle-module-operator/odh-mcp-lifecycle-module-operator-pull-request.yaml
@@ -25,7 +25,7 @@ spec:
   - name: output-image
     value: quay.io/opendatahub/odh-mcp-lifecycle-module-operator:$$OUTPUT_IMAGE_TAG$$
   - name: dockerfile
-    value: Dockerfile
+    value: Dockerfile.konflux
   - name: path-context
     value: .
   #add these additional params

--- a/pipelineruns/mcp-lifecycle-module-operator/odh-mcp-lifecycle-module-operator-push.yaml
+++ b/pipelineruns/mcp-lifecycle-module-operator/odh-mcp-lifecycle-module-operator-push.yaml
@@ -26,7 +26,7 @@ spec:
   - name: output-image
     value: quay.io/opendatahub/odh-mcp-lifecycle-module-operator:$$OUTPUT_IMAGE_TAG$$
   - name: dockerfile
-    value: Dockerfile
+    value: Dockerfile.konflux
   - name: path-context
     value: .
   pipelineRef:

--- a/pipelineruns/mcp-lifecycle-operator/odh-mcp-lifecycle-operator-pull-request.yaml
+++ b/pipelineruns/mcp-lifecycle-operator/odh-mcp-lifecycle-operator-pull-request.yaml
@@ -25,7 +25,7 @@ spec:
   - name: output-image
     value: quay.io/opendatahub/odh-mcp-lifecycle-operator:$$OUTPUT_IMAGE_TAG$$
   - name: dockerfile
-    value: Dockerfile.ocp
+    value: Dockerfile.konflux
   - name: path-context
     value: .
   #add these additional params

--- a/pipelineruns/mcp-lifecycle-operator/odh-mcp-lifecycle-operator-push.yaml
+++ b/pipelineruns/mcp-lifecycle-operator/odh-mcp-lifecycle-operator-push.yaml
@@ -26,7 +26,7 @@ spec:
   - name: output-image
     value: quay.io/opendatahub/odh-mcp-lifecycle-operator:$$OUTPUT_IMAGE_TAG$$
   - name: dockerfile
-    value: Dockerfile.ocp
+    value: Dockerfile.konflux
   - name: path-context
     value: .
   pipelineRef:


### PR DESCRIPTION
In https://github.com/opendatahub-io/mcp-lifecycle-operator/pull/36 and https://github.com/opendatahub-io/mcp-lifecycle-module-operator/pull/62 we rename the Dockerfile name for the MCP Lifecycle Operator and module operator. So adjusting it in the pipelines too

/hold until https://github.com/opendatahub-io/mcp-lifecycle-operator/pull/36 and https://github.com/opendatahub-io/mcp-lifecycle-module-operator/pull/62 is in