### PR TITLE
Rollback: Remove odh-dashboard from early-gate config

### DIFF
--- a/config/early-gate-config.yaml
+++ b/config/early-gate-config.yaml
@@ -28,5 +28,3 @@ config:
       early-gate-enabled: true
     odh-model-controller:
       early-gate-enabled: true
-    odh-dashboard:
-      early-gate-enabled: true


### PR DESCRIPTION
## What
Reverts the early-gate configuration change added in #470.

## Changes
- Remove `odh-dashboard` entry from `config/early-gate-config.yaml`

## Why
Rolling back the early-gate integration for odh-dashboard.

## Related PRs
- opendatahub-io/odh-konflux-central#470 (added config entry - being reverted)
- opendatahub-io/odh-dashboard#8201 (added pipeline files - being reverted in opendatahub-io/odh-dashboard#8304)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository release settings by removing an enabled early-gate configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->