### PR TITLE
Add odh-trustyai-service-ci PipelineRuns

### DIFF
--- a/.github/workflows/odh-konflux-onboarder.yml
+++ b/.github/workflows/odh-konflux-onboarder.yml
@@ -79,6 +79,7 @@ on:
           - mcp-lifecycle-module-operator
           - mcp-lifecycle-operator
           - trainer-operator
+          - trustyai-service
       pr_target_branch:
         description: 'Target branch for the PR (e.g. main)'
         required: true

--- a/pipelineruns/trustyai-service/odh-trustyai-service-pull-request.yaml
+++ b/pipelineruns/trustyai-service/odh-trustyai-service-pull-request.yaml
@@ -1,0 +1,52 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/trustyai-service?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
+      == "$$TARGET_BRANCH$$"
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: opendatahub-builds
+    appstudio.openshift.io/component: odh-trustyai-service-ci
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-trustyai-service-on-pull-request
+  namespace: open-data-hub-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/opendatahub/odh-trustyai-service:$$OUTPUT_IMAGE_TAG$$
+  - name: dockerfile
+    value: Containerfile
+  - name: path-context
+    value: .
+  #add these additional params
+  - name: additional-tags
+    value:
+    - 'odh-pr-{{revision}}'
+  - name: pipeline-type
+    value: pull-request
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/opendatahub-io/odh-konflux-central.git
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipeline/multi-arch-container-build.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-odh-trustyai-service-ci
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/pipelineruns/trustyai-service/odh-trustyai-service-push.yaml
+++ b/pipelineruns/trustyai-service/odh-trustyai-service-push.yaml
@@ -1,0 +1,47 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+#
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/trustyai-service?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "$$TARGET_BRANCH$$"
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: opendatahub-builds
+    appstudio.openshift.io/component: odh-trustyai-service-ci
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-trustyai-service-on-push
+  namespace: open-data-hub-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/opendatahub/odh-trustyai-service:$$OUTPUT_IMAGE_TAG$$
+  - name: dockerfile
+    value: Containerfile
+  - name: path-context
+    value: .
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/opendatahub-io/odh-konflux-central.git
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipeline/multi-arch-container-build.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-odh-trustyai-service-ci
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}


### PR DESCRIPTION
Adds push and pull-request PipelineRun YAMLs for 'odh-trustyai-service-ci'.

Component repo: https://github.com/opendatahub-io/trustyai-service
Jira: https://redhat.atlassian.net/browse/RHOAIENG-71920

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `trustyai-service` as an available option when starting the onboarding workflow.
  * Added automated build pipelines for `odh-trustyai-service` on pull requests and push events, enabling builds to run with the appropriate source, image, and authentication settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->