### PR TITLE
fix: use computeResources for OGX ITS pipeline sidecars

### DIFF
--- a/integration-tests/ogx-core/pr-its-pipeline.yaml
+++ b/integration-tests/ogx-core/pr-its-pipeline.yaml
@@ -148,13 +148,13 @@ spec:
                 command: ["pg_isready", "-U", "ogx", "-d", "ogx"]
               initialDelaySeconds: 5
               periodSeconds: 3
-            resources:
+            computeResources:
               requests:
-                memory: "256Mi"
-                cpu: "250m"
-              limits:
                 memory: "512Mi"
-                cpu: "500m"
+                cpu: "1"
+              limits:
+                memory: "1Gi"
+                cpu: "1"
 
           - name: vllm-inference
             image: quay.io/opendatahub/vllm-cpu:Qwen3-0.6B-granite-embedding-125m-english
@@ -181,7 +181,7 @@ spec:
               initialDelaySeconds: 60
               periodSeconds: 10
               failureThreshold: 60
-            resources:
+            computeResources:
               requests:
                 memory: "4Gi"
                 cpu: "2"
@@ -211,12 +211,12 @@ spec:
               initialDelaySeconds: 60
               periodSeconds: 10
               failureThreshold: 60
-            resources:
+            computeResources:
               requests:
-                memory: "1Gi"
+                memory: "2Gi"
                 cpu: "1"
               limits:
-                memory: "2Gi"
+                memory: "4Gi"
                 cpu: "2"
 
           - name: ogx
@@ -259,13 +259,13 @@ spec:
               initialDelaySeconds: 15
               periodSeconds: 5
               failureThreshold: 60
-            resources:
+            computeResources:
               requests:
-                memory: "512Mi"
-                cpu: "500m"
-              limits:
                 memory: "1Gi"
                 cpu: "1"
+              limits:
+                memory: "2Gi"
+                cpu: "2"
 
         steps:
           - name: clone-repo


### PR DESCRIPTION
## Summary
- Rename `resources` → `computeResources` on all 4 sidecars in the OGX Core ITS pipeline to fix Tekton v1 strict decoding failure
- Right-size memory/CPU limits based on actual workload (small models on CPU)

**Failing pipeline run:** https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/open-data-hub-tenant/applications/opendatahub-builds/pipelineruns/ogx-core-functional-its-mc5pz

| Sidecar | CPU req/limit | Memory req/limit |
|---------|--------------|-----------------|
| postgres | 1 / 1 | 512Mi / 1Gi |
| vllm-inference (Qwen3-0.6B) | 2 / 4 | 4Gi / 8Gi |
| vllm-embedding (granite-125m) | 1 / 2 | 2Gi / 4Gi |
| ogx | 1 / 2 | 1Gi / 2Gi |

## Test plan
- [ ] Verify pipeline run starts without strict decoding errors
- [ ] Verify sidecars start and pass readiness probes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated resource settings for test-sidecar services to use the current configuration format.
  * Increased CPU and memory allocations for database and application support services used during functional testing.
  * Adjusted embedding and inference service resource limits to improve test stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->