### PR TITLE
fix: right-size sidecar resources and fix clone path for OGX ITS

### DIFF
--- a/integration-tests/ogx-core/pr-its-pipeline.yaml
+++ b/integration-tests/ogx-core/pr-its-pipeline.yaml
@@ -148,13 +148,13 @@ spec:
                 command: ["pg_isready", "-U", "ogx", "-d", "ogx"]
               initialDelaySeconds: 5
               periodSeconds: 3
-            resources:
+            computeResources:
               requests:
-                memory: "256Mi"
-                cpu: "250m"
-              limits:
                 memory: "512Mi"
-                cpu: "500m"
+                cpu: "1"
+              limits:
+                memory: "1Gi"
+                cpu: "1"
 
           - name: vllm-inference
             image: quay.io/opendatahub/vllm-cpu:Qwen3-0.6B-granite-embedding-125m-english
@@ -181,7 +181,7 @@ spec:
               initialDelaySeconds: 60
               periodSeconds: 10
               failureThreshold: 60
-            resources:
+            computeResources:
               requests:
                 memory: "4Gi"
                 cpu: "2"
@@ -211,12 +211,12 @@ spec:
               initialDelaySeconds: 60
               periodSeconds: 10
               failureThreshold: 60
-            resources:
+            computeResources:
               requests:
-                memory: "1Gi"
+                memory: "2Gi"
                 cpu: "1"
               limits:
-                memory: "2Gi"
+                memory: "4Gi"
                 cpu: "2"
 
           - name: ogx
@@ -259,21 +259,26 @@ spec:
               initialDelaySeconds: 15
               periodSeconds: 5
               failureThreshold: 60
-            resources:
+            computeResources:
               requests:
-                memory: "512Mi"
-                cpu: "500m"
-              limits:
                 memory: "1Gi"
                 cpu: "1"
+              limits:
+                memory: "2Gi"
+                cpu: "2"
 
         steps:
           - name: clone-repo
             image: alpine/git
+            env:
+              - name: GIT_URL
+                value: $(params.git-url)
+              - name: GIT_REV
+                value: $(params.git-rev)
             script: |
-              echo "Cloning $(params.git-url) @ $(params.git-rev)"
-              git clone --depth 1 --branch $(params.git-rev) $(params.git-url) /workspace/source
-              ls /workspace/source/tests/functional/
+              echo "Cloning ${GIT_URL} @ ${GIT_REV}"
+              git clone --depth 1 --branch "${GIT_REV}" "${GIT_URL}" /workspace/src_code
+              ls /workspace/src_code/tests/functional/
 
           - name: run-functional-tests
             image: python:3.12-slim
@@ -285,7 +290,7 @@ spec:
                 value: "600"
               - name: ARTIFACT_DIR
                 value: /workspace/artifacts-dir
-            workingDir: /workspace/source/tests/functional
+            workingDir: /workspace/src_code/tests/functional
             script: |
               #!/bin/bash
               set -euo pipefail


### PR DESCRIPTION
## Summary
- Right-size `computeResources` limits based on actual model sizes (Qwen3-0.6B, granite-embedding-125m)
- Clone to `/workspace/src_code` instead of `/workspace/source` to avoid conflict with Tekton's pre-populated workspace directory (was causing `fatal: destination path '/workspace/source' already exists`)

Follow-up to #511.

| Sidecar | CPU req/limit | Memory req/limit |
|---------|--------------|-----------------|
| postgres | 1 / 1 | 512Mi / 1Gi |
| vllm-inference (Qwen3-0.6B) | 2 / 4 | 4Gi / 8Gi |
| vllm-embedding (granite-125m) | 1 / 2 | 2Gi / 4Gi |
| ogx | 1 / 2 | 1Gi / 2Gi |

## Test plan
- [ ] Verify clone step succeeds (no "already exists" error)
- [ ] Verify sidecars start and pass readiness probes
- [ ] Verify functional tests execute

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved functional test pipeline stability by tuning container resource allocations and updating test workspace paths, helping tests run more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->