### PR TITLE
Add BUILD_MODE parameter handling for CI and Release builds

### DIFF
--- a/.github/workflows/odh-konflux-onboarder.yml
+++ b/.github/workflows/odh-konflux-onboarder.yml
@@ -221,6 +221,8 @@ jobs:
 
                 sed -i -E 's|\$\$OUTPUT_IMAGE_TAG\$\$|'"${EFFECTIVE_TAG}"'|g' "$target_file"
                 sed -i -E 's|\$\$TARGET_BRANCH\$\$|'"${TARGET_BRANCH}"'|g' "$target_file"
+                # CI-only: Replace BUILD_MODE placeholder with RHOAI
+                sed -i -E 's|\$\$BUILD_MODE\$\$|RHOAI|g' "$target_file"
 
               ########################################
               # Push pipelines
@@ -232,6 +234,8 @@ jobs:
                 sed -i -E 's|\$\$OUTPUT_IMAGE_TAG\$\$|'"${EFFECTIVE_TAG}"'|g' "$target_file"
                 sed -i -E 's|\$\$TARGET_BRANCH\$\$|'"${TARGET_BRANCH}"'|g' "$target_file"
                 sed -i -E 's|\$\$BUILD_TYPE\$\$|'"${{ inputs.build_type }}"'|g' "$target_file"
+                # CI-only: Replace BUILD_MODE placeholder with RHOAI
+                sed -i -E 's|\$\$BUILD_MODE\$\$|RHOAI|g' "$target_file"
 
               ########################################
               # Other pipelines
@@ -273,6 +277,8 @@ jobs:
               sed -i -E 's|\$\$TARGET_BRANCH\$\$|'"${TARGET_BRANCH}"'|g' "$target_file"
               sed -i -E 's|\$\$BUILD_TYPE\$\$|'"${{ inputs.build_type }}"'|g' "$target_file"
               sed -i -E 's|Dockerfiles/rhoai\.Dockerfile|Dockerfiles/Dockerfile|g' "$target_file"
+              # Release-only: Remove BUILD_MODE parameter entirely
+              sed -i -E '/\$\$BUILD_MODE\$\$/d' "$target_file"
 
             done
           fi


### PR DESCRIPTION
This PR adds support for the `BUILD_MODE` parameter in the ODH Konflux Onboarder workflow with different behavior for CI and Release builds.

## Changes
- **CI builds** (pull & push): Replace `$$BUILD_MODE$$` placeholder with `RHOAI`
- **Release builds**: Remove `$$BUILD_MODE$$` parameter entirely

## Why
Pipelines that need the BUILD_MODE parameter can use `$$BUILD_MODE$$` as a placeholder:
- In CI builds, it gets set to `RHOAI`
- In Release builds, the parameter is removed completely (we don't need BUILD_MODE in releases)

This approach keeps release pipelines clean without unnecessary build arguments.

## Related
Alternative to #434 - this implementation removes the BUILD_MODE parameter in release builds instead of setting it to `ODH`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build pipeline processing to handle build-mode values more consistently during release generation.
  * CI-generated pipeline templates now use the standard build-mode value automatically.
  * Release-generated pipeline templates now omit the build-mode setting when it is not needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->