### PR TITLE
RHOAIENG-75542: Add e2e test image pipelines for mcp-lifecycle-operator

### DIFF
--- a/pipelineruns/mcp-lifecycle-operator/odh-mcp-lifecycle-operator-e2e-pull-request.yaml
+++ b/pipelineruns/mcp-lifecycle-operator/odh-mcp-lifecycle-operator-e2e-pull-request.yaml
@@ -13,9 +13,9 @@ metadata:
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: opendatahub-builds
-    appstudio.openshift.io/component: odh-mcp-lifecycle-operator-ci
+    appstudio.openshift.io/component: odh-mcp-lifecycle-operator-e2e-ci
     pipelines.appstudio.openshift.io/type: build
-  name: odh-mcp-lifecycle-operator-on-pull-request
+  name: odh-mcp-lifecycle-operator-e2e-on-pull-request
   namespace: open-data-hub-tenant
 spec:
   params:
@@ -24,9 +24,9 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/opendatahub/odh-mcp-lifecycle-operator:$$OUTPUT_IMAGE_TAG$$
+    value: quay.io/opendatahub/odh-mcp-lifecycle-operator/e2e:$$OUTPUT_IMAGE_TAG$$
   - name: dockerfile
-    value: Dockerfile.konflux
+    value: test/e2e/Dockerfile
   - name: path-context
     value: .
   #add these additional params
@@ -45,7 +45,7 @@ spec:
     - name: pathInRepo
       value: pipeline/multi-arch-container-build.yaml
   taskRunTemplate:
-    serviceAccountName: build-pipeline-odh-mcp-lifecycle-operator-ci
+    serviceAccountName: build-pipeline-odh-mcp-lifecycle-operator-e2e-ci
   workspaces:
   - name: git-auth
     secret:

--- a/pipelineruns/mcp-lifecycle-operator/odh-mcp-lifecycle-operator-e2e-push.yaml
+++ b/pipelineruns/mcp-lifecycle-operator/odh-mcp-lifecycle-operator-e2e-push.yaml
@@ -1,21 +1,21 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
+#
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/mcp-lifecycle-operator?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
-    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
-    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "$$TARGET_BRANCH$$"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: opendatahub-builds
-    appstudio.openshift.io/component: odh-mcp-lifecycle-operator-ci
+    appstudio.openshift.io/component: odh-mcp-lifecycle-operator-e2e-ci
     pipelines.appstudio.openshift.io/type: build
-  name: odh-mcp-lifecycle-operator-on-pull-request
+  name: odh-mcp-lifecycle-operator-e2e-on-push
   namespace: open-data-hub-tenant
 spec:
   params:
@@ -24,17 +24,11 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/opendatahub/odh-mcp-lifecycle-operator:$$OUTPUT_IMAGE_TAG$$
+    value: quay.io/opendatahub/odh-mcp-lifecycle-operator/e2e:$$OUTPUT_IMAGE_TAG$$
   - name: dockerfile
-    value: Dockerfile.konflux
+    value: test/e2e/Dockerfile
   - name: path-context
     value: .
-  #add these additional params
-  - name: additional-tags
-    value:
-    - 'odh-pr-{{revision}}'
-  - name: pipeline-type
-    value: pull-request
   pipelineRef:
     resolver: git
     params:
@@ -45,7 +39,7 @@ spec:
     - name: pathInRepo
       value: pipeline/multi-arch-container-build.yaml
   taskRunTemplate:
-    serviceAccountName: build-pipeline-odh-mcp-lifecycle-operator-ci
+    serviceAccountName: build-pipeline-odh-mcp-lifecycle-operator-e2e-ci
   workspaces:
   - name: git-auth
     secret:


### PR DESCRIPTION
Add Konflux pipelines for building the e2e test container image for mcp-lifecycle-operator.

## Changes

- Add PR and push pipelines for e2e test container image (`test/e2e/Dockerfile`)
- Output image: `quay.io/opendatahub/odh-mcp-lifecycle-operator/e2e`
- Use `pipelineRef` to central `multi-arch-container-build.yaml`
- Align operator PR pipeline: `cancel-in-progress=true`, add `pull_request_number` annotation

## Ref

- Jira: [RHOAIENG-75542](https://redhat.atlassian.net/browse/RHOAIENG-75542)
- MCPLO PR: opendatahub-io/mcp-lifecycle-operator#47

Assisted-by: 🤖 claude-opus-4-6@default

[RHOAIENG-75542]: https://redhat.atlassian.net/browse/RHOAIENG-75542?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated pipeline runs for pull requests and pushes, helping builds start consistently from code changes.
  * Added support for creating image tags that include pull request-specific identifiers.

* **Bug Fixes**
  * Updated pull request runs to cancel older in-progress executions, so only the latest build continues.
  * Added run retention controls to keep recent builds manageable.

* **Chores**
  * Improved build configuration to use shared source access and standardized service account settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->