### PR TITLE
Draft: Add pr-testing pipeline for trustyai-explainability

### DIFF
--- a/integration-tests/trustyai-explainability/pr-testing-pipeline.yaml
+++ b/integration-tests/trustyai-explainability/pr-testing-pipeline.yaml
@@ -1,0 +1,482 @@
+---
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  name: odh-pr-test-trustyai-explainability
+  annotations:
+    pipelinesascode.tekton.dev/on-event: "[pull_request]"
+    pipelinesascode.tekton.dev/on-target-branch: "[dev]"
+spec:
+  timeouts:
+    pipeline: 2h
+  pipelineSpec:
+    description: |
+      An integration test which provisions an ephemeral Hypershift cluster, deploys the TrustyAI
+      Explainability service from the Konflux snapshot image via kustomize, and runs the e2e tests
+      directly from the PR branch source.
+    params:
+      - description: Snapshot of the application
+        name: SNAPSHOT
+        type: string
+      - name: oci-artifacts-repo
+        default: 'quay.io/opendatahub/odh-ci-artifacts'
+        description: The OCI container used to store all test artifacts.
+      - name: artifact-browser-url
+        default: 'https://app-artifact-browser.apps.rosa.konflux-qe.zmr9.p3.openshiftapps.com'
+        description: The URL for browsing test artifacts.
+    tasks:
+      - name: audit-snapshot
+        params:
+          - name: SNAPSHOT
+            value: $(params.SNAPSHOT)
+        taskSpec:
+          params:
+            - name: SNAPSHOT
+              description: Snapshot of the application
+          results:
+          - name: pull-request-author
+          - name: pull-request-number
+          - name: git-repo
+          - name: git-org
+          - name: git-revision
+          steps:
+            - name: audit-snapshot
+              image: quay.io/konflux-ci/konflux-test:stable
+              workingDir: /workspace
+              env:
+                - name: SNAPSHOT
+                  value: $(params.SNAPSHOT)
+                - name: PR_AUTHOR
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['pac.test.appstudio.openshift.io/sender']
+                - name: PR_NUMBER
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['pac.test.appstudio.openshift.io/pull-request']
+                - name: GIT_REPO
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['pac.test.appstudio.openshift.io/url-repository']
+                - name: GIT_ORG
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['pac.test.appstudio.openshift.io/url-org']
+                - name: GIT_REVISION
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['pac.test.appstudio.openshift.io/sha']
+              script: |
+                #!/bin/bash
+                set -e
+                echo "SNAPSHOT=${SNAPSHOT}"
+
+                while IFS= read -r row; do
+                    COMPONENT_NAME=$(echo "$row" | base64 -d | jq -r '.name')
+                    IMAGE=$(echo "$row" | base64 -d | jq -r '.containerImage')
+                    GIT_COMMIT=$(echo "$row" | base64 -d | jq -r '.source.git.revision')
+                    GIT_URL=$(echo "$row" | base64 -d | jq -r '.source.git.url')
+                    echo "${COMPONENT_NAME} IMAGE: ${IMAGE}"
+                    echo "GIT_COMMIT=${GIT_COMMIT}"
+                    echo "GIT_URL=${GIT_URL}"
+                done < <(echo "$SNAPSHOT" | jq -r '.components[] | @base64')
+
+                echo -n "${PR_AUTHOR}" > "$(results.pull-request-author.path)"
+                echo -n "${PR_NUMBER}" > "$(results.pull-request-number.path)"
+                echo -n "${GIT_REPO}" > "$(results.git-repo.path)"
+                echo -n "${GIT_ORG}" > "$(results.git-org.path)"
+                echo -n "${GIT_REVISION}" > "$(results.git-revision.path)"
+
+      - name: provision-eaas-space
+        runAfter:
+          - audit-snapshot
+        taskRef:
+          resolver: git
+          params:
+            - name: url
+              value: https://github.com/konflux-ci/build-definitions.git
+            - name: revision
+              value: main
+            - name: pathInRepo
+              value: task/eaas-provision-space/0.1/eaas-provision-space.yaml
+        params:
+          - name: ownerName
+            value: $(context.pipelineRun.name)
+          - name: ownerUid
+            value: $(context.pipelineRun.uid)
+
+      - name: provision-cluster
+        runAfter:
+          - provision-eaas-space
+        taskSpec:
+          results:
+            - name: clusterName
+              value: "$(steps.create-cluster.results.clusterName)"
+          steps:
+            - name: get-supported-versions
+              ref:
+                resolver: git
+                params:
+                  - name: url
+                    value: https://github.com/konflux-ci/build-definitions.git
+                  - name: revision
+                    value: main
+                  - name: pathInRepo
+                    value: stepactions/eaas-get-supported-ephemeral-cluster-versions/0.1/eaas-get-supported-ephemeral-cluster-versions.yaml
+              params:
+                - name: eaasSpaceSecretRef
+                  value: $(tasks.provision-eaas-space.results.secretRef)
+            - name: pick-version
+              ref:
+                resolver: git
+                params:
+                  - name: url
+                    value: https://github.com/konflux-ci/build-definitions.git
+                  - name: revision
+                    value: main
+                  - name: pathInRepo
+                    value: stepactions/eaas-get-latest-openshift-version-by-prefix/0.1/eaas-get-latest-openshift-version-by-prefix.yaml
+              params:
+                - name: prefix
+                  value: "$(steps.get-supported-versions.results.versions[0])."
+            - name: create-cluster
+              ref:
+                resolver: git
+                params:
+                  - name: url
+                    value: https://github.com/konflux-ci/build-definitions.git
+                  - name: revision
+                    value: main
+                  - name: pathInRepo
+                    value: stepactions/eaas-create-ephemeral-cluster-hypershift-aws/0.1/eaas-create-ephemeral-cluster-hypershift-aws.yaml
+              params:
+                - name: eaasSpaceSecretRef
+                  value: $(tasks.provision-eaas-space.results.secretRef)
+                - name: version
+                  value: "$(steps.pick-version.results.version)"
+                - name: instanceType
+                  value: m5.2xlarge
+
+      - name: deploy-and-test
+        timeout: 90m
+        runAfter:
+          - provision-cluster
+        taskSpec:
+          volumes:
+            - name: credentials
+              emptyDir: {}
+            - name: test-status
+              emptyDir: {}
+          steps:
+            - name: get-kubeconfig
+              ref:
+                resolver: git
+                params:
+                  - name: url
+                    value: https://github.com/konflux-ci/build-definitions.git
+                  - name: revision
+                    value: main
+                  - name: pathInRepo
+                    value: stepactions/eaas-get-ephemeral-cluster-credentials/0.1/eaas-get-ephemeral-cluster-credentials.yaml
+              params:
+                - name: eaasSpaceSecretRef
+                  value: $(tasks.provision-eaas-space.results.secretRef)
+                - name: clusterName
+                  value: "$(tasks.provision-cluster.results.clusterName)"
+                - name: credentials
+                  value: credentials
+            - name: deploy-service
+              image: quay.io/rhoai/rhoai-task-toolset:trustyai
+              onError: continue
+              computeResources:
+                requests:
+                  memory: "4Gi"
+                  cpu: "2"
+                limits:
+                  memory: "8Gi"
+                  cpu: "4"
+              env:
+                - name: KUBECONFIG
+                  value: "/credentials/$(steps.get-kubeconfig.results.kubeconfig)"
+                - name: SNAPSHOT
+                  value: $(params.SNAPSHOT)
+              workingDir: /tmp
+              volumeMounts:
+                - name: credentials
+                  mountPath: /credentials
+                - name: test-status
+                  mountPath: /test-status
+              script: |
+                #!/bin/bash
+                set -e
+                STATUS_FILE="/test-status/deploy-and-e2e-status"
+                echo "failed" > "$STATUS_FILE"
+
+                oc whoami
+                oc get pods -A
+
+                echo "SNAPSHOT=${SNAPSHOT}"
+
+                # Extract service image and git info from the Konflux snapshot
+                TRUSTYAI_IMAGE=""
+                TRUSTYAI_GIT_COMMIT=""
+                TRUSTYAI_GIT_URL=""
+
+                while IFS= read -r row; do
+                  COMPONENT_NAME=$(echo "$row" | base64 -d | jq -r '.name')
+                  IMAGE=$(echo "$row" | base64 -d | jq -r '.containerImage')
+                  GIT_COMMIT=$(echo "$row" | base64 -d | jq -r '.source.git.revision')
+                  GIT_URL=$(echo "$row" | base64 -d | jq -r '.source.git.url')
+
+                  if echo "${GIT_URL}" | grep -q "trustyai-explainability"; then
+                    TRUSTYAI_IMAGE="${IMAGE}"
+                    TRUSTYAI_GIT_COMMIT="${GIT_COMMIT}"
+                    TRUSTYAI_GIT_URL="${GIT_URL}"
+                  fi
+                  echo "${COMPONENT_NAME} IMAGE: ${IMAGE} GIT_COMMIT: ${GIT_COMMIT}"
+                done < <(echo "$SNAPSHOT" | jq -r '.components[] | @base64')
+
+                echo "TRUSTYAI_IMAGE: ${TRUSTYAI_IMAGE}"
+                echo "TRUSTYAI_GIT_URL: ${TRUSTYAI_GIT_URL}"
+                echo "TRUSTYAI_GIT_COMMIT: ${TRUSTYAI_GIT_COMMIT}"
+
+                NAMESPACE="opendatahub"
+
+                # Create target namespace
+                oc create namespace ${NAMESPACE} --dry-run=client -o yaml | oc apply -f -
+
+                # Deploy the service using the image built by the Konflux PR build pipeline
+                echo "Deploying trustyai-explainability service (image: ${TRUSTYAI_IMAGE})..."
+
+                # Create deployment for trustyai-explainability
+                cat <<EOF | oc apply -f -
+                apiVersion: apps/v1
+                kind: Deployment
+                metadata:
+                  name: trustyai-service
+                  namespace: ${NAMESPACE}
+                spec:
+                  replicas: 1
+                  selector:
+                    matchLabels:
+                      app: trustyai-service
+                  template:
+                    metadata:
+                      labels:
+                        app: trustyai-service
+                    spec:
+                      containers:
+                      - name: trustyai-service
+                        image: ${TRUSTYAI_IMAGE}
+                        ports:
+                        - containerPort: 8080
+                        env:
+                        - name: SERVICE_STORAGE_FORMAT
+                          value: "PVC"
+                ---
+                apiVersion: v1
+                kind: Service
+                metadata:
+                  name: trustyai-service
+                  namespace: ${NAMESPACE}
+                spec:
+                  selector:
+                    app: trustyai-service
+                  ports:
+                  - protocol: TCP
+                    port: 8080
+                    targetPort: 8080
+                EOF
+
+                oc rollout status deployment/trustyai-service -n ${NAMESPACE} --timeout=300s
+
+                echo "success" > "$STATUS_FILE"
+
+            - name: run-opendatahub-tests
+              image: quay.io/opendatahub/opendatahub-tests:latest
+              volumeMounts:
+                - name: credentials
+                  mountPath: /credentials
+              env:
+                - name: KUBECONFIG
+                  value: "/credentials/$(steps.get-kubeconfig.results.kubeconfig)"
+                - name: ARTIFACT_DIR
+                  value: /workspace/artifacts-dir
+              workingDir: /tmp
+              script: |
+                #!/bin/bash
+                set -e
+                mkdir -p "${ARTIFACT_DIR}"
+
+                # Run opendatahub-tests smoke tests
+                cd /opt/app-root/tests
+                pytest -m "smoke" --junitxml="${ARTIFACT_DIR}/trustyai-smoke-tests.xml" -v || true
+
+            - name: must-gather
+              onError: continue
+              image: quay.io/rhoai/rhoai-task-toolset:trustyai
+              env:
+                - name: KUBECONFIG
+                  value: "/credentials/$(steps.get-kubeconfig.results.kubeconfig)"
+                - name: ARTIFACT_DIR
+                  value: /workspace/artifacts-dir
+              workingDir: /tmp
+              volumeMounts:
+                - name: credentials
+                  mountPath: /credentials
+              script: |
+                NAMESPACE="opendatahub"
+                mkdir -p "${ARTIFACT_DIR}/gather-trustyai"
+                oc get deployments,services,pods -n ${NAMESPACE} -o yaml \
+                  > "${ARTIFACT_DIR}/gather-trustyai/trustyai-resources.yaml" 2>/dev/null || true
+                oc get pods -n ${NAMESPACE} -o wide \
+                  > "${ARTIFACT_DIR}/gather-trustyai/pods.txt" 2>/dev/null || true
+                oc get events -n ${NAMESPACE} --sort-by='.lastTimestamp' \
+                  > "${ARTIFACT_DIR}/gather-trustyai/events.txt" 2>/dev/null || true
+                oc describe deployment/trustyai-service -n ${NAMESPACE} \
+                  > "${ARTIFACT_DIR}/gather-trustyai/service-deployment.txt" 2>/dev/null || true
+                oc logs deployment/trustyai-service -n ${NAMESPACE} \
+                  > "${ARTIFACT_DIR}/gather-trustyai/service-logs.txt" 2>/dev/null || true
+
+            - name: git-push-artifacts
+              ref:
+                resolver: git
+                params:
+                  - name: url
+                    value: https://github.com/red-hat-data-services/rhoai-konflux-tasks.git
+                  - name: revision
+                    value: main
+                  - name: pathInRepo
+                    value: stepactions/secure-git-push/0.1/secure-git-push.yaml
+              params:
+                - name: source-path
+                  value: /workspace/artifacts-dir
+                - name: repo-path
+                  value: 'opendatahub-io/odh-build-metadata'
+                - name: repo-branch
+                  value: 'ci-artifacts'
+                - name: sparse-file-path
+                  value: 'test-artifacts/docs'
+                - name: dest-path
+                  value: 'test-artifacts/$(context.pipelineRun.name)'
+                - name: pipelinerun-name
+                  value: $(context.pipelineRun.name)
+
+            - name: check-test-exit-code
+              image: quay.io/rhoai-konflux/alpine:latest
+              volumeMounts:
+                - name: test-status
+                  mountPath: /test-status
+              script: |
+                STATUS_FILE="/test-status/deploy-and-e2e-status"
+                if ! [ -f "$STATUS_FILE" ] || [ "$(cat "$STATUS_FILE")" != "success" ]; then
+                  echo "Failing pipeline because deploy-and-e2e step failed"
+                  exit 1
+                fi
+                echo "deploy-and-e2e step succeeded"
+
+    finally:
+    - name: push-ci-artifacts-and-update-pr
+      params:
+        - name: oci-artifacts-repo
+          value: $(params.oci-artifacts-repo)
+        - name: pipeline-status
+          value: $(tasks.status)
+      taskSpec:
+        volumes:
+          - name: odh-registry-secret-volume
+            secret:
+              secretName: odh-registry-secret
+              items:
+              - key: .dockerconfigjson
+                path: oci-storage-dockerconfigjson
+        params:
+          - name: oci-artifacts-repo
+            description: oci-artifacts-repo
+          - name: pipeline-status
+            type: string
+        steps:
+          - name: pull-ci-artifacts
+            ref:
+              resolver: git
+              params:
+                - name: url
+                  value: https://github.com/red-hat-data-services/rhoai-konflux-tasks.git
+                - name: revision
+                  value: main
+                - name: pathInRepo
+                  value: stepactions/git-clone/0.1/git-clone.yaml
+            params:
+              - name: repo-path
+                value: 'opendatahub-io/odh-build-metadata'
+              - name: repo-branch
+                value: 'ci-artifacts'
+              - name: sparse-file-path
+                value: 'test-artifacts/$(context.pipelineRun.name)'
+              - name: dest-path
+                value: /workspace/odh-ci-artifacts
+              - name: artifacts-dir-path
+                value: 'test-artifacts/$(context.pipelineRun.name)'
+          - name: secure-push-oci
+            ref:
+              resolver: git
+              params:
+                - name: url
+                  value: https://github.com/red-hat-data-services/rhoai-konflux-tasks.git
+                - name: revision
+                  value: main
+                - name: pathInRepo
+                  value: stepactions/secure-push-oci/0.1/secure-push-oci.yaml
+            params:
+              - name: workdir-path
+                value: '/workspace/odh-ci-artifacts/test-artifacts/$(context.pipelineRun.name)'
+              - name: oci-ref
+                value: $(params.oci-artifacts-repo):$(context.pipelineRun.name)
+              - name: credentials-volume-name
+                value: odh-registry-secret-volume
+          - name: share-status-on-pull-request
+            ref:
+              resolver: git
+              params:
+                - name: url
+                  value: https://github.com/red-hat-data-services/rhoai-konflux-tasks.git
+                - name: revision
+                  value: main
+                - name: pathInRepo
+                  value: stepactions/pull-request-comment/0.1/pull-request-comment.yaml
+            params:
+              - name: test-name
+                value: $(context.pipelineRun.name)
+              - name: oci-container
+                value: $(params.oci-artifacts-repo):$(context.pipelineRun.name)
+              - name: pipeline-aggregate-status
+                value: $(params.pipeline-status)
+              - name: pull-request-author
+                value: $(tasks.audit-snapshot.results.pull-request-author)
+              - name: pull-request-number
+                value: $(tasks.audit-snapshot.results.pull-request-number)
+              - name: git-repo
+                value: $(tasks.audit-snapshot.results.git-repo)
+              - name: git-org
+                value: $(tasks.audit-snapshot.results.git-org)
+              - name: git-revision
+                value: $(tasks.audit-snapshot.results.git-revision)
+              - name: artifact-browser-url
+                value: $(params.artifact-browser-url)
+          - name: cleanup-artifacts-from-git
+            ref:
+              resolver: git
+              params:
+                - name: url
+                  value: https://github.com/red-hat-data-services/rhoai-konflux-tasks.git
+                - name: revision
+                  value: main
+                - name: pathInRepo
+                  value: stepactions/cleanup-git-repo/0.1/cleanup-git-repo.yaml
+            params:
+              - name: work-dir
+                value: '/workspace/odh-ci-artifacts'
+              - name: artifacts-dir-path
+                value: 'test-artifacts'
+              - name: dir-to-be-deleted
+                value: '$(context.pipelineRun.name)'


### PR DESCRIPTION
- Provisions ephemeral Hypershift cluster via EaaS
- Deploys TrustyAI service from Konflux snapshot image
- Runs opendatahub-tests smoke tests (pytest -m "smoke")
- Collects and uploads test artifacts to OCI registry
- Posts results back to PR

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated pull request testing for TrustyAI Explainability changes.
  * PRs now run against a temporary cluster, deploy the service, and execute smoke tests.
  * Test results and deployment status are collected and posted back to the pull request for easier review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->