### PR TITLE
Add odh-mcp-lifecycle-operator-e2e-ci PipelineRuns

### DIFF
--- a/pipelineruns/mcp-lifecycle-operator/odh-mcp-lifecycle-operator-e2e-pull-request.yaml
+++ b/pipelineruns/mcp-lifecycle-operator/odh-mcp-lifecycle-operator-e2e-pull-request.yaml
@@ -1,0 +1,52 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/mcp-lifecycle-operator?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
+      == "$$TARGET_BRANCH$$"
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: opendatahub-builds
+    appstudio.openshift.io/component: odh-mcp-lifecycle-operator-e2e-ci
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-mcp-lifecycle-operator-e2e-on-pull-request
+  namespace: open-data-hub-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/opendatahub/odh-mcp-lifecycle-operator-e2e:$$OUTPUT_IMAGE_TAG$$
+  - name: dockerfile
+    value: test/e2e/Dockerfile
+  - name: path-context
+    value: .
+  #add these additional params
+  - name: additional-tags
+    value:
+    - 'odh-pr-{{revision}}'
+  - name: pipeline-type
+    value: pull-request
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/opendatahub-io/odh-konflux-central.git
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipeline/multi-arch-container-build.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-odh-mcp-lifecycle-operator-e2e-ci
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/pipelineruns/mcp-lifecycle-operator/odh-mcp-lifecycle-operator-e2e-push.yaml
+++ b/pipelineruns/mcp-lifecycle-operator/odh-mcp-lifecycle-operator-e2e-push.yaml
@@ -1,0 +1,47 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+#
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/mcp-lifecycle-operator?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "$$TARGET_BRANCH$$"
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: opendatahub-builds
+    appstudio.openshift.io/component: odh-mcp-lifecycle-operator-e2e-ci
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-mcp-lifecycle-operator-e2e-on-push
+  namespace: open-data-hub-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/opendatahub/odh-mcp-lifecycle-operator-e2e:$$OUTPUT_IMAGE_TAG$$
+  - name: dockerfile
+    value: test/e2e/Dockerfile
+  - name: path-context
+    value: .
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/opendatahub-io/odh-konflux-central.git
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipeline/multi-arch-container-build.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-odh-mcp-lifecycle-operator-e2e-ci
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}


### PR DESCRIPTION
Adds push and pull-request PipelineRun YAMLs for 'odh-mcp-lifecycle-operator-e2e-ci'.

Component repo: https://github.com/opendatahub-io/mcp-lifecycle-operator
Jira: https://redhat.atlassian.net/browse/RHOAIENG-76108

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated end-to-end container build workflows for pull requests.
  * Added automated end-to-end container build workflows for pushes to the target branch.
  * Configured builds with source revision, Dockerfile, image tags, and registry authentication settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->