### PR TITLE
fix: add retry with rebase to push-build-metadata task

### DIFF
--- a/pipeline/multi-arch-operator-build.yaml
+++ b/pipeline/multi-arch-operator-build.yaml
@@ -750,7 +750,22 @@ spec:
 
             git add --sparse components/odh-operator/${OUTPUT_IMAGE_DIGEST}
             git commit -m "build-meta for operator image ${OUTPUT_IMAGE_DIGEST}"
-            git push
+
+            # Retry loop: concurrent builds writing to different digest dirs
+            # can race on git push. Rebase is safe because paths never overlap.
+            MAX_RETRIES=5
+            for attempt in $(seq 1 $MAX_RETRIES); do
+              if git push; then
+                echo "Push succeeded (attempt ${attempt})"
+                break
+              fi
+              if [ "$attempt" -eq "$MAX_RETRIES" ]; then
+                echo "ERROR: Push failed after ${MAX_RETRIES} attempts"
+                exit 1
+              fi
+              echo "Push failed (attempt ${attempt}/${MAX_RETRIES}), rebasing and retrying..."
+              git pull --rebase origin main
+            done
 
     when:
     - input: "$(params.build-type)"


### PR DESCRIPTION
## Summary

The `push-build-metadata` task in the operator build pipeline does `git clone` → `git commit` → `git push` to the [odh-build-metadata](https://github.com/opendatahub-io/odh-build-metadata) repo. Since `cancel-in-progress` is set to `false`, multiple PipelineRuns can execute concurrently. When a second run tries to push after another run already pushed, it fails with:

```
! [rejected]  main -> main (fetch first)
error: failed to push some refs to 'https://github.com/opendatahub-io/odh-build-metadata.git'
```

This is a race condition — both runs clone the same state, but only the first push succeeds.

## Fix

Replace the bare `git push` with a retry loop (up to 5 attempts) that does `git pull --rebase origin main` before retrying. This is safe because each build writes to its own digest-based subdirectory (`components/odh-operator/<sha>/`), so rebase will never encounter merge conflicts.

## Evidence

Recent failures observed in `odh-operator-ci-on-push` PipelineRuns on `stone-prd-rh01`:
- `odh-operator-ci-on-push-cwrnj` — failed at `push-build-metadata` with the exact error above
- `odh-operator-ci-on-push-vp82m` — same failure, same root cause