### PR TITLE
Add PR-attached group testing support for Early Gate

### DIFF
--- a/early-gate/docs/early-gate-group-testing-design.md
+++ b/early-gate/docs/early-gate-group-testing-design.md
@@ -1,0 +1,538 @@
+# Early Gate Group Testing — Design Document
+
+**Feature name:** PR-Attached Group Testing  
+**Pipelines:** `early-gate-component-pipeline`, `early-gate-operator-pipeline`, `early-gate-test-pipeline`
+
+---
+
+## 1. Purpose
+
+This feature enables coordinated testing of multiple related PRs across repositories by embedding a group configuration directly in a PR description. When a developer needs to test changes that span repositories (e.g., kserve + feast), they list the related PR URLs in a config block in their "leader" PR description. The pipeline detects this configuration, resolves all specified PRs to their component images, and builds a combined snapshot for integration testing.
+
+The design is **self-service** (no approval gates), **backward compatible** (PRs without config work exactly as before), and **gracefully degrading** (errors fall back to single-PR mode).
+
+---
+
+## 2. Workflow Diagram
+
+```mermaid
+flowchart TD
+    PUSH["Push to leader PR"] --> INIT["init task<br/>Extract REPO_NAME, PR_NUMBER<br/>from PipelinesAsCode labels"]:::init
+
+    INIT --> RESOLVE["resolve-group-configuration<br/><br/>Fetch PR description (GitHub API)<br/>Search for config marker<br/>Parse PR URLs<br/>Lookup components in repo map<br/>Merge with PR metadata"]:::resolve
+
+    RESOLVE --> SNAPSHOT["generate-snapshot<br/><br/>For each component:<br/>Query Quay for odh-pr-{number}<br/>Fallback to odh-stable if missing<br/>Build snapshot.json with SHA digests"]:::snapshot
+
+    SNAPSHOT --> WARNING["post-group-testing-warning<br/><br/>Build markdown table with PR links<br/>Post summary comment to PR<br/>Show fallback warnings if any"]:::warning
+
+    WARNING --> AUDIT["audit-snapshot"]:::existing
+
+    AUDIT --> BUILD["build-operator-container<br/>build-bundle-container<br/>build-fbc-container"]:::existing
+
+    BUILD --> POST["post-build-complete-comment<br/><br/>Post consolidated build results<br/>Include snapshot and test info"]:::post
+
+    POST --> TEST["trigger-early-gate-test<br/><br/>Extract group repos<br/>Trigger test pipeline<br/>Pass group repos to Jenkins"]:::test
+
+    classDef init fill:#e0e0e0,stroke:#757575,color:#000
+    classDef resolve fill:#bbdefb,stroke:#1976d2,color:#000
+    classDef snapshot fill:#b2dfdb,stroke:#00796b,color:#000
+    classDef warning fill:#fff9c4,stroke:#f9a825,color:#000
+    classDef existing fill:#e0e0e0,stroke:#757575,color:#000
+    classDef post fill:#e1bee7,stroke:#7b1fa2,color:#000
+    classDef test fill:#c8e6c9,stroke:#388e3c,color:#000
+```
+
+---
+
+## 3. Decision Tree
+
+```mermaid
+flowchart TD
+    START([START]):::terminal --> FETCH["Fetch PR description<br/>via GitHub API"]:::resolve
+
+    FETCH --> MARKER{Config marker<br/>found?}:::decision
+
+    MARKER -- "No" --> SINGLE["Single-PR mode<br/>Resolve components for<br/>current repo only"]:::single
+
+    MARKER -- "Yes" --> PARSE["Parse PR URLs<br/>from config block"]:::resolve
+
+    PARSE --> VALID{Valid URLs<br/>found?}:::decision
+
+    VALID -- "No (parse error)" --> SINGLE
+
+    VALID -- "Yes" --> LOOKUP["Lookup components in<br/>component_repo_map.json"]:::resolve
+
+    LOOKUP --> MAP_OK{Map file<br/>available?}:::decision
+
+    MAP_OK -- "No" --> FAIL([Pipeline fails<br/>critical dependency]):::fail
+
+    MAP_OK -- "Yes" --> MERGE["Merge leader + collaborator<br/>components with PR metadata"]:::resolve
+
+    MERGE --> QUAY["Query Quay for each<br/>component image"]:::snapshot
+
+    QUAY --> IMG{Image<br/>found?}:::decision
+
+    IMG -- "Yes" --> SHA["Use PR image<br/>SHA digest"]:::pass
+
+    IMG -- "No" --> STABLE["Fallback to<br/>odh-stable + warn"]:::warn
+
+    SHA --> SNAP["Build snapshot.json"]:::snapshot
+    STABLE --> SNAP
+
+    SINGLE --> SNAP
+
+    SNAP --> TEST["Run integration tests"]:::test
+
+    classDef terminal fill:#e0e0e0,stroke:#757575,color:#000
+    classDef decision fill:#ffe0b2,stroke:#f57c00,color:#000
+    classDef resolve fill:#bbdefb,stroke:#1976d2,color:#000
+    classDef snapshot fill:#b2dfdb,stroke:#00796b,color:#000
+    classDef single fill:#e0e0e0,stroke:#757575,color:#000
+    classDef pass fill:#c8e6c9,stroke:#388e3c,color:#000
+    classDef warn fill:#fff3e0,stroke:#ff9800,color:#000
+    classDef fail fill:#ffcdd2,stroke:#d32f2f,color:#000
+    classDef test fill:#c8e6c9,stroke:#388e3c,color:#000
+```
+
+---
+
+## 4. Execution Phases
+
+### Phase 1: Resolve Group Configuration
+
+**Task:** `resolve-group-configuration`
+**Source:** `early-gate/tasks/resolve-group-configuration.yaml`
+
+Fetches the PR description from GitHub, searches for the group config marker, parses collaborator PR URLs, and resolves all repos to their component images.
+
+**Process:**
+
+1. Extract `REPO_NAME` and `PR_NUMBER` from PipelinesAsCode labels
+2. Fetch PR description via GitHub API (authenticated if token available, unauthenticated fallback)
+3. Search for `## Early Gate Testing` heading (or any heading containing "earlygate")
+4. Extract PR URLs from the config block (stops at next `##` heading)
+5. Automatically include leader PR components
+6. For each collaborator URL, parse `org/repo/pr` and lookup components in `component_repo_map.json`
+7. Merge all components with PR metadata into `group-components` JSON
+
+**Parameters:**
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `PR_NUMBER` | *(required)* | Pull request number |
+| `REPO_NAME` | *(required)* | Repository name |
+| `GITHUB_ORG` | `opendatahub-io` | GitHub organization |
+
+**Results:**
+
+| Result | Description |
+|--------|-------------|
+| `group-components` | Resolved components JSON with PR metadata |
+| `has-group-config` | `"true"` if group config found, `"false"` otherwise |
+
+**Component Output Format:**
+
+```json
+{
+  "kserve-agent-ci": {
+    "quay_path": "opendatahub/kserve-agent",
+    "pr": "123"
+  },
+  "feast-operator-ci": {
+    "quay_path": "opendatahub/feast-operator",
+    "pr": "456"
+  }
+}
+```
+
+---
+
+### Phase 2: Generate Snapshot
+
+**Task:** `generate-snapshot-for-group-testing`
+**Source:** `early-gate/tasks/generate-snapshot-for-group-testing.yaml`
+
+Queries Quay registry for each component's PR-specific image and builds a combined snapshot with immutable SHA digest references.
+
+```mermaid
+flowchart TD
+    A[Component: kserve-agent-ci<br/>PR: 123] --> B{Query Quay for<br/>odh-pr-123 tag}
+    B -->|Image exists| C[Get SHA digest]
+    B -->|404 Not Found| D{Fallback: Query<br/>odh-stable tag}
+    C --> E[Use PR image<br/>sha256:abc123...]
+    D -->|Found| F[Use stable image<br/>sha256:stable789...]
+    D -->|Not Found| G[ERROR: Critical failure]
+    E --> H[Add to snapshot.json]
+    F --> I[Add to snapshot.json<br/>+ log warning]
+
+    style B fill:#fff4e6
+    style E fill:#e8f5e9
+    style F fill:#ffe0b2
+    style G fill:#ffebee
+```
+
+**Image Resolution Strategy:**
+
+| Scenario | Image Tag Query | Result | Action |
+|----------|----------------|--------|--------|
+| PR build complete | `odh-pr-{number}` exists | Found | Use PR image (immutable SHA digest) |
+| PR build in progress | `odh-pr-{number}` not found | Not ready | Fallback to `odh-stable` + log warning |
+| Stable fallback available | `odh-stable` exists | Found | Use stable image + warning in test logs |
+| Both missing | Neither tag exists | Critical | Pipeline fails (component not testable) |
+
+**Component Format Support (backward compatible):**
+
+| Format | Example | Usage |
+|--------|---------|-------|
+| Old (string) | `{"component": "path"}` | Single-PR mode |
+| New (object) | `{"component": {"quay_path": "path", "pr": "123"}}` | Group testing mode |
+
+**Snapshot JSON Structure:**
+
+```json
+{
+  "kserve-agent-ci": {
+    "image": "quay.io/opendatahub/kserve-agent@sha256:abc123...",
+    "image_tag": "odh-pr-123",
+    "git.url": "https://github.com/opendatahub-io/kserve",
+    "git.commit": "abc123def456..."
+  },
+  "feast-operator-ci": {
+    "image": "quay.io/opendatahub/feast-operator@sha256:def456...",
+    "image_tag": "odh-pr-456",
+    "git.url": "https://github.com/opendatahub-io/feast",
+    "git.commit": "789abc012def..."
+  }
+}
+```
+
+---
+
+### Phase 3: Post Group Testing Warning
+
+**Task:** `post-group-testing-warning`
+**Source:** `early-gate/tasks/post-group-testing-warning.yaml`
+
+Builds a markdown table summarizing the group test and posts it as a PR comment. Only shows warnings when actual fallbacks occurred or repos were skipped.
+
+**Summary table includes:**
+- PR numbers (clickable links)
+- Components from each PR
+- Tags used (`odh-pr-XXX` or `odh-stable`)
+- Status (ready or fallback)
+- Image digests
+
+---
+
+### Phase 4: Post Build Complete Comment
+
+**Task:** `post-build-complete-comment`
+**Source:** `early-gate/tasks/post-build-complete-comment.yaml`
+
+Posts a consolidated build results comment to the PR after the build phase completes. Includes snapshot information and test configuration.
+
+---
+
+### Phase 5: Extract Group Repos and Trigger Tests
+
+**Task:** `extract-group-repos`
+**Source:** `early-gate/tasks/extract-group-repos.yaml`
+
+Extracts the list of repositories from the group components JSON for passing to the test pipeline trigger.
+
+**Task:** `trigger-test-pipeline`
+**Source:** `early-gate/tasks/trigger-test-pipeline.yaml`
+
+Triggers the early-gate test pipeline via GitHub Actions workflow dispatch, passing group repos so Jenkins runs tests for all components in the group.
+
+---
+
+## 5. Configuration Schema
+
+### PR Description Format
+
+Configuration is embedded in PR descriptions under an `## Early Gate Testing` heading:
+
+```markdown
+## Early Gate Testing
+https://github.com/opendatahub-io/kserve/pull/123
+https://github.com/opendatahub-io/feast/pull/456
+```
+
+### Detection Rules
+
+| Rule | Detail |
+|------|--------|
+| Marker | Any `##` heading containing "earlygate" or "early gate" (case-insensitive) |
+| URL format | `https://github.com/{org}/{repo}/pull/{number}` |
+| Block end | Next `##` heading |
+| Formatting | URLs can have bullets, dashes, or whitespace prefix |
+
+### URL Parsing
+
+```
+https://github.com/opendatahub-io/kserve/pull/123
+                   └────┬────┘ └──┬──┘      └┬┘
+                     org       repo         pr
+```
+
+---
+
+## 6. Data Flow
+
+### Component Resolution
+
+```mermaid
+sequenceDiagram
+    participant PR as GitHub PR
+    participant Pipeline as Pipeline
+    participant GitHub as GitHub API
+    participant Map as component_repo_map.json
+    participant Quay as Quay Registry
+
+    Pipeline->>GitHub: Fetch PR description
+    GitHub-->>Pipeline: PR body with config
+    Pipeline->>Pipeline: Parse PR URLs
+    Pipeline->>Map: Lookup repos → components
+    Map-->>Pipeline: Component list
+
+    loop For each component
+        Pipeline->>Quay: Query odh-pr-{number} tag
+        alt Image exists
+            Quay-->>Pipeline: SHA digest (immutable ref)
+            Pipeline->>Pipeline: Add to snapshot
+        else Image not built yet
+            Quay-->>Pipeline: 404 Not Found
+            Pipeline->>Quay: Fallback: Query odh-stable
+            Quay-->>Pipeline: SHA digest (stable)
+            Pipeline->>Pipeline: Add to snapshot + warn
+        end
+    end
+
+    Pipeline->>Pipeline: Build snapshot.json
+```
+
+### Data Transformation
+
+| Stage | Input | Output |
+|-------|-------|--------|
+| URL Parsing | `github.com/opendatahub-io/kserve/pull/123` | `{org: opendatahub-io, repo: kserve, pr: 123}` |
+| Component Lookup | `component_repo_map.json["kserve"]` | `{"kserve-agent-ci": "...", "kserve-controller-ci": "..."}` |
+| Metadata Merge | Components + PR number | `{"kserve-agent-ci": {"quay_path": "...", "pr": "123"}}` |
+| Image Resolution | Component metadata | `quay.io/.../kserve-agent:odh-pr-123 → sha256:abc...` |
+
+---
+
+## 7. Task Dependency Graph
+
+### Component/Operator Pipeline
+
+```mermaid
+flowchart TD
+    INIT["init<br/>(task 1)"]:::init -->|runAfter| RESOLVE["resolve-group-configuration<br/>(task 2)"]:::resolve
+
+    RESOLVE -->|runAfter| SNAPSHOT["generate-snapshot<br/>(task 3)<br/>Input: group-components"]:::snapshot
+
+    SNAPSHOT -->|runAfter| WARNING["post-group-testing-warning<br/>(task 4)<br/>Input: component-table, fallback-warnings"]:::warning
+
+    SNAPSHOT -->|runAfter| AUDIT["audit-snapshot<br/>(task 5)"]:::existing
+
+    AUDIT --> BUILD["build-operator / build-bundle / build-fbc<br/>(tasks 6-8)"]:::existing
+
+    BUILD --> POST["post-build-complete-comment<br/>(task 9)"]:::post
+
+    POST --> TRIGGER["trigger-early-gate-test<br/>(task 10)"]:::test
+
+    classDef init fill:#e0e0e0,stroke:#757575,color:#000
+    classDef resolve fill:#bbdefb,stroke:#1976d2,color:#000
+    classDef snapshot fill:#b2dfdb,stroke:#00796b,color:#000
+    classDef warning fill:#fff9c4,stroke:#f9a825,color:#000
+    classDef existing fill:#e0e0e0,stroke:#757575,color:#000
+    classDef post fill:#e1bee7,stroke:#7b1fa2,color:#000
+    classDef test fill:#c8e6c9,stroke:#388e3c,color:#000
+```
+
+### Test Pipeline
+
+```mermaid
+flowchart TD
+    EXTRACT["extract-group-repos<br/>(task 1)<br/>Input: snapshot-repos"]:::resolve -->|runAfter| CHECK["check-ongoing-jobs<br/>(task 2)"]:::existing
+
+    CHECK -->|"when: resume-from == none"| TRIGGER["trigger-test-pipeline<br/>(task 3)<br/>Input: group-repos"]:::test
+
+    TRIGGER --> MONITOR["monitor-jenkins-job<br/>(task 4)"]:::existing
+
+    classDef resolve fill:#bbdefb,stroke:#1976d2,color:#000
+    classDef existing fill:#e0e0e0,stroke:#757575,color:#000
+    classDef test fill:#c8e6c9,stroke:#388e3c,color:#000
+```
+
+---
+
+## 8. Error Handling and Resilience
+
+### Graceful Degradation Principle
+
+Every error (except missing `component_repo_map.json`) falls back to **single-PR mode**, ensuring pipelines never fail due to group testing issues.
+
+### resolve-group-configuration
+
+| Failure | Behavior |
+|---------|----------|
+| No config marker in PR description | Single-PR mode (expected for non-group PRs) |
+| Invalid/unparseable config | Single-PR mode + warning logged |
+| Invalid PR URL format | Skip entry, process remaining valid URLs |
+| Non-existent PR (GitHub API 404) | Skip entry, process others |
+| Repo not in component_repo_map.json | Skip repo + warning, merge others |
+| GitHub API error / rate limit | Single-PR mode + warning |
+| **component_repo_map.json missing** | **Pipeline fails (critical dependency)** |
+
+### generate-snapshot-for-group-testing
+
+| Failure | Behavior |
+|---------|----------|
+| PR image not found on Quay (`odh-pr-{number}`) | Fallback to `odh-stable` tag + warning |
+| Stable image also missing | Pipeline fails for that component |
+| Quay API error | Retry, then fail |
+
+### post-group-testing-warning
+
+| Failure | Behavior |
+|---------|----------|
+| No group config detected | Task skipped (no comment posted) |
+| GitHub API error posting comment | Warning logged, pipeline continues |
+
+### Warning Format
+
+```
+⚠️  WARNING: Component 'feast-operator-ci' does not have PR image for tag odh-pr-456
+   Quay query returned: 404 Not Found
+   Reason: PR build may still be in progress
+   Action: Falling back to odh-stable tag
+   Impact: Group test will use stable image instead of PR code
+```
+
+---
+
+## 9. Design Decisions
+
+### PR-Attached vs Central Configuration
+
+**Chosen:** PR-Attached Configuration
+
+| Aspect | PR-Attached (chosen) | Central Config (alternative) |
+|--------|---------------------|------------------------------|
+| Config location | Leader PR description | `config/earlygate-group-configuration.yaml` in OKC repo |
+| Setup | Self-service, no PR to OKC needed | Requires PR to OKC, must be reviewed and merged |
+| Visibility | Config visible to PR reviewers | Centralized, discoverable in one place |
+| Lifecycle | Automatic cleanup when PR closes | Manual cleanup via PR to OKC |
+| Discovery | Distributed across PR descriptions | Single file lists all active groups |
+
+**Rationale:**
+- Self-service model with no approval gates
+- Configuration co-located with the code change
+- Automatic lifecycle management (config goes away when PR closes/merges)
+- Zero coordination overhead for teams
+
+### Leader PR Auto-Inclusion
+
+Users only list collaborator PRs in config. The PR where config is added is automatically included.
+
+**Rationale:** Simpler for users, less error-prone, avoids redundant self-references.
+
+### Simple Text Format (No YAML)
+
+Config is just a heading + URLs, no YAML parsing needed.
+
+**Rationale:** Easier to use, fewer syntax errors for developers.
+
+### Graceful Fallback
+
+If a PR image isn't ready, use `odh-stable` and warn instead of failing.
+
+**Rationale:** Tests can still run with partial group coverage. Users can re-trigger later when all builds are ready.
+
+---
+
+## 10. Backward Compatibility
+
+### 100% Backward Compatible
+
+| Scenario | Behavior |
+|----------|----------|
+| PR without group config | Single-PR mode (no change from before) |
+| `enable-group-testing=false` | Group config ignored, single-PR mode |
+| Existing pipeline parameters | No changes required |
+| Snapshot format | Unchanged (same JSON structure) |
+| Downstream tasks | Unaffected |
+
+### Component Format Support
+
+The `generate-snapshot` task supports both formats:
+
+| Format | Example | Mode |
+|--------|---------|------|
+| String (legacy) | `{"component": "quay/path"}` | Single-PR |
+| Object (new) | `{"component": {"quay_path": "quay/path", "pr": "123"}}` | Group testing |
+
+---
+
+## 11. Parameters Reference
+
+### resolve-group-configuration
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `PR_NUMBER` | *(required)* | Pull request number (from PipelinesAsCode labels) |
+| `REPO_NAME` | *(required)* | Repository name (from PipelinesAsCode labels) |
+| `GITHUB_ORG` | `opendatahub-io` | GitHub organization |
+
+### generate-snapshot-for-group-testing
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `COMPONENTS` | *(required)* | Group components JSON from resolve task |
+| `CURRENT_PR_NUMBER` | `""` | Current PR number (fallback for legacy format) |
+| `fallback-tag` | `odh-stable` | Tag to use when PR image not found |
+| `ociStorage` | *(required)* | OCI storage path for snapshot artifact |
+| `ociArtifactExpiresAfter` | `7d` | Snapshot artifact expiration |
+
+### Secret Configuration
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `pr-token-secret-name` | `odh-github-secret` | K8s secret for GitHub API token |
+| `pr-token-secret-key` | `commenter-token` | Key within the secret |
+
+---
+
+## 12. Performance Characteristics
+
+### API Calls per Execution
+
+**Single-PR mode (no config):**
+- 1 GitHub API call (fetch PR description, marker not found)
+- N Quay API calls (N = number of components in repo)
+
+**Group testing mode (2 PRs, 4 components each):**
+- 1 GitHub API call (fetch PR description)
+- ~8 Quay API calls (2 queries per component: tag check + manifest)
+
+**Rate Limits:**
+- GitHub API: 60 req/hr (unauthenticated), 5000 req/hr (authenticated)
+- Quay API: No documented limit
+
+---
+
+## 13. Security Considerations
+
+### GitHub Authentication
+- Reads token from workspace `basic-auth/.git-credentials`
+- Falls back to unauthenticated API (rate limited)
+- Tokens never logged or exposed
+
+### Input Validation
+- PR URLs validated with regex
+- Only accepts `https://github.com/` URLs
+- PR numbers must be numeric
+- Config parsing errors caught gracefully (no injection risk)

--- a/early-gate/docs/group-testing-user-guide.md
+++ b/early-gate/docs/group-testing-user-guide.md
@@ -1,0 +1,288 @@
+# Group Testing User Guide
+
+**Feature:** PR-Attached Group Testing for Early Gate  
+**Pipeline:** `early-gate-component-pipeline` / `early-gate-operator-pipeline`
+
+---
+
+## Overview
+
+Group testing lets you test multiple related PRs together in the early-gate pipeline. Add a simple config to your PR description, and the pipeline automatically builds a combined snapshot with images from all grouped PRs and runs integration tests against it.
+
+---
+
+## Quick Start
+
+Copy this into your **leader PR description**:
+
+```markdown
+## Early Gate Testing
+https://github.com/opendatahub-io/COLLABORATOR_REPO/pull/COLLABORATOR_PR_NUMBER
+```
+
+**Replace:**
+- `COLLABORATOR_REPO` with the collaborator repository name
+- `COLLABORATOR_PR_NUMBER` with the collaborator PR number
+
+**Important:**
+- Only list collaborator PRs (other repos' PRs) - one URL per line
+- The leader PR (the one with this config) is automatically included
+- Don't include the leader PR link - it's redundant
+
+---
+
+## Complete Example
+
+**In kserve PR #123 description:**
+
+```markdown
+## Summary
+This PR updates the KServe API to support OAuth2 authentication.
+
+## Early Gate Testing
+https://github.com/opendatahub-io/feast/pull/456
+
+## Dependencies
+- Depends on Feast PR #456 for OAuth2 client library
+- Both PRs must merge together
+
+## Test Plan
+- [ ] Unit tests pass
+- [ ] Integration tests with Feast
+- [ ] OAuth2 flow end-to-end test
+```
+
+**What gets tested:**
+- kserve #123 - automatically included (leader PR)
+- Feast #456 - from config above (collaborator PR)
+
+---
+
+## Multi-Component Example
+
+For changes spanning 3+ repositories:
+
+```markdown
+## Early Gate Testing
+https://github.com/opendatahub-io/opendatahub-operator/pull/111
+https://github.com/opendatahub-io/kubeflow/pull/222
+https://github.com/opendatahub-io/notebook-controller/pull/333
+```
+
+---
+
+## Configuration Rules
+
+1. **Required heading:** `## Early Gate Testing` (or any heading containing "earlygate", case-insensitive)
+2. **PR URLs:** One per line under the heading (bullets/dashes optional, flexible formatting)
+3. **URL format:** `https://github.com/opendatahub-io/REPO/pull/NUMBER`
+4. **Config block ends at:** Next `##` heading
+5. Only PRs from `opendatahub-io` organization are supported
+6. PRs from repos not configured for early-gate will trigger a warning
+
+**Flexible formatting examples (all work):**
+```markdown
+## Early Gate Testing
+https://github.com/opendatahub-io/kserve/pull/123
+- https://github.com/opendatahub-io/feast/pull/456
+  - https://github.com/opendatahub-io/notebook/pull/789
+```
+
+---
+
+## How It Works
+
+```mermaid
+sequenceDiagram
+    participant Dev as Developer
+    participant GH as GitHub PR
+    participant Pipeline as Early-Gate Pipeline
+    participant Resolve as resolve-group-configuration
+    participant Snapshot as generate-snapshot
+    participant Quay as Quay Registry
+    participant Test as Integration Tests
+
+    Dev->>GH: Create PR #123 in kserve
+    Dev->>GH: Create PR #456 in feast
+    Dev->>GH: Add group config to kserve PR #123 description
+    
+    Note over GH: Config lists feast PR #456<br/>(leader kserve #123 is implicit)
+    
+    Dev->>GH: Push to kserve #123 branch
+    GH->>Pipeline: Trigger early-gate pipeline
+    
+    Pipeline->>Resolve: Run resolve-group-configuration
+    Resolve->>GH: Fetch PR #123 description
+    Resolve->>Resolve: Parse config, extract feast PR #456 URL
+    Resolve->>Resolve: Lookup kserve components (leader)
+    Resolve->>Resolve: Lookup feast components (from URL)
+    Resolve-->>Pipeline: Output group-components JSON
+    
+    Pipeline->>Snapshot: Run generate-snapshot with group-components
+    
+    loop For each component
+        Snapshot->>Quay: Query odh-pr-{number} tag
+        Quay-->>Snapshot: Return SHA digest
+    end
+    
+    Snapshot->>Snapshot: Build snapshot.json with all images
+    Snapshot-->>Pipeline: Output snapshot artifact
+    
+    Pipeline->>Test: Deploy snapshot to cluster
+    Test->>Test: Run integration tests
+    Test-->>GH: Post results to PR #123
+```
+
+### Step-by-Step
+
+1. **Developer adds config** to leader PR description listing collaborator PR URLs
+2. **Push triggers pipeline** - PipelinesAsCode detects push and launches early-gate pipeline
+3. **resolve-group-configuration** fetches PR description from GitHub API, finds the config marker, extracts collaborator PR URLs, and looks up components for each repo in `component_repo_map.json`
+4. **generate-snapshot** queries Quay for each component's PR-specific image (`odh-pr-{number}`), falls back to `odh-stable` if not ready
+5. **Integration tests** run with the combined snapshot
+6. **Results posted** back to the leader PR as a comment with a summary table
+
+---
+
+## Image Resolution
+
+For each component in the group, the pipeline resolves images as follows:
+
+| Scenario | Image Tag | Action |
+|----------|-----------|--------|
+| PR build complete | `odh-pr-{number}` found | Use PR image (immutable SHA digest) |
+| PR build in progress | `odh-pr-{number}` not found | Fallback to `odh-stable` + log warning |
+| Both missing | Neither tag exists | Pipeline fails for that component |
+
+All images use **SHA digest references** for reproducibility.
+
+**Best practice:** Ensure all PR builds in the group have completed before triggering the leader PR's group test. Re-trigger with `/test` after collaborator builds complete.
+
+---
+
+## PR Comment Summary
+
+After the build phase, the pipeline posts a summary comment on the leader PR showing:
+
+- PR numbers (clickable links)
+- Components from each PR
+- Tags used (`odh-pr-XXX` or `odh-stable`)
+- Status (ready or fallback)
+- Image digests
+
+Warnings appear only when:
+- Some components fell back to stable (PR builds not ready)
+- Some repos not configured for early-gate (invalid repos skipped)
+
+---
+
+## Best Practices
+
+### DO
+- Add config to the **leader PR** (the one you want results on)
+- Add cross-references in collaborator PRs: "Part of group: kserve#123"
+- Ensure all PR builds complete before triggering group test
+- Remove config when done (or when PR closes)
+
+### DON'T
+- Add config to multiple PRs in the group (choose one leader)
+- Include PRs from outside `opendatahub-io` org (not supported)
+- Include the leader PR's own URL in the config (it's automatic)
+
+---
+
+## Triggering the Pipeline
+
+The group test runs automatically when you push to the **leader PR**.
+
+**Manual trigger:**
+```
+/test
+```
+
+**Check status:**
+- GitHub PR checks show "early-gate-test" status
+- Pipeline logs show which components are included
+
+---
+
+## Troubleshooting
+
+### Config not detected?
+- Check for heading containing "Early Gate Testing" or "earlygate"
+- Verify URLs are on separate lines under the heading
+- Ensure config is in PR description (not a comment)
+- Config block ends at next `##` heading
+
+### Invalid repo warning?
+- "Repo X is not configured for early-gate testing and was skipped"
+- The PR's repository is not in the early-gate system
+- Pipeline continues with valid repos only
+
+### PR image not found?
+- Check that PR builds have completed
+- Look for warning in pipeline logs
+- Pipeline falls back to `odh-stable` image
+- Re-trigger after builds complete
+
+### Test failed?
+- Check which images were used (PR or stable fallback)
+- Verify all PRs are ready
+- Re-trigger after builds complete
+
+---
+
+## Example Workflow
+
+### Day 1: Create PRs
+```bash
+gh pr create --repo opendatahub-io/kserve --title "Add OAuth2 support"
+# -> PR #123
+
+gh pr create --repo opendatahub-io/feast --title "Update OAuth2 client"
+# -> PR #456
+```
+
+### Day 2: Add Group Config
+Edit kserve PR #123 description to add:
+
+```markdown
+## Early Gate Testing
+https://github.com/opendatahub-io/feast/pull/456
+```
+
+### Day 3: Push Triggers Test
+```bash
+git push  # to kserve branch
+# -> Pipeline runs with both PR images
+```
+
+### Day 4: Merge
+```bash
+# After tests pass, merge both PRs
+gh pr merge 123
+gh pr merge 456
+# Config auto-removed when PR closes
+```
+
+---
+
+## FAQ
+
+**Q: Which PR should have the config?**
+A: The one you want test results on (the "leader"). Usually the first or most critical PR.
+
+**Q: Should I include the leader PR's link in the config?**
+A: No. The leader PR is automatically included. Only list collaborator PRs.
+
+**Q: Can I test PRs from different orgs?**
+A: Not yet. All PRs must be in `opendatahub-io` organization.
+
+**Q: What if one PR's image isn't built yet?**
+A: Pipeline falls back to `odh-stable` for that component and logs a warning.
+
+**Q: Do I need approval to use this?**
+A: No. Self-service. Just add the config and push.
+
+**Q: Does this affect other PRs?**
+A: No. Only the leader PR runs group tests. Other PRs run normally.

--- a/early-gate/early-gate-component-pipeline.yaml
+++ b/early-gate/early-gate-component-pipeline.yaml
@@ -9,10 +9,8 @@ spec:
     a single Tekton pipeline for quick feature-branch validation before pushing to stable.
   params:
   # --- Group snapshot ---
-  - name: group-components
-    type: string
-    description: List of components in the group (JSON)
-    default: ""
+  # NOTE: group-components is now auto-resolved from PR description via resolve-group-configuration task
+  # To enable group testing, add YAML config block to PR description (see docs/GROUP-TESTING-TEMPLATE.md)
 
   # --- General ---
   - description: Source Repository URL
@@ -143,7 +141,7 @@ spec:
     description: Quay tag used for image lookups by processors
   - name: enable-early-gate-testing
     type: string
-    default: "true"
+    default: "false"
     description: Triggers early gate test pipeline on comment /early-gate-test
 
   results:
@@ -221,12 +219,31 @@ spec:
   # Group snapshot block
   # --------------------------------------------------------------------------
 
-  - name: generate-snapshot
+  # NOTE: resolve-group-configuration task reads PR description and resolves group config
+  # It automatically includes leader PR components + collaborator PRs from config
+  # PipelinesAsCode labels (PR_NUMBER, REPO_NAME) are available to the task
+  - name: resolve-group-configuration
     runAfter:
     - init
+    workspaces:
+    - name: basic-auth
+      workspace: git-auth
+    taskRef:
+      resolver: git
+      params:
+      - name: url
+        value: https://github.com/opendatahub-io/odh-konflux-central.git
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: early-gate/tasks/resolve-group-configuration.yaml
+
+  - name: generate-snapshot
+    runAfter:
+    - resolve-group-configuration
     params:
     - name: COMPONENTS
-      value: $(params.group-components)
+      value: $(tasks.resolve-group-configuration.results.group-components)
     - name: ociStorage
       value: $(params.operator-output-image).snapshot
     - name: ociArtifactExpiresAfter
@@ -1002,6 +1019,7 @@ spec:
     runAfter:
     - validate-fbc
     - apply-tags-fbc
+    - generate-snapshot
     params:
     - name: catalog-image-url
       value: $(tasks.build-fbc-container.results.IMAGE_URL)
@@ -1009,6 +1027,16 @@ spec:
       value: $(tasks.build-fbc-container.results.IMAGE_DIGEST)
     - name: unique-tag
       value: $(tasks.rhoai-init.results.unique-tag)
+    - name: has-group-config
+      value: $(tasks.resolve-group-configuration.results.has-group-config)
+    - name: component-table
+      value: $(tasks.generate-snapshot.results.component-table)
+    - name: fallback-warning
+      value: $(tasks.generate-snapshot.results.fallback-warning)
+    - name: invalid-repo-warnings
+      value: $(tasks.resolve-group-configuration.results.invalid-repo-warnings)
+    - name: format-help-warning
+      value: $(tasks.resolve-group-configuration.results.format-help-warning)
     taskRef:
       resolver: git
       params:

--- a/early-gate/early-gate-operator-pipeline.yaml
+++ b/early-gate/early-gate-operator-pipeline.yaml
@@ -143,7 +143,7 @@ spec:
     description: Quay tag used for image lookups by processors
   - name: enable-early-gate-testing
     type: string
-    default: "true"
+    default: "false"
     description: Triggers early gate test pipeline on comment /early-gate-test
 
   results:
@@ -221,12 +221,28 @@ spec:
   # Group snapshot block
   # --------------------------------------------------------------------------
 
-  - name: generate-snapshot
+  - name: resolve-group-configuration
     runAfter:
     - init
+    workspaces:
+    - name: basic-auth
+      workspace: git-auth
+    taskRef:
+      resolver: git
+      params:
+      - name: url
+        value: https://github.com/opendatahub-io/odh-konflux-central.git
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: early-gate/tasks/resolve-group-configuration.yaml
+
+  - name: generate-snapshot
+    runAfter:
+    - resolve-group-configuration
     params:
     - name: COMPONENTS
-      value: $(params.group-components)
+      value: $(tasks.resolve-group-configuration.results.group-components)
     - name: ociStorage
       value: $(params.operator-output-image).snapshot
     - name: ociArtifactExpiresAfter
@@ -759,6 +775,7 @@ spec:
     runAfter:
     - validate-fbc
     - apply-tags-fbc
+    - generate-snapshot
     params:
     - name: catalog-image-url
       value: $(tasks.build-fbc-container.results.IMAGE_URL)
@@ -766,6 +783,16 @@ spec:
       value: $(tasks.build-fbc-container.results.IMAGE_DIGEST)
     - name: unique-tag
       value: $(tasks.rhoai-init.results.unique-tag)
+    - name: has-group-config
+      value: $(tasks.resolve-group-configuration.results.has-group-config)
+    - name: component-table
+      value: $(tasks.generate-snapshot.results.component-table)
+    - name: fallback-warning
+      value: $(tasks.generate-snapshot.results.fallback-warning)
+    - name: invalid-repo-warnings
+      value: $(tasks.resolve-group-configuration.results.invalid-repo-warnings)
+    - name: format-help-warning
+      value: $(tasks.resolve-group-configuration.results.format-help-warning)
     taskRef:
       resolver: git
       params:

--- a/early-gate/early-gate-test-pipeline.yaml
+++ b/early-gate/early-gate-test-pipeline.yaml
@@ -111,11 +111,27 @@ spec:
         value: early-gate/tasks/check-prerequisites.yaml
 
   # --------------------------------------------------------------------------
-  # 2. Check for ongoing jobs — scan PR comments for idempotency
+  # 2. Extract group repositories — read Early Gate section from PR description
+  # --------------------------------------------------------------------------
+  - name: extract-group-repos
+    runAfter:
+    - check-prerequisites
+    taskRef:
+      resolver: git
+      params:
+      - name: url
+        value: https://github.com/opendatahub-io/odh-konflux-central.git
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: early-gate/tasks/extract-group-repos.yaml
+
+  # --------------------------------------------------------------------------
+  # 3. Check for ongoing jobs — scan PR comments for idempotency
   # --------------------------------------------------------------------------
   - name: check-ongoing-jobs
     runAfter:
-    - check-prerequisites
+    - extract-group-repos
     taskRef:
       resolver: git
       params:
@@ -144,7 +160,7 @@ spec:
       value: $(params.jenkins-url-secret-key)
 
   # --------------------------------------------------------------------------
-  # 3. Trigger test pipeline — dispatch GitHub workflow, post queue-url-comment
+  # 4. Trigger test pipeline — dispatch GitHub workflow, post queue-url-comment
   #    Skipped when a previous run left an active queue-url or job-url comment
   # --------------------------------------------------------------------------
   - name: trigger-test-pipeline
@@ -182,9 +198,11 @@ spec:
       value: $(params.jenkins-url-secret-key)
     - name: delete-intermediate-comments
       value: $(params.delete-intermediate-comments)
+    - name: repositories
+      value: $(tasks.extract-group-repos.results.repositories)
 
   # --------------------------------------------------------------------------
-  # 4a. Monitor (fresh) — runs after trigger-test-pipeline for new jobs
+  # 5a. Monitor (fresh) — runs after trigger-test-pipeline for new jobs
   #     Receives queue-url and correlation-id from trigger-test-pipeline results
   # --------------------------------------------------------------------------
   - name: monitor-fresh
@@ -235,7 +253,7 @@ spec:
       value: $(params.jenkins-url-secret-key)
 
   # --------------------------------------------------------------------------
-  # 4b. Monitor (resume) — runs when check-ongoing-jobs found an active job
+  # 5b. Monitor (resume) — runs when check-ongoing-jobs found an active job
   #     Receives job-url and correlation-id from check-ongoing-jobs results
   # --------------------------------------------------------------------------
   - name: monitor-resume

--- a/early-gate/tasks/extract-group-repos.yaml
+++ b/early-gate/tasks/extract-group-repos.yaml
@@ -1,0 +1,105 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: extract-group-repos
+spec:
+  description: |
+    Extracts repository names from Early Gate Testing section in PR description
+    for passing to Jenkins trigger workflow
+  results:
+    - name: repositories
+      description: Comma-separated list of repository names (leader + collaborators)
+    - name: has-group-config
+      description: true if group config found, false otherwise
+  steps:
+    - name: extract-repos
+      image: quay.io/konflux-ci/konflux-test:stable
+      env:
+        - name: PR_NUMBER
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['pipelinesascode.tekton.dev/pull-request']
+        - name: REPO_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['pipelinesascode.tekton.dev/url-repository']
+        - name: GITHUB_ORG
+          value: "opendatahub-io"
+      script: |
+        #!/bin/bash
+        set -e
+
+        echo "=== Extract Group Repos Task ===" >&2
+        echo "PR_NUMBER=${PR_NUMBER}" >&2
+        echo "REPO_NAME=${REPO_NAME}" >&2
+
+        EARLYGATE_SECTION_PATTERN="early.*gate"  # Matches "earlygate", "early gate", "early-gate", etc.
+        ALLOWED_ORG="opendatahub-io"
+
+        # --- Fetch PR description from GitHub API ---
+        echo "Fetching PR description from GitHub..." >&2
+        GITHUB_API_URL="https://api.github.com/repos/${GITHUB_ORG}/${REPO_NAME}/pulls/${PR_NUMBER}"
+
+        # Unauthenticated call (rate limited but sufficient for most cases)
+        PR_DATA=$(curl -sSf "${GITHUB_API_URL}" 2>&1 || echo "")
+
+        if [[ -z "${PR_DATA}" ]]; then
+          echo "Failed to fetch PR description" >&2
+          echo -n "false" > "$(results.has-group-config.path)"
+          echo -n "${REPO_NAME}" > "$(results.repositories.path)"
+          exit 0
+        fi
+
+        PR_BODY=$(echo "${PR_DATA}" | jq -r '.body // ""')
+
+        # Remove Windows line endings (CR) if present
+        PR_BODY=$(echo "${PR_BODY}" | tr -d '\r')
+
+        # --- Check for Early Gate section ---
+        if ! echo "${PR_BODY}" | grep -qi "^##.*${EARLYGATE_SECTION_PATTERN}"; then
+          echo "No Early Gate section found" >&2
+          echo -n "false" > "$(results.has-group-config.path)"
+          echo -n "${REPO_NAME}" > "$(results.repositories.path)"
+          exit 0
+        fi
+
+        echo "✓ Early Gate section found" >&2
+        echo -n "true" > "$(results.has-group-config.path)"
+
+        # --- Extract PR URLs ---
+        # Allow flexible formatting: whitespace, bullets, dashes, etc.
+        PR_URLS=$(echo "${PR_BODY}" | awk -v IGNORECASE=1 "
+          /^##.*${EARLYGATE_SECTION_PATTERN}/ { found=1; next }
+          found && /^##/ { exit }
+          found && /https:\/\/github\.com\/[^\/]+\/[^\/]+\/pull\/[0-9]+/ {
+            match(\$0, /https:\/\/github\.com\/[^\/]+\/[^\/]+\/pull\/[0-9]+/)
+            print substr(\$0, RSTART, RLENGTH)
+          }
+        " || true)
+
+        # --- Start with leader repo ---
+        REPOS="${REPO_NAME}"
+
+        # --- Extract repo names from URLs ---
+        while IFS= read -r url; do
+          if [[ ! "${url}" =~ ^https://github\.com/([^/]+)/([^/]+)/pull/([0-9]+)$ ]]; then
+            continue
+          fi
+
+          ORG="${BASH_REMATCH[1]}"
+          REPO="${BASH_REMATCH[2]}"
+
+          # Security: only ODH repos
+          if [[ "${ORG}" != "${ALLOWED_ORG}" ]]; then
+            echo "⚠️  Skipping non-ODH repo: ${ORG}/${REPO}" >&2
+            continue
+          fi
+
+          # Add to list (avoid duplicates)
+          if ! echo ",${REPOS}," | grep -q ",${REPO},"; then
+            REPOS="${REPOS},${REPO}"
+          fi
+        done <<< "${PR_URLS}"
+
+        echo "Final repository list: ${REPOS}" >&2
+        echo -n "${REPOS}" > "$(results.repositories.path)"

--- a/early-gate/tasks/generate-snapshot-for-group-testing.yaml
+++ b/early-gate/tasks/generate-snapshot-for-group-testing.yaml
@@ -8,12 +8,20 @@ spec:
       optional: true
   params:
     - name: COMPONENTS
-      description: List of components in the group (JSON). If empty, fetched from component_repo_map.json using REPO_NAME.
+      description: |
+        List of components in the group (JSON).
+        Format: {"comp1": "path1", "comp2": "path2"} OR
+                {"comp1": {"quay_path": "path1", "pr": "123"}, "comp2": {...}}
+        If empty, fetched from component_repo_map.json using REPO_NAME.
       default: ""
     - name: fallback-tag
       type: string
       default: odh-stable
       description: Quay tag when PR image is missing
+    - name: CURRENT_PR_NUMBER
+      description: Current PR number (for components without explicit PR metadata)
+      type: string
+      default: ""
     - name: ociStorage
       type: string
       description: OCI repository for storing the SNAPSHOT trusted artifact
@@ -26,6 +34,10 @@ spec:
     name: SNAPSHOT_ARTIFACT
   - description: Resolved COMPONENTS JSON used to generate the snapshot
     name: group-components
+  - description: Warning message if any components fell back to stable (empty if all PRs found)
+    name: fallback-warning
+  - description: Component summary table for PR comment (TSV format - PR component tag status digest)
+    name: component-table
   volumes:
   - name: workdir
     emptyDir: {}
@@ -46,6 +58,8 @@ spec:
           value: $(workspaces.basic-auth.bound)
         - name: WORKSPACE_BASIC_AUTH_DIRECTORY_PATH
           value: $(workspaces.basic-auth.path)
+        - name: CURRENT_PR_NUMBER
+          value: $(params.CURRENT_PR_NUMBER)
         - name: PR_NUMBER
           valueFrom:
             fieldRef:
@@ -80,28 +94,63 @@ spec:
 
         json_string="$COMPONENTS"
         echo ${COMPONENTS}
-        
+
         # Temporary file to store results
         temp_file=$(mktemp)
         echo "{}" > "$temp_file"
 
+        # Track fallback warnings and component table (use temp files to avoid subshell issues)
+        FALLBACK_WARNINGS_FILE=$(mktemp)
+        COMPONENT_TABLE_FILE=$(mktemp)
+        > "$FALLBACK_WARNINGS_FILE"
+        > "$COMPONENT_TABLE_FILE"
+
+        # Use CURRENT_PR_NUMBER if set, otherwise fall back to PR_NUMBER from labels
+        DEFAULT_PR_NUMBER="${CURRENT_PR_NUMBER:-${PR_NUMBER}}"
+
         # Parse JSON and iterate through each component
         while IFS= read -r row; do
-            # Tag to search for
-            TAG="odh-pr-${PR_NUMBER}"
-        
             # Decode the base64 encoded row
             component=$(echo "$row" | base64 -d | jq -r '.key')
-            repo_path=$(echo "$row" | base64 -d | jq -r '.value')
-            
-            echo "component=${component}"
-            echo "repo_path=${repo_path}"
-        
-            if skopeo inspect "docker://quay.io/${repo_path}:${TAG}" &>/dev/null; then
-              echo "found the image with tag ${TAG}"
+            value_raw=$(echo "$row" | base64 -d | jq -c '.value')
+
+            # Check if value is a string (old format) or object (new format with PR metadata)
+            value_type=$(echo "$value_raw" | jq -r 'type')
+
+            if [[ "$value_type" == "object" ]]; then
+              # New format: {"quay_path": "...", "pr": "123"}
+              repo_path=$(echo "$value_raw" | jq -r '.quay_path')
+              component_pr=$(echo "$value_raw" | jq -r '.pr')
+              TAG="odh-pr-${component_pr}"
+              echo "component=${component} (from PR #${component_pr})"
             else
-              echo "No image found with tag ${TAG}, falling back to the ${FALLBACK_TAG} image for ${repo_path}"
+              # Old format: string path
+              repo_path=$(echo "$value_raw" | jq -r '.')
+              TAG="odh-pr-${DEFAULT_PR_NUMBER}"
+              echo "component=${component} (using default PR #${DEFAULT_PR_NUMBER})"
+            fi
+
+            echo "repo_path=${repo_path}"
+
+            # Check if PR-specific image exists
+            IMAGE_STATUS=""
+            if skopeo inspect "docker://quay.io/${repo_path}:${TAG}" &>/dev/null; then
+              echo "✓ Found image with tag ${TAG}"
+              IMAGE_STATUS="ready"
+            else
+              echo "⚠️  WARNING: Component '${component}' does not have PR image for tag ${TAG}" >&2
+              echo "   Quay query returned: 404 Not Found" >&2
+              echo "   Reason: PR build may still be in progress" >&2
+              echo "   Action: Falling back to ${FALLBACK_TAG} tag" >&2
+              echo "   Impact: Group test will use stable image instead of PR code" >&2
+
+              # Track this fallback for PR comment
+              if [[ "$value_type" == "object" ]]; then
+                echo "- Component \`${component}\` from PR #${component_pr}: using \`${FALLBACK_TAG}\` (PR build not ready)" >> "$FALLBACK_WARNINGS_FILE"
+              fi
+
               TAG=${FALLBACK_TAG}
+              IMAGE_STATUS="fallback"
             fi
                 
             
@@ -191,6 +240,15 @@ spec:
                '. + {($key): {image: $image, "git.url": $giturl, "git.commit": $gitcommit, "image_tag": $image_tag}}' \
                "$temp_file" > "${temp_file}.tmp" && mv "${temp_file}.tmp" "$temp_file"
 
+            # Add to component table for PR comment (only for group testing components)
+            if [[ "$value_type" == "object" ]]; then
+              SHORT_DIGEST=$(echo "$manifest_digest" | cut -c 1-12)
+              if [[ -z "$SHORT_DIGEST" ]]; then
+                SHORT_DIGEST="N/A"
+              fi
+              echo "${component_pr}|${component}|${TAG}|${IMAGE_STATUS}|${SHORT_DIGEST}" >> "$COMPONENT_TABLE_FILE"
+            fi
+
             echo "" >&2
         done < <(echo "$json_string" | jq -r 'to_entries[] | @base64')
 
@@ -203,8 +261,18 @@ spec:
         cp "$temp_file" /var/workdir/snapshot/snapshot.json
         echo "Snapshot written to /var/workdir/snapshot/snapshot.json" >&2
 
+        # Output fallback warnings
+        if [[ -s "$FALLBACK_WARNINGS_FILE" ]]; then
+          cat "$FALLBACK_WARNINGS_FILE" > "$(results.fallback-warning.path)"
+        else
+          echo "" > "$(results.fallback-warning.path)"
+        fi
+
+        # Output component table
+        cat "$COMPONENT_TABLE_FILE" > "$(results.component-table.path)"
+
         # Cleanup
-        rm -f "$temp_file"
+        rm -f "$temp_file" "$FALLBACK_WARNINGS_FILE" "$COMPONENT_TABLE_FILE"
 
     - name: create-trusted-artifact
       image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:81c4864dae6bb11595f657be887e205262e70086a05ed16ada827fd6391926ac

--- a/early-gate/tasks/post-build-complete-comment.yaml
+++ b/early-gate/tasks/post-build-complete-comment.yaml
@@ -19,6 +19,26 @@ spec:
   - name: unique-tag
     description: Unique tag to use in the FBC image reference
     type: string
+  - name: has-group-config
+    description: Whether this is a group testing run (true/false)
+    type: string
+    default: "false"
+  - name: component-table
+    description: Component summary table (TSV format) from group testing
+    type: string
+    default: ""
+  - name: fallback-warning
+    description: Warning message from generate-snapshot (empty if no fallbacks)
+    type: string
+    default: ""
+  - name: invalid-repo-warnings
+    description: Warning messages for repos not found in component_repo_map.json
+    type: string
+    default: ""
+  - name: format-help-warning
+    description: Helpful message when earlygate format is incorrect
+    type: string
+    default: ""
   - name: pr-token-secret-name
     description: Name of the Kubernetes secret containing the GitHub token for PR comment operations
     type: string
@@ -57,6 +77,16 @@ spec:
       value: $(params.catalog-image-digest)
     - name: UNIQUE_TAG
       value: $(params.unique-tag)
+    - name: HAS_GROUP_CONFIG
+      value: $(params.has-group-config)
+    - name: COMPONENT_TABLE
+      value: $(params.component-table)
+    - name: FALLBACK_WARNING
+      value: $(params.fallback-warning)
+    - name: INVALID_REPO_WARNINGS
+      value: $(params.invalid-repo-warnings)
+    - name: FORMAT_HELP_WARNING
+      value: $(params.format-help-warning)
     script: |
       #!/bin/bash
       set -euo pipefail
@@ -69,15 +99,102 @@ spec:
       echo "FBC_IMAGE: ${FBC_IMAGE}"
       printf '%s' "${FBC_IMAGE}" > "$(results.fbc-image.path)"
 
-      COMMENT_BODY=$(printf '<!-- early-gate-build-complete -->\n:white_check_mark: **Early Gate Build - Complete**\n\n| Field | Value |\n|-------|-------|\n| **Status** | :white_check_mark: SUCCESS |\n| **FBC Image** | %s |' \
+      # --- Debug: Show parameters ---
+      echo "=== Post Build Complete Comment Parameters ===" >&2
+      echo "HAS_GROUP_CONFIG='${HAS_GROUP_CONFIG}'" >&2
+      echo "COMPONENT_TABLE length: ${#COMPONENT_TABLE}" >&2
+      echo "COMPONENT_TABLE (first 200 chars): ${COMPONENT_TABLE:0:200}" >&2
+      echo "FALLBACK_WARNING: ${FALLBACK_WARNING}" >&2
+      echo "INVALID_REPO_WARNINGS: ${INVALID_REPO_WARNINGS}" >&2
+      echo "FORMAT_HELP_WARNING length: ${#FORMAT_HELP_WARNING}" >&2
+
+      # --- Build the FBC build complete section (always included) ---
+      BUILD_SECTION=$(printf ':white_check_mark: **Early Gate Build - Complete**\n\n| Field | Value |\n|-------|-------|\n| **Status** | :white_check_mark: SUCCESS |\n| **FBC Image** | %s |' \
         "${FBC_IMAGE}")
 
+      # --- Build the group testing section (if applicable) ---
+      GROUP_TESTING_SECTION=""
+
+      # Check for format help warning (posted even when not group testing)
+      TRIMMED_FORMAT_HELP=$(echo "${FORMAT_HELP_WARNING}" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+
+      if [[ "${HAS_GROUP_CONFIG}" == "true" && -n "${COMPONENT_TABLE}" ]]; then
+        # --- Group Testing Summary ---
+        echo "Including group testing summary" >&2
+
+        # Check if there are fallbacks
+        HAS_FALLBACKS="false"
+        TRIMMED_WARNING=$(echo "${FALLBACK_WARNING}" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+        if [[ -n "${TRIMMED_WARNING}" ]]; then
+          HAS_FALLBACKS="true"
+        fi
+
+        # Build component table
+        COMPONENT_MAP_URL="https://raw.githubusercontent.com/opendatahub-io/odh-konflux-central/main/config/component_repo_map.json"
+        COMPONENT_MAP=$(curl -sSf "${COMPONENT_MAP_URL}" 2>/dev/null || echo "{}")
+
+        declare -A PR_TO_REPO
+
+        while IFS='|' read -r pr comp tag status digest; do
+          if [[ -z "$pr" ]]; then continue; fi
+          REPO_FOUND=$(echo "${COMPONENT_MAP}" | jq -r --arg comp "${comp}" 'to_entries[] | select(.value | has($comp)) | .key' | head -1)
+          if [[ -n "$REPO_FOUND" ]]; then
+            PR_TO_REPO[$pr]="$REPO_FOUND"
+          fi
+        done <<< "${COMPONENT_TABLE}"
+
+        TABLE_HEADER="| PR | Component | Tag | Status | Digest |\n|---|---|---|---|---|\n"
+        TABLE_ROWS=""
+
+        while IFS='|' read -r pr comp tag status digest; do
+          if [[ -z "$pr" ]]; then continue; fi
+
+          REPO_FOUND="${PR_TO_REPO[$pr]}"
+          if [[ -n "$REPO_FOUND" ]]; then
+            PR_LINK="[#${pr}](https://github.com/opendatahub-io/${REPO_FOUND}/pull/${pr})"
+          else
+            PR_LINK="#${pr}"
+          fi
+
+          if [[ "$status" == "ready" ]]; then
+            STATUS_TEXT="PR build ready"
+          else
+            STATUS_TEXT="Using stable"
+          fi
+
+          TABLE_ROWS="${TABLE_ROWS}| ${PR_LINK} | ${comp} | ${tag} | ${STATUS_TEXT} | ${digest} |\n"
+        done <<< "${COMPONENT_TABLE}"
+
+        # Build warnings
+        WARNING_NOTE=""
+        if [[ "$HAS_FALLBACKS" == "true" ]]; then
+          WARNING_NOTE="\n\n⚠️ Some components fell back to stable images because PR builds have not completed yet. Re-trigger with /retest after all builds finish.\n"
+        fi
+
+        INVALID_REPO_NOTE=""
+        TRIMMED_INVALID_WARNINGS=$(echo "${INVALID_REPO_WARNINGS}" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+        if [[ -n "${TRIMMED_INVALID_WARNINGS}" ]]; then
+          INVALID_REPO_NOTE="\n\n### Configuration Warnings\n\n${INVALID_REPO_WARNINGS}\n"
+        fi
+
+        GROUP_TESTING_SECTION="\n\n---\n\n**Group Testing Summary**\n\nTesting multiple PRs together:\n\n${TABLE_HEADER}${TABLE_ROWS}${WARNING_NOTE}${INVALID_REPO_NOTE}"
+
+      elif [[ -n "${TRIMMED_FORMAT_HELP}" ]]; then
+        # --- Format Help Warning ---
+        echo "Including format help warning" >&2
+        GROUP_TESTING_SECTION="\n\n---\n\n${FORMAT_HELP_WARNING}"
+      fi
+
+      # --- Combine sections ---
+      COMMENT_BODY="<!-- early-gate-build-complete -->\n${BUILD_SECTION}${GROUP_TESTING_SECTION}\n\n---\nPosted by Early-Gate"
+
+      # --- Post comment ---
       curl -sSf \
         -X POST \
         -H "Authorization: Bearer ${PR_GITHUB_TOKEN}" \
         -H "Accept: application/vnd.github+json" \
         "https://api.github.com/repos/${OWNER}/${REPO}/issues/${PR_NUMBER}/comments" \
-        -d "{\"body\":$(echo "${COMMENT_BODY}" | jq -Rs .)}" \
+        -d "{\"body\":$(echo -e "${COMMENT_BODY}" | jq -Rs .)}" \
         2>/dev/null || echo "WARNING: Failed to post PR comment (non-fatal)"
 
-      echo "Posted build-complete comment on PR #${PR_NUMBER}"
+      echo "Posted consolidated build + group testing comment on PR #${PR_NUMBER}"

--- a/early-gate/tasks/post-group-testing-warning.yaml
+++ b/early-gate/tasks/post-group-testing-warning.yaml
@@ -1,0 +1,189 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: post-group-testing-warning
+spec:
+  description: |
+    Posts a summary comment to the PR for group testing runs
+  params:
+    - name: has-group-config
+      description: Whether this is a group testing run (true/false)
+      type: string
+    - name: fallback-warning
+      description: Warning message from generate-snapshot (empty if no fallbacks)
+      type: string
+    - name: component-table
+      description: Component summary table (TSV format)
+      type: string
+    - name: invalid-repo-warnings
+      description: Warning messages for repos not found in component_repo_map.json
+      type: string
+      default: ""
+    - name: format-help-warning
+      description: Helpful message when earlygate format is incorrect
+      type: string
+      default: ""
+    - name: pr-token-secret-name
+      description: Name of the Kubernetes secret containing the GitHub token
+      type: string
+      default: odh-github-secret
+    - name: pr-token-secret-key
+      description: Key in the secret that holds the GitHub token
+      type: string
+      default: commenter-token
+  steps:
+    - name: post-summary
+      image: quay.io/konflux-ci/konflux-test:stable
+      env:
+        - name: PR_NUMBER
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['pipelinesascode.tekton.dev/pull-request']
+        - name: REPO_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['pipelinesascode.tekton.dev/url-repository']
+        - name: REPO_ORG
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.annotations['pipelinesascode.tekton.dev/url-org']
+        - name: HAS_GROUP_CONFIG
+          value: $(params.has-group-config)
+        - name: FALLBACK_WARNING
+          value: $(params.fallback-warning)
+        - name: COMPONENT_TABLE
+          value: $(params.component-table)
+        - name: INVALID_REPO_WARNINGS
+          value: $(params.invalid-repo-warnings)
+        - name: FORMAT_HELP_WARNING
+          value: $(params.format-help-warning)
+        - name: PR_GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: $(params.pr-token-secret-name)
+              key: $(params.pr-token-secret-key)
+              optional: true
+      script: |
+        #!/bin/bash
+        set -e
+
+        # Check if we have format help to post (even when not a group testing run)
+        TRIMMED_FORMAT_HELP=$(echo "${FORMAT_HELP_WARNING}" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+
+        if [[ "${HAS_GROUP_CONFIG}" != "true" ]]; then
+          echo "Not a group testing run (has-group-config=${HAS_GROUP_CONFIG})"
+
+          # Post format help if available
+          if [[ -n "${TRIMMED_FORMAT_HELP}" ]]; then
+            echo "Found format help warning - posting to PR..."
+          else
+            echo "No format help needed - skipping PR comment"
+            exit 0
+          fi
+        else
+          # Group testing run
+          echo "Posting group testing summary to PR..."
+
+          # Exit if no component table
+          if [[ -z "${COMPONENT_TABLE}" ]]; then
+            echo "No component table - skipping PR comment"
+            exit 0
+          fi
+        fi
+
+        # Build comment based on whether this is group testing or format help
+        if [[ "${HAS_GROUP_CONFIG}" == "true" ]]; then
+          # --- Group Testing Summary ---
+
+          # Check if there are fallbacks (trim whitespace first)
+          HAS_FALLBACKS="false"
+          TRIMMED_WARNING=$(echo "${FALLBACK_WARNING}" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+          if [[ -n "${TRIMMED_WARNING}" ]]; then
+            HAS_FALLBACKS="true"
+          fi
+
+          # First pass: extract unique PRs and map to repos (from component names)
+          COMPONENT_MAP_URL="https://raw.githubusercontent.com/opendatahub-io/odh-konflux-central/main/config/component_repo_map.json"
+          COMPONENT_MAP=$(curl -sSf "${COMPONENT_MAP_URL}" 2>/dev/null || echo "{}")
+
+          declare -A PR_TO_REPO
+
+          while IFS='|' read -r pr comp tag status digest; do
+            if [[ -z "$pr" ]]; then continue; fi
+
+            # Find which repo this component belongs to
+            REPO=$(echo "${COMPONENT_MAP}" | jq -r --arg comp "${comp}" 'to_entries[] | select(.value | has($comp)) | .key' | head -1)
+
+            if [[ -n "$REPO" ]]; then
+              PR_TO_REPO[$pr]="$REPO"
+            fi
+          done <<< "${COMPONENT_TABLE}"
+
+          # Build markdown table from TSV (PR|component|tag|status|digest)
+          TABLE_HEADER="| PR | Component | Tag | Status | Digest |\n|---|---|---|---|---|\n"
+          TABLE_ROWS=""
+
+          while IFS='|' read -r pr comp tag status digest; do
+            if [[ -z "$pr" ]]; then continue; fi
+
+            # Make PR number a link if we know the repo
+            REPO="${PR_TO_REPO[$pr]}"
+            if [[ -n "$REPO" ]]; then
+              PR_LINK="[#${pr}](https://github.com/opendatahub-io/${REPO}/pull/${pr})"
+            else
+              PR_LINK="#${pr}"
+            fi
+
+            if [[ "$status" == "ready" ]]; then
+              STATUS_TEXT="PR build ready"
+            else
+              STATUS_TEXT="Using stable"
+            fi
+
+            TABLE_ROWS="${TABLE_ROWS}| ${PR_LINK} | ${comp} | ${tag} | ${STATUS_TEXT} | ${digest} |\n"
+          done <<< "${COMPONENT_TABLE}"
+
+          # Build comment
+          if [[ "$HAS_FALLBACKS" == "true" ]]; then
+            TITLE="Group Testing Summary"
+            WARNING_NOTE="\n\n⚠️ Some components fell back to stable images because PR builds have not completed yet. Re-trigger with /retest after all builds finish.\n"
+          else
+            TITLE="Group Testing Summary"
+            WARNING_NOTE=""
+          fi
+
+          # Add invalid repo warnings if any
+          INVALID_REPO_NOTE=""
+          TRIMMED_INVALID_WARNINGS=$(echo "${INVALID_REPO_WARNINGS}" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+          if [[ -n "${TRIMMED_INVALID_WARNINGS}" ]]; then
+            INVALID_REPO_NOTE="\n\n### Configuration Warnings\n\n${INVALID_REPO_WARNINGS}\n"
+          fi
+
+          COMMENT_BODY="${TITLE}\n\nTesting multiple PRs together:\n\n${TABLE_HEADER}${TABLE_ROWS}${WARNING_NOTE}${INVALID_REPO_NOTE}\n---\nPosted by Early-Gate Group Testing"
+        else
+          # --- Format Help Warning ---
+          COMMENT_BODY="${FORMAT_HELP_WARNING}\n\n---\nPosted by Early-Gate Group Testing"
+        fi
+
+        # Post to PR
+        if [[ -z "${PR_GITHUB_TOKEN}" ]]; then
+          echo "No GitHub token available"
+          echo -e "Comment would have been:\n${COMMENT_BODY}"
+          exit 0
+        fi
+
+        GITHUB_API_URL="https://api.github.com/repos/${REPO_ORG}/${REPO_NAME}/issues/${PR_NUMBER}/comments"
+
+        ESCAPED_BODY=$(echo -e "${COMMENT_BODY}" | jq -Rs .)
+
+        RESPONSE=$(curl -s -X POST \
+          -H "Authorization: token ${PR_GITHUB_TOKEN}" \
+          -H "Content-Type: application/json" \
+          "${GITHUB_API_URL}" \
+          -d "{\"body\": ${ESCAPED_BODY}}")
+
+        if echo "${RESPONSE}" | jq -e '.id' &>/dev/null; then
+          echo "Comment posted successfully"
+        else
+          echo "Failed to post comment: ${RESPONSE}"
+        fi

--- a/early-gate/tasks/resolve-group-configuration.yaml
+++ b/early-gate/tasks/resolve-group-configuration.yaml
@@ -1,0 +1,353 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: resolve-group-configuration
+spec:
+  workspaces:
+    - name: basic-auth
+      optional: true
+  results:
+    - name: group-components
+      description: Resolved components JSON with PR metadata for group testing
+    - name: has-group-config
+      description: true if group config found, false otherwise
+    - name: invalid-repo-warnings
+      description: Warning messages for repos not found in component_repo_map.json
+    - name: format-help-warning
+      description: Helpful message when earlygate is mentioned incorrectly or PR URLs found outside section
+  volumes:
+    - name: workdir
+      emptyDir: {}
+  stepTemplate:
+    volumeMounts:
+      - mountPath: /var/workdir
+        name: workdir
+  steps:
+    - name: resolve-configuration
+      image: quay.io/konflux-ci/konflux-test:stable
+      workingDir: /workspace
+      env:
+        - name: PR_NUMBER
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['pipelinesascode.tekton.dev/pull-request']
+        - name: REPO_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['pipelinesascode.tekton.dev/url-repository']
+        - name: GITHUB_ORG
+          value: "opendatahub-io"
+        - name: WORKSPACE_BASIC_AUTH_DIRECTORY_BOUND
+          value: $(workspaces.basic-auth.bound)
+        - name: WORKSPACE_BASIC_AUTH_DIRECTORY_PATH
+          value: $(workspaces.basic-auth.path)
+      script: |
+        #!/bin/bash
+        set -e
+
+        echo "=== Resolve Group Configuration Task ===" >&2
+        echo "PR_NUMBER=${PR_NUMBER}" >&2
+        echo "REPO_NAME=${REPO_NAME}" >&2
+        echo "GITHUB_ORG=${GITHUB_ORG}" >&2
+
+        # --- Constants ---
+        EARLYGATE_SECTION_PATTERN="early.*gate"  # Matches "earlygate", "early gate", "early-gate", etc.  # Case-insensitive search in ## headings
+        COMPONENT_MAP_URL="https://raw.githubusercontent.com/opendatahub-io/odh-konflux-central/main/config/component_repo_map.json"
+        ALLOWED_ORG="opendatahub-io"  # Only accept PRs from this GitHub org
+
+        # --- Fetch component_repo_map.json (critical dependency) ---
+        echo "Fetching component_repo_map.json..." >&2
+        COMPONENT_MAP=$(curl -sSf "${COMPONENT_MAP_URL}")
+        if [[ -z "${COMPONENT_MAP}" ]]; then
+          echo "ERROR: Failed to fetch component_repo_map.json" >&2
+          exit 1
+        fi
+        echo "Component map loaded successfully" >&2
+
+        # --- Fetch PR description from GitHub API ---
+        echo "Fetching PR description from GitHub..." >&2
+        GITHUB_API_URL="https://api.github.com/repos/${GITHUB_ORG}/${REPO_NAME}/pulls/${PR_NUMBER}"
+
+        # Use authentication if available
+        GITHUB_TOKEN=""
+        if [[ "${WORKSPACE_BASIC_AUTH_DIRECTORY_BOUND}" == "true" ]]; then
+          echo "Checking for GitHub token in workspace..." >&2
+          if [[ -f "${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/.git-credentials" ]]; then
+            echo "Found .git-credentials file" >&2
+            # Format examples:
+            # https://TOKEN:x-oauth-basic@github.com
+            # https://x-access-token:TOKEN@github.com
+            # https://username:TOKEN@github.com
+            CREDS_LINE=$(cat "${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/.git-credentials" | grep github.com | head -1)
+
+            # Try different extraction patterns
+            # Pattern 1: https://TOKEN:x-oauth-basic@github.com
+            GITHUB_TOKEN=$(echo "${CREDS_LINE}" | sed -n 's|https://\([^:]*\):x-oauth-basic@github\.com.*|\1|p')
+
+            # Pattern 2: https://x-access-token:TOKEN@github.com
+            if [[ -z "${GITHUB_TOKEN}" ]]; then
+              GITHUB_TOKEN=$(echo "${CREDS_LINE}" | sed -n 's|https://x-access-token:\([^@]*\)@github\.com.*|\1|p')
+            fi
+
+            # Pattern 3: https://username:TOKEN@github.com (any username)
+            if [[ -z "${GITHUB_TOKEN}" ]]; then
+              GITHUB_TOKEN=$(echo "${CREDS_LINE}" | sed -n 's|https://[^:]*:\([^@]*\)@github\.com.*|\1|p')
+            fi
+          fi
+
+          # Also check for .github-token file (alternative location)
+          if [[ -z "${GITHUB_TOKEN}" && -f "${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/.github-token" ]]; then
+            echo "Found .github-token file" >&2
+            GITHUB_TOKEN=$(cat "${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/.github-token")
+          fi
+        fi
+
+        if [[ -n "${GITHUB_TOKEN}" ]]; then
+          echo "Using authenticated GitHub API (token length: ${#GITHUB_TOKEN} chars)" >&2
+          # Try with 'token' prefix first (classic format)
+          PR_DATA=$(curl -sS -H "Authorization: token ${GITHUB_TOKEN}" "${GITHUB_API_URL}" 2>&1)
+
+          # If that fails with 401, try with 'Bearer' prefix
+          if echo "${PR_DATA}" | grep -q "Bad credentials\|Requires authentication"; then
+            echo "Classic token auth failed, trying Bearer format..." >&2
+            PR_DATA=$(curl -sS -H "Authorization: Bearer ${GITHUB_TOKEN}" "${GITHUB_API_URL}" 2>&1)
+          fi
+
+          # Check if still failing
+          if echo "${PR_DATA}" | grep -q "Bad credentials\|Requires authentication"; then
+            echo "ERROR: GitHub authentication failed with provided token" >&2
+            echo "Response: ${PR_DATA:0:200}" >&2
+            echo "Falling back to unauthenticated API..." >&2
+            PR_DATA=$(curl -sSf "${GITHUB_API_URL}" 2>&1)
+          fi
+        else
+          echo "⚠️  WARNING: No GitHub authentication found, using unauthenticated API (rate limited)" >&2
+          PR_DATA=$(curl -sSf "${GITHUB_API_URL}" 2>&1)
+        fi
+
+        if [[ -z "${PR_DATA}" ]]; then
+          echo "⚠️  WARNING: Failed to fetch PR description from GitHub API" >&2
+          echo "   Falling back to single-PR mode" >&2
+          echo -n "false" > "$(results.has-group-config.path)"
+          echo -n "" > "$(results.invalid-repo-warnings.path)"
+          echo -n "" > "$(results.format-help-warning.path)"
+          # Return components for current repo only
+          COMPONENTS=$(echo "${COMPONENT_MAP}" | jq -c --arg repo "${REPO_NAME}" '.[$repo]')
+          echo -n "${COMPONENTS}" > "$(results.group-components.path)"
+          exit 0
+        fi
+
+        PR_BODY=$(echo "${PR_DATA}" | jq -r '.body // ""')
+        echo "PR description fetched successfully" >&2
+
+        # Remove Windows line endings (CR) if present
+        PR_BODY=$(echo "${PR_BODY}" | tr -d '\r')
+
+        # --- Search for Early Gate section (## heading containing "earlygate") ---
+        echo "Searching for Early Gate section in PR description..." >&2
+
+        # Check if there's a ## heading containing "earlygate" (case-insensitive)
+        if ! echo "${PR_BODY}" | grep -qi "^##.*${EARLYGATE_SECTION_PATTERN}"; then
+          echo "No Early Gate section found in PR description" >&2
+          echo "Using single-PR mode (repo: ${REPO_NAME}, pr: ${PR_NUMBER})" >&2
+          echo -n "false" > "$(results.has-group-config.path)"
+          echo -n "" > "$(results.invalid-repo-warnings.path)"
+
+          # --- Check for common mistakes and provide helpful guidance ---
+          FORMAT_HELP=""
+
+          # Check 1: "earlygate" mentioned but not in ## heading
+          if echo "${PR_BODY}" | grep -qi "${EARLYGATE_SECTION_PATTERN}"; then
+            echo "Found 'earlygate' mention but not in proper ## heading format" >&2
+            FORMAT_HELP="## ⚠️ Group Testing Format Issue"$'\n\n'"Found \`earlygate\` mentioned in your PR description, but it's not in the correct format for group testing."$'\n\n'"**To enable group testing, use this format:**"$'\n\n'"\`\`\`markdown"$'\n'"## Early Gate Testing"$'\n'"https://github.com/opendatahub-io/REPO/pull/NUMBER"$'\n'"\`\`\`"$'\n\n'"**Requirements:**"$'\n'"- Must be a \`##\` heading containing \"earlygate\""$'\n'"- Only PRs from \`opendatahub-io\` organization"$'\n\n'"See [Group Testing Template](https://github.com/opendatahub-io/odh-konflux-central/blob/main/early-gate/docs/GROUP-TESTING-TEMPLATE.md) for details."
+          else
+            # Check 2: GitHub PR URLs found in description
+            if echo "${PR_BODY}" | grep -q "https://github.com/opendatahub-io/[^/]*/pull/[0-9]"; then
+              echo "Found opendatahub-io PR URLs but not marked for group testing" >&2
+              FORMAT_HELP="## ℹ️ Group Testing Available"$'\n\n'"Found GitHub PR URLs in your description. If you want to test these PRs together, use group testing:"$'\n\n'"**Format:**"$'\n'"\`\`\`markdown"$'\n'"## Early Gate Testing"$'\n'"https://github.com/opendatahub-io/REPO/pull/NUMBER"$'\n'"\`\`\`"$'\n\n'"See [Group Testing Template](https://github.com/opendatahub-io/odh-konflux-central/blob/main/early-gate/docs/GROUP-TESTING-TEMPLATE.md) for details."
+            fi
+          fi
+
+          echo -n "${FORMAT_HELP}" > "$(results.format-help-warning.path)"
+
+          # Return components for current repo only
+          COMPONENTS=$(echo "${COMPONENT_MAP}" | jq -c --arg repo "${REPO_NAME}" '.[$repo]')
+          if [[ -z "${COMPONENTS}" || "${COMPONENTS}" == "null" ]]; then
+            echo "ERROR: No entry found for REPO_NAME=${REPO_NAME} in component_repo_map.json" >&2
+            exit 1
+          fi
+          echo -n "${COMPONENTS}" > "$(results.group-components.path)"
+          exit 0
+        fi
+
+        echo "✓ Early Gate section found" >&2
+        echo -n "true" > "$(results.has-group-config.path)"
+        echo -n "" > "$(results.format-help-warning.path)"  # No format help needed
+
+        # --- Extract PR URLs from Early Gate section ---
+        # Find the section and extract URLs until the next ## heading
+        # Allow optional whitespace and bullets/dashes before URLs
+        PR_URLS=$(echo "${PR_BODY}" | awk -v IGNORECASE=1 "
+          /^##.*${EARLYGATE_SECTION_PATTERN}/ { found=1; next }
+          found && /^##/ { exit }
+          found && /https:\/\/github\.com\/[^\/]+\/[^\/]+\/pull\/[0-9]+/ {
+            match(\$0, /https:\/\/github\.com\/[^\/]+\/[^\/]+\/pull\/[0-9]+/)
+            print substr(\$0, RSTART, RLENGTH)
+          }
+        " || true)
+
+        if [[ -z "${PR_URLS}" ]]; then
+          echo "⚠️  WARNING: No PR URLs found in Early Gate section" >&2
+          echo "   Falling back to single-PR mode" >&2
+          echo -n "false" > "$(results.has-group-config.path)"
+          echo -n "" > "$(results.invalid-repo-warnings.path)"
+          FORMAT_HELP="## ⚠️ Empty Early Gate Section"$'\n\n'"Found an Early Gate section in your PR description, but no PR URLs were listed."$'\n\n'"**Add PR URLs like this:**"$'\n'"\`\`\`markdown"$'\n'"## Early Gate Testing"$'\n'"https://github.com/opendatahub-io/REPO/pull/NUMBER"$'\n'"\`\`\`"$'\n\n'"See [Group Testing Template](https://github.com/opendatahub-io/odh-konflux-central/blob/main/early-gate/docs/GROUP-TESTING-TEMPLATE.md) for details."
+          echo -n "${FORMAT_HELP}" > "$(results.format-help-warning.path)"
+          COMPONENTS=$(echo "${COMPONENT_MAP}" | jq -c --arg repo "${REPO_NAME}" '.[$repo]')
+          echo -n "${COMPONENTS}" > "$(results.group-components.path)"
+          exit 0
+        fi
+
+        echo "Found PR URLs:" >&2
+        echo "${PR_URLS}" >&2
+
+        # --- ALWAYS include leader PR's components first ---
+        echo "" >&2
+        echo "=== Resolving Components ===" >&2
+        echo "Step 1: Adding leader PR components (${REPO_NAME} #${PR_NUMBER})..." >&2
+        TEMP_COMPONENTS=$(mktemp)
+        echo "{}" > "${TEMP_COMPONENTS}"
+
+        # Initialize warnings tracking
+        WARNINGS=""
+
+        # Get leader PR components with PR metadata
+        LEADER_COMPONENTS=$(echo "${COMPONENT_MAP}" | jq -c --arg repo "${REPO_NAME}" '.[$repo]')
+        if [[ -n "${LEADER_COMPONENTS}" && "${LEADER_COMPONENTS}" != "null" ]]; then
+          LEADER_COMPONENTS_WITH_PR=$(echo "${LEADER_COMPONENTS}" | jq -c --arg pr "${PR_NUMBER}" '
+            to_entries |
+            map({
+              key: .key,
+              value: {
+                quay_path: .value,
+                pr: $pr
+              }
+            }) |
+            from_entries
+          ')
+          NUM_LEADER=$(echo "${LEADER_COMPONENTS_WITH_PR}" | jq 'length')
+          echo "✓ Added ${NUM_LEADER} components from leader PR #${PR_NUMBER}" >&2
+          echo "${LEADER_COMPONENTS_WITH_PR}" > "${TEMP_COMPONENTS}"
+        else
+          echo "⚠️  WARNING: No components found for leader repo: ${REPO_NAME}" >&2
+          echo "   This is unusual - verify component_repo_map.json has an entry for ${REPO_NAME}" >&2
+        fi
+
+        # --- Parse each collaborator PR URL and add their components ---
+        echo "" >&2
+        echo "Step 2: Adding collaborator PR components..." >&2
+        while IFS= read -r url; do
+          echo "Processing collaborator URL: ${url}" >&2
+
+          # Extract org/repo/pr from URL
+          # Format: https://github.com/{org}/{repo}/pull/{number}
+          if [[ ! "${url}" =~ ^https://github\.com/([^/]+)/([^/]+)/pull/([0-9]+)$ ]]; then
+            echo "⚠️  WARNING: Invalid PR URL format: ${url}" >&2
+            echo "   Skipping this entry" >&2
+            continue
+          fi
+
+          ORG="${BASH_REMATCH[1]}"
+          REPO="${BASH_REMATCH[2]}"
+          PR="${BASH_REMATCH[3]}"
+
+          echo "  Org: ${ORG}" >&2
+          echo "  Repo: ${REPO}" >&2
+          echo "  PR: ${PR}" >&2
+
+          # Security check: Only allow PRs from opendatahub-io organization
+          if [[ "${ORG}" != "${ALLOWED_ORG}" ]]; then
+            echo "⚠️  WARNING: PR from unauthorized organization: ${ORG}" >&2
+            echo "   Only PRs from ${ALLOWED_ORG} are allowed" >&2
+            echo "   Skipping this entry" >&2
+            # Track warning for PR comment
+            WARNING_MSG="⚠️ PR from \`${ORG}/${REPO}\` (#${PR}) was skipped - only PRs from \`${ALLOWED_ORG}\` organization are allowed."
+            if [[ -z "${WARNINGS}" ]]; then
+              WARNINGS="${WARNING_MSG}"
+            else
+              WARNINGS="${WARNINGS}"$'\n'"${WARNING_MSG}"
+            fi
+            continue
+          fi
+
+          # Lookup components for this repo in component_repo_map.json
+          REPO_COMPONENTS=$(echo "${COMPONENT_MAP}" | jq -c --arg repo "${REPO}" '.[$repo]')
+
+          if [[ -z "${REPO_COMPONENTS}" || "${REPO_COMPONENTS}" == "null" ]]; then
+            echo "⚠️  WARNING: No components found for repo: ${REPO}" >&2
+            echo "   Skipping this repo" >&2
+            # Track warning for PR comment
+            WARNING_MSG="⚠️ Repo \`${ORG}/${REPO}\` from PR #${PR} is not configured for early-gate testing and was skipped."
+            if [[ -z "${WARNINGS}" ]]; then
+              WARNINGS="${WARNING_MSG}"
+            else
+              WARNINGS="${WARNINGS}"$'\n'"${WARNING_MSG}"
+            fi
+            continue
+          fi
+
+          echo "  Found components for ${REPO}" >&2
+
+          # Add PR metadata to each component
+          # Transform: {"comp1": "path1", "comp2": "path2"}
+          # To: {"comp1": {"quay_path": "path1", "pr": "123"}, "comp2": {...}}
+          REPO_COMPONENTS_WITH_PR=$(echo "${REPO_COMPONENTS}" | jq -c --arg pr "${PR}" '
+            to_entries |
+            map({
+              key: .key,
+              value: {
+                quay_path: .value,
+                pr: $pr
+              }
+            }) |
+            from_entries
+          ')
+
+          echo "  Components with PR metadata:" >&2
+          echo "  ${REPO_COMPONENTS_WITH_PR}" >&2
+
+          # Merge into accumulated components
+          jq -s '.[0] * .[1]' "${TEMP_COMPONENTS}" <(echo "${REPO_COMPONENTS_WITH_PR}") > "${TEMP_COMPONENTS}.tmp"
+          mv "${TEMP_COMPONENTS}.tmp" "${TEMP_COMPONENTS}"
+
+        done <<< "${PR_URLS}"
+
+        # --- Output final components JSON ---
+        FINAL_COMPONENTS=$(cat "${TEMP_COMPONENTS}")
+
+        if [[ "${FINAL_COMPONENTS}" == "{}" ]]; then
+          echo "⚠️  WARNING: No valid components resolved from group configuration" >&2
+          echo "   Falling back to single-PR mode" >&2
+          echo -n "false" > "$(results.has-group-config.path)"
+          echo -n "" > "$(results.invalid-repo-warnings.path)"
+          echo -n "" > "$(results.format-help-warning.path)"
+          COMPONENTS=$(echo "${COMPONENT_MAP}" | jq -c --arg repo "${REPO_NAME}" '.[$repo]')
+          echo -n "${COMPONENTS}" > "$(results.group-components.path)"
+        else
+          echo "✓ Group components resolved successfully:" >&2
+          echo "${FINAL_COMPONENTS}" | jq '.' >&2
+          echo -n "${FINAL_COMPONENTS}" > "$(results.group-components.path)"
+
+          # Output warnings if any
+          if [[ -n "${WARNINGS}" ]]; then
+            echo "" >&2
+            echo "⚠️  Invalid repo warnings:" >&2
+            echo "${WARNINGS}" >&2
+          fi
+          echo -n "${WARNINGS}" > "$(results.invalid-repo-warnings.path)"
+        fi
+
+        # Cleanup
+        rm -f "${TEMP_COMPONENTS}"
+
+        echo "=== Resolution complete ===" >&2

--- a/early-gate/tasks/trigger-test-pipeline.yaml
+++ b/early-gate/tasks/trigger-test-pipeline.yaml
@@ -47,6 +47,10 @@ spec:
     description: "When true, intermediate PR comments include a note that they will be replaced"
     type: string
     default: "false"
+  - name: repositories
+    description: "Comma-separated list of repository names for group testing (e.g., 'kserve,feast')"
+    type: string
+    default: ""
   results:
   - name: queue-url
     description: Relative Jenkins queue path for the triggered job (e.g. /queue/item/12345)
@@ -89,6 +93,8 @@ spec:
       value: $(params.trigger-workflow-file)
     - name: DELETE_INTERMEDIATE_COMMENTS
       value: $(params.delete-intermediate-comments)
+    - name: REPOSITORIES
+      value: $(params.repositories)
     script: |
       #!/bin/bash
       set -euo pipefail
@@ -103,11 +109,19 @@ spec:
       WORKFLOW_REPO_NAME="${WORKFLOW_REPO##*/}"
 
       REPO_NAME="${REPO}"
+
+      # Use repositories from group config if available, otherwise just the current repo
+      if [[ -n "${REPOSITORIES}" ]]; then
+        REPOS_LIST="${REPOSITORIES}"
+      else
+        REPOS_LIST="${REPO_NAME}"
+      fi
+
       FBC_TAG="odh-pr-${PR_NUMBER}-${REPO_NAME}"
       CORRELATION_ID="eg-$(date +%s)"
 
       echo "Triggering early-gate test pipeline for PR #${PR_NUMBER}"
-      echo "Repo: ${REPO_NAME}, FBC tag: ${FBC_TAG}, Correlation ID: ${CORRELATION_ID}"
+      echo "Leader repo: ${REPO_NAME}, All repos: ${REPOS_LIST}, FBC tag: ${FBC_TAG}, Correlation ID: ${CORRELATION_ID}"
 
       # ---------------------------------------------------------------
       # Helper: GitHub API calls with separate tokens per operation type
@@ -145,7 +159,7 @@ spec:
       gh_workflow_api POST \
         "https://api.github.com/repos/${WORKFLOW_REPO}/actions/workflows/${TRIGGER_WORKFLOW}/dispatches" \
         -d "{\"ref\":\"main\",\"inputs\":{
-          \"repositories\":\"${REPO_NAME}\",
+          \"repositories\":\"${REPOS_LIST}\",
           \"fbc_tag\":\"${FBC_TAG}\",
           \"pr_number\":\"${PR_NUMBER}\",
           \"correlation_id\":\"${CORRELATION_ID}\"


### PR DESCRIPTION
## Summary
- Adds group testing capability allowing developers to attach a group configuration directly in PR descriptions, enabling coordinated testing of multiple related PRs across repositories (e.g., kserve + feast)
- Introduces new tasks: `resolve-group-configuration`, `extract-group-repos`, `post-group-testing-warning`, and `post-build-complete-comment`
- Updates component, operator, and test pipelines to support group testing flow — resolving group configs, generating multi-component snapshots, and triggering test pipelines with group repos
- Adds design doc and user guide for group testing

## Test plan
- [ ] Verify a PR with a valid group testing config in the description triggers the full group testing flow
- [ ] Verify PRs without group config continue to work as before (no regression)
- [ ] Verify format warnings are posted when group config syntax is incorrect
- [ ] Verify the consolidated build comment is posted with correct snapshot and test results
- [ ] Verify multi-repo snapshot generation includes images from all grouped PRs
- [ ] Run CI test pipeline (`early-gate-ci-test.yaml`) to validate end-to-end