### PR TITLE
fix: upgrade task-prefetch-dependencies-oci-ta from 0.2 to 0.4.1

### DIFF
--- a/pipeline/multi-arch-container-build.yaml
+++ b/pipeline/multi-arch-container-build.yaml
@@ -229,7 +229,7 @@ spec:
       - name: name
         value: prefetch-dependencies-oci-ta
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.2@sha256:3fa0204a481044b21f0e784ce39cbd25e8fb49c664a5458f3eef351fff1c906e
+        value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.4.1@sha256:ba1a3975a1e7b12ee1d11c4885930bf3540f532ddb57b5b66bb8b1122f41fa65
       - name: kind
         value: task
       resolver: bundles


### PR DESCRIPTION
## Summary

Upgrade `task-prefetch-dependencies-oci-ta` from version 0.2 to 0.4.1 to fix a bug that causes `KeyError: 'version'` during dependency prefetch for some npm packages.

## Problem

The older version (0.2) has a bug in the hermeto tool that fails to parse certain npm package metadata, resulting in:

```
ERROR KeyError: 'version'
```

This is blocking builds for components like `odh-workbench-codeserver-datascience-cpu-py312-ubi9-ci` on the stable branch.

## Solution

Update the prefetch-dependencies task bundle to 0.4.1, which includes the fix for this issue.

```yaml
# Before (buggy):
value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.2@sha256:3fa0204a...

# After (fixed):
value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.4.1@sha256:ba1a3975a1e7...
```

## Related

This aligns with the same fix applied in `opendatahub-io/notebooks` (commit fbd6b8dd4) by @atheo89.

## Testing

Once merged, retrigger the failing stable branch builds to verify the fix.

Made with [Cursor](https://cursor.com)