### PR TITLE
olminstall E2E: EaaS smoke A/B ITS (ocp-421/422) + HyperShift fixes

### DIFF
--- a/integration-tests/olminstall/README.md
+++ b/integration-tests/olminstall/README.md
@@ -136,7 +136,10 @@ Skipped nodes are normal: EaaS vs external vs `PRODUCT=existing`, Conforma **ski
 | [`runners/report/send_notification.py`](runners/report/send_notification.py) | Tekton step: Slack notification summarising pipeline run results |
 | [`install/patch_cluster_pull_secret.py`](install/patch_cluster_pull_secret.py) | Tekton step: injects `quay.io/rhoai` credentials into the [EaaS](../../doc/contributing-konflux-testing-rhoai.md#eaas) cluster at all required levels |
 | [`tekton/its/its-olminstall-open-data-hub-tenant.yaml`](tekton/its/its-olminstall-open-data-hub-tenant.yaml) | [ITS](../../doc/contributing-konflux-testing-rhoai.md#its) `odh-olminstall` for [ODH](../../doc/contributing-konflux-testing-rhoai.md#odh) (`open-data-hub-tenant`, `odh-operator-catalog` component) |
-| [`tekton/its/its-rhoai-e2e-eaas-ocp421.yaml`](tekton/its/its-rhoai-e2e-eaas-ocp421.yaml) | [ITS](../../doc/contributing-konflux-testing-rhoai.md#its) `rhoai-e2e-eaas-ocp421` — EaaS on **`rhoai-fbc-fragment-ocp-421`** (`CLUSTER_SOURCE=EAAS`, `component_rhoai-fbc-fragment-ocp-421`) |
+| [`tekton/its/its-rhoai-e2e-eaas-ocp421.yaml`](tekton/its/its-rhoai-e2e-eaas-ocp421.yaml) | [ITS](../../doc/contributing-konflux-testing-rhoai.md#its) `rhoai-e2e-eaas-ocp421` - EaaS **slice A** on **`rhoai-fbc-fragment-ocp-421`** (in-tree; enable after upstream merge) |
+| [`tekton/its/its-rhoai-e2e-eaas-ocp422.yaml`](tekton/its/its-rhoai-e2e-eaas-ocp422.yaml) | [ITS](../../doc/contributing-konflux-testing-rhoai.md#its) `rhoai-e2e-eaas-ocp422` - EaaS **slice B** on **`rhoai-fbc-fragment-ocp-422`** (in-tree; enable after upstream merge) |
+| [`tekton/its/its-rhoai-e2e-eaas-playpen-a.yaml`](tekton/its/its-rhoai-e2e-eaas-playpen-a.yaml) | Playpen debug **slice A** (all smoke except platform + Cypress) |
+| [`tekton/its/its-rhoai-e2e-eaas-playpen-b.yaml`](tekton/its/its-rhoai-e2e-eaas-playpen-b.yaml) | Playpen debug **slice B** (`dashboard_cypress` + `platform` only) |
 | [`tekton/its/its-rhoai-e2e-rh-nightly-pm-ocp420.yaml`](tekton/its/its-rhoai-e2e-rh-nightly-pm-ocp420.yaml) | Auto [ITS](../../doc/contributing-konflux-testing-rhoai.md#its) on **`rhoai-fbc-fragment-ocp-420`** for external rh-nightly cluster (`optional: true`) |
 | [`config/test-snapshot-rh-nightly.yaml`](config/test-snapshot-rh-nightly.yaml) | Offline FBC pin for `--run-its` when Konflux lookup fails (rh-nightly ITS) |
 | [`suite/its_registry.py`](suite/its_registry.py) | Resolve in-tree ITS YAML by `metadata.name` for `--enable-its` / `--disable-its` |
@@ -166,7 +169,7 @@ Konflux Tekton does **not** support nested `pipelineRef` pipelines. The runnable
 | `pipeline-run-summary-step` | Dispatch `steps.pipeline_run_summary_steps` |
 | `write-konflux-task-summary-finally` | Per-task `TASK_MESSAGE` via `tekton/scripts/run_write_task_message.sh` (standalone Tasks use `finally:`; inline pipeline `taskSpec`s use a last step  -  Konflux rejects nested `taskSpec.finally`) |
 
-ITS objects ([`its-rhoai-e2e-eaas-ocp421.yaml`](tekton/its/its-rhoai-e2e-eaas-ocp421.yaml), [`its-rhoai-e2e-rh-nightly-pm-ocp420.yaml`](tekton/its/its-rhoai-e2e-rh-nightly-pm-ocp420.yaml), [`its-olminstall-open-data-hub-tenant.yaml`](tekton/its/its-olminstall-open-data-hub-tenant.yaml)) point at the monolithic pipeline via `resolverRef`, not at snippets.
+ITS objects ([`its-rhoai-e2e-eaas-ocp421.yaml`](tekton/its/its-rhoai-e2e-eaas-ocp421.yaml), [`its-rhoai-e2e-eaas-ocp422.yaml`](tekton/its/its-rhoai-e2e-eaas-ocp422.yaml), [`its-rhoai-e2e-eaas-playpen-a.yaml`](tekton/its/its-rhoai-e2e-eaas-playpen-a.yaml), [`its-rhoai-e2e-eaas-playpen-b.yaml`](tekton/its/its-rhoai-e2e-eaas-playpen-b.yaml), [`its-rhoai-e2e-rh-nightly-pm-ocp420.yaml`](tekton/its/its-rhoai-e2e-rh-nightly-pm-ocp420.yaml), [`its-olminstall-open-data-hub-tenant.yaml`](tekton/its/its-olminstall-open-data-hub-tenant.yaml)) point at the monolithic pipeline via `resolverRef`, not at snippets.
 
 ### Konflux UI (reading a PipelineRun)
 
@@ -179,7 +182,7 @@ The [Pipeline flow](#pipeline-flow) diagram is the expected DAG. In the UI:
 
 [`its-olminstall-open-data-hub-tenant.yaml`](tekton/its/its-olminstall-open-data-hub-tenant.yaml) targets **`open-data-hub-tenant`**, application **`opendatahub-builds`**, context `component_odh-operator-catalog`, triggering on [ODH](../../doc/contributing-konflux-testing-rhoai.md#odh) [FBCF](../../doc/contributing-konflux-testing-rhoai.md#fbc--fbcf) builds.
 
-[`its-rhoai-e2e-eaas-ocp421.yaml`](tekton/its/its-rhoai-e2e-eaas-ocp421.yaml) targets **`rhoai-tenant`**, application **`rhoai-fbc-fragment-ocp-421`**, auto-triggering EaaS E2E on upstream FBC component builds (OCP 4.21). Use **`--konflux-app testops-playpen`** only for sandbox debug on manual Snapshots.
+[`its-rhoai-e2e-eaas-ocp421.yaml`](tekton/its/its-rhoai-e2e-eaas-ocp421.yaml) targets **`rhoai-tenant`**, application **`rhoai-fbc-fragment-ocp-421`**, with EaaS **slice A** `COMPONENTS` (pairs with [`its-rhoai-e2e-eaas-ocp422.yaml`](tekton/its/its-rhoai-e2e-eaas-ocp422.yaml) = slice B on ocp-422). Keep both in-tree until after upstream merge; debug with playpen ITS or `--run-its … --konflux-app testops-playpen`. Re-applying `ocp421` on the FBC app cuts that app over from the previous full matrix to slice A.
 
 **Why extra PipelineRuns appear:** A Konflux [Snapshot](../../doc/contributing-konflux-testing-rhoai.md#snapshot) for an **Application** starts **one `PipelineRun` per `IntegrationTestScenario`** that matches that app. Old scenarios still **on the cluster** (for example `rhoai-test` → `testops-e2e-test`) are **not** removed when you update git; they keep firing until deleted. **`testops-playpen-enterprise-contract-*`** runs are **Enterprise Contract** policy checks  -  separate from olminstall; tune or disable them in Konflux application / release / EC settings for your tenant, not via `tekton/pipelines/olminstall-pipeline.yaml`.
 
@@ -218,7 +221,8 @@ This is the **official [HyperShift](../../doc/contributing-konflux-testing-rhoai
 - **Manual (`oc` only):** After [logging in](../../doc/contributing-konflux-testing-rhoai.md#log-in-and-pick-a-namespace) to the tenant namespace, apply an [ITS](../../doc/contributing-konflux-testing-rhoai.md#its), then create a [Snapshot](../../doc/contributing-konflux-testing-rhoai.md#snapshot) (pinned file or latest image for your app label). Example for the [RHOAI](../../doc/contributing-konflux-testing-rhoai.md#rhoai) sandbox [ITS](../../doc/contributing-konflux-testing-rhoai.md#its) and `rhoai-fbc-fragment-ocp-421`:
 
 ```bash
-oc apply -n rhoai-tenant -f integration-tests/olminstall/tekton/its/its-rhoai-e2e-eaas-ocp421.yaml
+# Prefer playpen debug until after upstream merge; applying ocp421 on FBC cuts over to slice A:
+# oc apply -n rhoai-tenant -f integration-tests/olminstall/tekton/its/its-rhoai-e2e-eaas-ocp421.yaml
 oc create -n rhoai-tenant -f integration-tests/olminstall/config/test-snapshot.yaml
 # Or substitute the latest snapshot image (adjust -l / jsonpath for your application):
 LATEST=$(oc get snapshots -n rhoai-tenant \
@@ -235,12 +239,15 @@ For generic Konflux testing (login, namespaces, [PipelineRun](../../doc/contribu
 
 ### IntegrationTestScenario admin (`--enable-its` / `--disable-its` / `--run-its`)
 
-Rh-nightly and EaaS olminstall ITS live on the **FBC fragment Applications** (native Konflux auto-trigger on component build Snapshots), not on `testops-playpen`.
+Rh-nightly stays on **FBC ocp-420** (full matrix, external cluster). EaaS smoke is split across FBC apps: **ocp-421 = slice A** (all smoke except Cypress/platform), **ocp-422 = slice B** (`dashboard_cypress` + `platform` only; same `COMPONENTS` as playpen-a/b). Debug on **`testops-playpen`** via `--run-its rhoai-e2e-eaas-playpen-*` (or FBC ITS names + `--konflux-app testops-playpen`). Do **not** `--enable-its` for `rhoai-e2e-eaas-ocp421` / `ocp422` on FBC apps until after this PR merges upstream; re-applying `ocp421` cuts that app over from full matrix to slice A.
 
-| ITS name | Konflux Application | Cluster | `CLUSTER_SOURCE` | Auto-trigger context | ITS PipelineRun prefix |
-|----------|---------------------|---------|------------------|----------------------|-------------------------|
-| `rhoai-e2e-rh-nightly-pm-ocp420` | **`rhoai-fbc-fragment-ocp-420`** | rh-nightly-pm (external) | `olminstall-kubeconfig-rh-nightly-pm` | `component_rhoai-fbc-fragment-ocp-420` | `e2e-its-rh-nightly-pm-bvt-smoke-*` |
-| `rhoai-e2e-eaas-ocp421` | **`rhoai-fbc-fragment-ocp-421`** | EaaS (ephemeral) | `EAAS` | `component_rhoai-fbc-fragment-ocp-421` | `e2e-its-eaas-bvt-smoke-*` |
+| ITS name | Konflux Application | Cluster | `CLUSTER_SOURCE` | Auto-trigger context | Smoke | ITS PipelineRun prefix |
+|----------|---------------------|---------|------------------|----------------------|-------|-------------------------|
+| `rhoai-e2e-rh-nightly-pm-ocp420` | **`rhoai-fbc-fragment-ocp-420`** | rh-nightly-pm (external) | `olminstall-kubeconfig-rh-nightly-pm` | `component_rhoai-fbc-fragment-ocp-420` | full | `e2e-its-rh-nightly-pm-bvt-smoke-*` |
+| `rhoai-e2e-eaas-ocp421` | **`rhoai-fbc-fragment-ocp-421`** | EaaS (ephemeral) | `EAAS` | `component_rhoai-fbc-fragment-ocp-421` | **slice A** | `e2e-its-eaas-bvt-smoke-*` |
+| `rhoai-e2e-eaas-ocp422` | **`rhoai-fbc-fragment-ocp-422`** | EaaS (ephemeral) | `EAAS` | `component_rhoai-fbc-fragment-ocp-422` | **slice B** | `e2e-its-eaas-bvt-smoke-*` |
+| `rhoai-e2e-eaas-playpen-a` | **`testops-playpen`** | EaaS (ephemeral) | `EAAS` | `push` (manual) | **slice A** | `e2e-its-eaas-bvt-smoke-*` |
+| `rhoai-e2e-eaas-playpen-b` | **`testops-playpen`** | EaaS (ephemeral) | `EAAS` | `push` (manual) | **slice B** | `e2e-its-eaas-bvt-smoke-*` |
 
 Use [`olm_pipeline.py`](olm_pipeline.py) to apply or remove in-tree [ITS](../../doc/contributing-konflux-testing-rhoai.md#its) manifests by **`metadata.name`**, **olminstall-relative path** (preferred, e.g. `tekton/its/its-rhoai-e2e-rh-nightly-pm-ocp420.yaml`), **repo-relative path** (e.g. `integration-tests/olminstall/tekton/its/…`), or **absolute path** under the repository root. **`--enable-its`** applies the ITS only (launch-and-forget); only Konflux rollout flags are allowed (`--konflux-repo`, `--konflux-branch`, `--konflux-app`). **`--run-its`** creates a one-shot direct CLI PipelineRun (`e2e-cli-*`, Konflux **Incoming**) without applying ITS; cluster and test overrides (`--components`, `--tests`, `--external-kubeconfig`, etc.) are allowed.
 
@@ -254,14 +261,24 @@ python3 integration-tests/olminstall/olm_pipeline.py \
   --konflux-repo https://github.com/<you>/odh-konflux-central.git \
   --konflux-branch <branch> \
   --konflux-namespace rhoai-tenant
+```
+
+**After this PR merges upstream** (EaaS slice A on 421 + slice B on 422):
+
+```bash
 python3 integration-tests/olminstall/olm_pipeline.py \
   --enable-its rhoai-e2e-eaas-ocp421 \
   --konflux-repo https://github.com/<you>/odh-konflux-central.git \
-  --konflux-branch <branch> \
+  --konflux-branch main \
+  --konflux-namespace rhoai-tenant
+python3 integration-tests/olminstall/olm_pipeline.py \
+  --enable-its rhoai-e2e-eaas-ocp422 \
+  --konflux-repo https://github.com/<you>/odh-konflux-central.git \
+  --konflux-branch main \
   --konflux-namespace rhoai-tenant
 ```
 
-Tenant secret **`olminstall-kubeconfig-rh-nightly-pm`** must exist before rh-nightly runs. Both ITS use `optional: true` so failures do not block FBC release.
+Tenant secret **`olminstall-kubeconfig-rh-nightly-pm`** must exist before rh-nightly runs. All three ITS use `optional: true` so failures do not block FBC release.
 
 **Autonomous external login (RHOAIENG-57718):** store durable htpasswd credentials in tenant Secret **`olminstall-external-rh-nightly-pm-credentials`** (`HTPASSWD_USER`, `HTPASSWD_PASS`, `API_SERVER`). The pipeline step **`refresh-external-kubeconfig`** (in **`external-cluster-ready`**) logs in with those credentials, refreshes the bearer token, writes the kubeconfig back to **`CLUSTER_SOURCE`** (step fails if write-back fails), and stages it for downstream tasks.
 
@@ -272,8 +289,12 @@ Tenant secret **`olminstall-kubeconfig-rh-nightly-pm`** must exist before rh-nig
 | Enable rh-nightly ITS (FBC app, auto on upstream builds) | `--enable-its rhoai-e2e-rh-nightly-pm-ocp420` (manifest app) |
 | Debug rh-nightly ITS on playpen (manual Snapshots only) | `--enable-its rhoai-e2e-rh-nightly-pm-ocp420 --konflux-app testops-playpen` |
 | Debug rh-nightly ITS cluster on playpen | add `--external-kubeconfig ~/.kube/<cluster>` to **`--run-its`** |
-| Enable EaaS ITS (421 FBC app, auto on upstream builds) | `--enable-its rhoai-e2e-eaas-ocp421` |
+| Enable EaaS slice A (421 FBC) after upstream merge | `--enable-its rhoai-e2e-eaas-ocp421` |
+| Enable EaaS slice B (422 FBC) after upstream merge | `--enable-its rhoai-e2e-eaas-ocp422` |
 | Debug EaaS ITS on playpen (manual Snapshots only) | `--enable-its rhoai-e2e-eaas-ocp421 --konflux-app testops-playpen` |
+| Enable playpen EaaS smoke slice A/B (not FBC) | `--enable-its rhoai-e2e-eaas-playpen-a` / `…-playpen-b` |
+| Run playpen EaaS slice now | `--run-its rhoai-e2e-eaas-playpen-a` (or `-b`) |
+| Debug FBC A/B ITS on playpen | `--run-its rhoai-e2e-eaas-ocp421 --konflux-app testops-playpen` (same for `ocp422`) |
 | Run rh-nightly now (direct CLI PR, streams logs) | `--run-its rhoai-e2e-rh-nightly-pm-ocp420` |
 | Scoped smoke debug | `--run-its rhoai-e2e-rh-nightly-pm-ocp420 --tests smoke --components dashboard_cypress` |
 | Disable a profile | `--disable-its NAME` |

--- a/integration-tests/olminstall/components/codeflare_sdk/kueue_prep.py
+++ b/integration-tests/olminstall/components/codeflare_sdk/kueue_prep.py
@@ -16,6 +16,8 @@ from suite.component_version_gate import (
 
 _KUEUE_API_GROUP = "kueue.x-k8s.io"
 _OPENSHIFT_KUEUE_CLUSTER = "cluster"
+_KUEUE_WEBHOOK_NS = "openshift-kueue-operator"
+_KUEUE_WEBHOOK_SVC = "kueue-webhook-service"
 _DEFAULT_TIMEOUT_SEC = 600
 _POLL_SEC = 15
 
@@ -42,6 +44,40 @@ def _kueue_api_available() -> bool:
     if proc.returncode != 0:
         return False
     return "resourceflavor" in (proc.stdout or "").lower()
+
+
+def _kueue_webhook_ready() -> bool:
+    """Conversion webhook Service must exist with endpoints (ClusterQueue create fails otherwise)."""
+    svc = oc_run(
+        ["get", "svc", _KUEUE_WEBHOOK_SVC, "-n", _KUEUE_WEBHOOK_NS, "-o", "name"],
+        check=False,
+        capture_output=True,
+        timeout=30,
+    )
+    if svc.returncode != 0:
+        return False
+    eps = oc_run(
+        ["get", "endpoints", _KUEUE_WEBHOOK_SVC, "-n", _KUEUE_WEBHOOK_NS, "-o", "json"],
+        check=False,
+        capture_output=True,
+        timeout=30,
+    )
+    if eps.returncode != 0:
+        return False
+    try:
+        doc = json.loads(eps.stdout or "{}")
+    except json.JSONDecodeError:
+        return False
+    for subset in doc.get("subsets") or []:
+        if not isinstance(subset, dict):
+            continue
+        if subset.get("addresses"):
+            return True
+    return False
+
+
+def _kueue_smoke_ready() -> bool:
+    return _kueue_api_available() and _kueue_webhook_ready()
 
 
 def _clear_stuck_openshift_kueue_cluster() -> None:
@@ -83,13 +119,13 @@ def _clear_stuck_openshift_kueue_cluster() -> None:
 
 
 def ensure_codeflare_kueue_ready(timeout_sec: int | None = None) -> None:
-    """Enable DSC Kueue and wait until RayJob smoke can use kueue.x-k8s.io APIs."""
-    if _kueue_api_available():
-        print("✓ Kueue API (kueue.x-k8s.io/resourceflavors) already available", flush=True)
-        return
-    ready_status, _, _ = _dsc_condition("KueueReady")
-    if ready_status == "True":
-        print("✓ DataScienceCluster KueueReady=True", flush=True)
+    """Enable DSC Kueue and wait until RayJob smoke can use kueue.x-k8s.io + conversion webhook."""
+    if _kueue_smoke_ready():
+        print(
+            "✓ Kueue API + webhook "
+            f"({_KUEUE_WEBHOOK_NS}/{_KUEUE_WEBHOOK_SVC}) already ready",
+            flush=True,
+        )
         return
 
     timeout = timeout_sec or int(
@@ -100,18 +136,26 @@ def ensure_codeflare_kueue_ready(timeout_sec: int | None = None) -> None:
     _clear_stuck_openshift_kueue_cluster()
     deadline = time.time() + timeout
     while time.time() < deadline:
-        if _kueue_api_available():
-            print("✓ Kueue API (kueue.x-k8s.io/resourceflavors) available", flush=True)
+        if _kueue_smoke_ready():
+            print(
+                "✓ Kueue API + webhook "
+                f"({_KUEUE_WEBHOOK_NS}/{_KUEUE_WEBHOOK_SVC}) ready",
+                flush=True,
+            )
             return
+        api_ok = _kueue_api_available()
+        wh_ok = _kueue_webhook_ready()
         status, reason, message = _dsc_condition("KueueReady")
-        if status == "True":
-            print("✓ DataScienceCluster KueueReady=True", flush=True)
-            return
-        detail = f"status={status or '?'} reason={reason or '?'}"
+        detail = (
+            f"api={'ok' if api_ok else 'missing'} "
+            f"webhook={'ok' if wh_ok else 'missing'} "
+            f"KueueReady={status or '?'} reason={reason or '?'}"
+        )
         if message:
             detail = f"{detail}: {message[:120]}"
         print(f"Waiting for Kueue ({detail})...", flush=True)
         time.sleep(_POLL_SEC)
     raise RuntimeError(
-        f"Kueue not ready after {timeout}s (expected KueueReady or {_KUEUE_API_GROUP} CRDs)"
+        f"Kueue not ready after {timeout}s "
+        f"(need {_KUEUE_API_GROUP} CRDs and {_KUEUE_WEBHOOK_NS}/{_KUEUE_WEBHOOK_SVC} endpoints)"
     )

--- a/integration-tests/olminstall/components/dashboard_cypress/runtime.py
+++ b/integration-tests/olminstall/components/dashboard_cypress/runtime.py
@@ -74,10 +74,10 @@ _BYOIDC_EXTRA_SKIP_TAGS = (
     "@LLMDServingCI @HardwareProfilesCI @HardwareProfileModelServing"
 )
 _KONFLUX_MANIFEST_EXTRA_SKIP_TAGS = "@ODS-327 @ODS-492"
-# Konflux EaaS HCP: kube bearer bypass has no OAuth IdP users for LDAP/RBAC or long notebook/train paths.
-_EAAS_BEARER_EXTRA_SKIP_TAGS = (
-    "@ModelTrainingCI @HardwareProfilesCI @ODS-1877 @NonConcurrent @ModelRegistryCI"
-)
+# Konflux EaaS HCP: historically skipped training/hardware paths under bearer auth.
+# JP-cypress-EaaS-parity: keep empty so SmokeSets match regular-cluster coverage;
+# auth failures surface as real fails until LDAP/OAuth IdP is available.
+_EAAS_BEARER_EXTRA_SKIP_TAGS = ""
 
 
 def stage_writable_kubeconfig(artifacts_dir: Path, kubeconfig_src: str) -> Path:
@@ -625,6 +625,9 @@ def htpasswd_hcp_extra_cypress_skip_tags(*, odh_dashboard_url: str) -> str:
         return ""
     if _ldap._cluster_is_byoidc():
         return ""
+    # Bearer EaaS must not inherit SHARED HCP skips (JP-cypress-EaaS-parity).
+    if gateway_cypress_uses_bearer_bypass(odh_dashboard_url=odh_dashboard_url):
+        return ""
     from install.ldap import cluster_has_ldap_identity
 
     if cluster_has_ldap_identity():
@@ -642,7 +645,7 @@ def byoidc_extra_cypress_skip_tags(*, odh_dashboard_url: str) -> str:
 
 
 def eaas_bearer_extra_cypress_skip_tags(*, odh_dashboard_url: str) -> str:
-    """Extra skipTags when gateway Cypress uses kube bearer (no OAuth htpasswd/LDAP users)."""
+    """No extra skipTags on bearer EaaS (JP-cypress-EaaS-parity vs regular-cluster smoke)."""
     if not gateway_cypress_uses_bearer_bypass(odh_dashboard_url=odh_dashboard_url):
         return ""
     return _EAAS_BEARER_EXTRA_SKIP_TAGS

--- a/integration-tests/olminstall/components/maas_billing/gateway.py
+++ b/integration-tests/olminstall/components/maas_billing/gateway.py
@@ -92,6 +92,57 @@ def _copy_tls_secret_to_gateway_ns(name: str, *, src_ns: str) -> bool:
     return True
 
 
+_OPENSHIFT_DEFAULT_GATEWAY_CLASS = "openshift-default"
+_OPENSHIFT_GATEWAY_CONTROLLER = "openshift.io/gateway-controller/v1"
+
+
+def ensure_openshift_default_gateway_class() -> None:
+    """Ensure GatewayClass openshift-default exists (Jenkins configure-maas-gateway parity)."""
+    r = oc_run(
+        [
+            "get",
+            "gatewayclass",
+            _OPENSHIFT_DEFAULT_GATEWAY_CLASS,
+            "-o",
+            "jsonpath={.status.conditions[?(@.type==\"Accepted\")].status}",
+        ],
+        check=False,
+        capture_output=True,
+        timeout=30,
+    )
+    if r.returncode == 0 and (r.stdout or "").strip() == "True":
+        print(
+            f"✓ GatewayClass {_OPENSHIFT_DEFAULT_GATEWAY_CLASS} Accepted=True",
+            flush=True,
+        )
+        return
+    yaml_doc = f"""\
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: {_OPENSHIFT_DEFAULT_GATEWAY_CLASS}
+spec:
+  controllerName: "{_OPENSHIFT_GATEWAY_CONTROLLER}"
+"""
+    print(f"Applying GatewayClass {_OPENSHIFT_DEFAULT_GATEWAY_CLASS}...", flush=True)
+    apply = oc_run(
+        ["apply", "-f", "-"],
+        stdin_text=yaml_doc,
+        check=False,
+        capture_output=True,
+        timeout=60,
+    )
+    if apply.returncode != 0:
+        err = (apply.stderr or apply.stdout or "").strip()
+        print(
+            f"WARN: could not apply GatewayClass {_OPENSHIFT_DEFAULT_GATEWAY_CLASS}: "
+            f"{err[:200]}",
+            flush=True,
+        )
+        return
+    print(f"✓ GatewayClass {_OPENSHIFT_DEFAULT_GATEWAY_CLASS} applied", flush=True)
+
+
 def ensure_maas_gateway_ingress_tls_secret() -> None:
     """Ensure the Gateway HTTPS listener certificateRef exists in openshift-ingress."""
     cert_name = _ingress_tls_secret_name()
@@ -298,10 +349,104 @@ def ensure_maas_api_auth_policy() -> None:
     print(f"✓ MaaS API AuthPolicy {_MAAS_APPS_NS}/{_MAAS_AUTH_POLICY} applied", flush=True)
 
 
+def ensure_maas_gateway_https_service_clusterip() -> bool:
+    """On EaaS/HyperShift, create gateway-owned HTTPS ClusterIP when controller never Programs.
+
+    OpenShift Gateway controller may leave Programmed=Unknown without creating the
+    ``maas-default-gateway-openshift-default`` Service (LB provisioning gap). maas-api
+    only needs a resolvable HTTPS ClusterIP + Route passthrough.
+    """
+    from components.maas_billing.common import _maas_gateway_https_service_ready
+    from install.gateway_config import cluster_source_is_eaas
+    from install.rosa_hcp_pull_setup import is_hypershift_managed_cluster
+
+    if not (cluster_source_is_eaas() or is_hypershift_managed_cluster()):
+        return False
+    ready, detail = _maas_gateway_https_service_ready()
+    if ready:
+        return True
+    pods = oc_run(
+        [
+            "get",
+            "pods",
+            "-n",
+            _GATEWAY_NS,
+            "-l",
+            f"gateway.networking.k8s.io/gateway-name={_GATEWAY_NAME}",
+            "-o",
+            "jsonpath={.items[*].metadata.name}",
+        ],
+        check=False,
+        capture_output=True,
+        timeout=30,
+    )
+    if pods.returncode != 0 or not (pods.stdout or "").strip():
+        print(
+            f"NOTE: no gateway pods labeled for {_GATEWAY_NAME}; "
+            "cannot synthesize HTTPS ClusterIP yet",
+            flush=True,
+        )
+        return False
+    yaml_doc = f"""\
+apiVersion: v1
+kind: Service
+metadata:
+  name: {_GATEWAY_SVC}
+  namespace: {_GATEWAY_NS}
+  labels:
+    gateway.networking.k8s.io/gateway-name: {_GATEWAY_NAME}
+    app.kubernetes.io/name: maas
+    app.kubernetes.io/instance: {_GATEWAY_NAME}
+    app.kubernetes.io/component: gateway
+    opendatahub.io/managed: "false"
+spec:
+  type: ClusterIP
+  selector:
+    gateway.networking.k8s.io/gateway-name: {_GATEWAY_NAME}
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8080
+      protocol: TCP
+    - name: https
+      port: 443
+      targetPort: 8443
+      protocol: TCP
+"""
+    print(
+        f"Applying EaaS fallback HTTPS ClusterIP {_GATEWAY_NS}/{_GATEWAY_SVC}...",
+        flush=True,
+    )
+    apply = oc_run(
+        ["apply", "-f", "-"],
+        stdin_text=yaml_doc,
+        check=False,
+        capture_output=True,
+        timeout=60,
+    )
+    if apply.returncode != 0:
+        err = (apply.stderr or apply.stdout or "").strip()
+        print(
+            f"WARN: could not apply EaaS HTTPS ClusterIP: {err[:200]}",
+            flush=True,
+        )
+        return False
+    ready, detail = _maas_gateway_https_service_ready()
+    if ready:
+        print(f"✓ EaaS HTTPS ClusterIP ready ({detail})", flush=True)
+        return True
+    print(
+        f"WARN: EaaS HTTPS ClusterIP applied but still not ready ({detail[:120]})",
+        flush=True,
+    )
+    return False
+
+
 def ensure_maas_gateway() -> None:
     """Ensure maas-default-gateway exists with MaaS-required annotations (olminstall configure-maas-gateway)."""
     from components.maas_billing.common import _maas_gateway_annotations_ready
 
+    ensure_openshift_default_gateway_class()
     r = oc_run(
         ["get", "gateway", _GATEWAY_NAME, "-n", _GATEWAY_NS],
         check=False,

--- a/integration-tests/olminstall/components/maas_billing/oidc_users.py
+++ b/integration-tests/olminstall/components/maas_billing/oidc_users.py
@@ -521,22 +521,6 @@ def ensure_maas_oidc_keycloak_users() -> None:
     print(f"✓ MaaS OIDC Keycloak users provisioned in {_MAAS_OIDC_REALM}", flush=True)
 
 
-def _maas_eaas_ldap_vault_overlay(vault: dict[str, str]) -> dict[str, str]:
-    """Keep vault LDAP users on Konflux EaaS (do not remap to htpasswd admin)."""
-    user = vault.get("TEST_USER_USERNAME", "").strip()
-    passwd = vault.get("TEST_USER_PASSWORD", "").strip()
-    if not user or not passwd:
-        return {}
-    auth_type = vault.get("TEST_USER_AUTH_TYPE", "").strip() or "ldap"
-    cluster_auth = vault.get("CLUSTER_AUTH", "").strip() or auth_type
-    return {
-        "TEST_USER_USERNAME": user,
-        "TEST_USER_PASSWORD": passwd,
-        "TEST_USER_AUTH_TYPE": auth_type,
-        "CLUSTER_AUTH": cluster_auth,
-    }
-
-
 def _maas_billing_byoidc_overlay() -> dict[str, str]:
     """BYOIDC / late EaaS ``oidc/byoidc-credentials`` (dashboard Cypress poll parity)."""
     from components.codeflare_sdk.auth import codeflare_byoidc_test_user_overlay
@@ -560,19 +544,24 @@ def maas_billing_htpasswd_env_overrides() -> dict[str, str]:
 
     cluster_source = os.environ.get("CLUSTER_SOURCE", "").strip()
     is_eaas = cluster_source == CLUSTER_SOURCE_EAAS
+    is_byoidc = _cluster_is_byoidc()
 
-    if _cluster_is_byoidc() or is_eaas:
+    if is_byoidc or is_eaas:
         byoidc = _maas_billing_byoidc_overlay()
         if byoidc:
             return byoidc
-        if _cluster_is_byoidc():
+        if is_byoidc:
             return {}
-        if is_eaas and not cluster_has_htpasswd_identity():
-            vault = read_pytest_vault_env()
-            return _maas_eaas_ldap_vault_overlay(vault)
-
-    if _cluster_is_byoidc():
-        return {}
+        # EaaS HyperShift often blocks OAuth IdP patches (HostedCluster ValidatingAdmissionPolicy).
+        # Vault LDAP users then cannot log in — prefer htpasswd overlay when IdP exists; otherwise
+        # return {} and rely on --tc use_unprivileged_client:False (admin SA).
+        if not cluster_has_htpasswd_identity():
+            print(
+                "NOTE: EaaS has no htpasswd OAuth IdP (HyperShift may block OAuth patches) — "
+                "skipping vault LDAP overlay; use admin client for MaaS billing",
+                flush=True,
+            )
+            return {}
 
     vault = read_pytest_vault_env()
     for key in (
@@ -810,7 +799,15 @@ def maas_billing_rosa_hcp_skip_htpasswd_oauth_idp() -> bool:
     if _cluster_is_byoidc():
         return False
     from install.ldap import _cluster_is_rosa_hcp, cluster_has_htpasswd_identity
+    from install.rosa_hcp_pull_setup import is_hypershift_managed_cluster
+    from suite.its_trigger_params import CLUSTER_SOURCE_EAAS
 
+    # EaaS HyperShift: HostedCluster VAP blocks OAuth IdP patches (same as ROSA HCP).
+    if (
+        os.environ.get("CLUSTER_SOURCE", "").strip() == CLUSTER_SOURCE_EAAS
+        or is_hypershift_managed_cluster()
+    ) and not cluster_has_htpasswd_identity():
+        return True
     return _cluster_is_rosa_hcp() or cluster_has_htpasswd_identity()
 
 
@@ -819,7 +816,8 @@ def maas_billing_rosa_hcp_pytest_extra_args() -> str:
     if not maas_billing_rosa_hcp_skip_htpasswd_oauth_idp():
         return ""
     print(
-        "✓ ROSA HCP/htpasswd cluster — skipping maas_htpasswd_oauth_idp-dependent pytest "
+        "✓ External HCP/EaaS (no htpasswd OAuth IdP) - skipping "
+        "maas_htpasswd_oauth_idp-dependent pytest "
         "(HostedCluster VAP blocks OAuth identityProvider patches)",
         flush=True,
     )
@@ -853,14 +851,17 @@ _MAAS_SKIP_AITENANT_BOOTSTRAP_CHILD_GATEWAY = (
 
 
 def maas_billing_aitenant_bootstrap_pytest_extra_args() -> str:
-    """Skip bootstrap child-gateway assertion on external HCP (pooled gatewayRef drift)."""
-    from suite.its_trigger_params import is_external_cluster_source
+    """Skip bootstrap child-gateway assertion on external HCP / EaaS (gatewayRef drift)."""
+    from suite.its_trigger_params import CLUSTER_SOURCE_EAAS, is_external_cluster_source
 
-    if not is_external_cluster_source(os.environ.get("CLUSTER_SOURCE", "")):
+    source = os.environ.get("CLUSTER_SOURCE", "")
+    if not (
+        is_external_cluster_source(source) or source.strip() == CLUSTER_SOURCE_EAAS
+    ):
         return ""
     print(
-        "✓ External cluster — skipping test_aitenant_bootstrap_creates_tenant_environment "
-        "(default Tenant gatewayRef vs e2e-aigw bootstrap on pooled HCP)",
+        "✓ External/EaaS cluster — skipping test_aitenant_bootstrap_creates_tenant_environment "
+        "(default Tenant gatewayRef vs e2e-aigw bootstrap)",
         flush=True,
     )
     return _MAAS_SKIP_AITENANT_BOOTSTRAP_CHILD_GATEWAY

--- a/integration-tests/olminstall/components/maas_billing/prep.py
+++ b/integration-tests/olminstall/components/maas_billing/prep.py
@@ -64,8 +64,15 @@ def _restart_maas_api_after_gateway() -> None:
 def ensure_maas_gateway_before_models_as_service(*, https_wait_sec: int | None = None) -> None:
     """Gateway HTTPS service must exist before modelsAsService enables maas-api."""
     from components.maas_billing.auth import recover_kuadrant_after_gateway_api_provider
+    from components.maas_billing.gateway import ensure_openshift_default_gateway_class
+    from helpers.hypershift_admission_webhooks import (
+        neutralize_broken_hypershift_admission_webhooks,
+    )
     from steps.cluster_prep_state import maas_gateway_https_blocked_reason
 
+    # HyperShift stub webhooks fail-closed and can block gateway Service / Deployments.
+    neutralize_broken_hypershift_admission_webhooks()
+    ensure_openshift_default_gateway_class()
     # cleanup+reinstall: Kuadrant often stuck MissingDependency until GatewayClass exists;
     # restart operator once provider is present so MaaS smoke can run.
     recover_kuadrant_after_gateway_api_provider()

--- a/integration-tests/olminstall/components/maas_billing/wait.py
+++ b/integration-tests/olminstall/components/maas_billing/wait.py
@@ -95,12 +95,59 @@ def _nudge_maas_gateway_reconcile() -> None:
     from components.maas_billing.auth import ensure_authorino_tls
     from components.maas_billing.gateway import (
         ensure_maas_gateway,
+        ensure_maas_gateway_https_service_clusterip,
         ensure_maas_gateway_ingress_tls_secret,
+        ensure_openshift_default_gateway_class,
     )
 
+    ensure_openshift_default_gateway_class()
     ensure_maas_gateway_ingress_tls_secret()
     ensure_authorino_tls()
     ensure_maas_gateway()
+    ensure_maas_gateway_https_service_clusterip()
+
+
+def _dump_maas_gateway_https_diagnostics() -> None:
+    """Best-effort cluster dump when HTTPS Service wait fails (EaaS Programmed gaps)."""
+    cmds = (
+        ["get", "gatewayclass", "-o", "wide"],
+        ["get", "gateway", _GATEWAY_NAME, "-n", _GATEWAY_NS, "-o", "yaml"],
+        [
+            "get",
+            "svc",
+            "-n",
+            _GATEWAY_NS,
+            "-l",
+            f"gateway.networking.k8s.io/gateway-name={_GATEWAY_NAME}",
+            "-o",
+            "wide",
+        ],
+        [
+            "get",
+            "pods",
+            "-n",
+            _GATEWAY_NS,
+            "-l",
+            f"gateway.networking.k8s.io/gateway-name={_GATEWAY_NAME}",
+            "-o",
+            "wide",
+        ],
+        [
+            "get",
+            "deploy",
+            "-n",
+            _GATEWAY_NS,
+            "-o",
+            "wide",
+        ],
+    )
+    for args in cmds:
+        r = oc_run(args, check=False, capture_output=True, timeout=45)
+        out = (r.stdout or r.stderr or "").strip()
+        print(
+            f"DIAG maas-gateway [{' '.join(args)}]:\n{out[:4000]}",
+            flush=True,
+        )
 
 
 def _wait_maas_gateway_https_service(*, timeout_sec: int) -> None:
@@ -170,6 +217,10 @@ def _wait_maas_gateway_https_for_models_as_service(*, timeout_sec: int) -> None:
         time.sleep(12)
     _, svc_detail = _maas_gateway_https_service_ready()
     msg = f"MaaS gateway HTTPS service not ready after {timeout_sec}s — {svc_detail[:300]}"
+    try:
+        _dump_maas_gateway_https_diagnostics()
+    except Exception as exc:
+        print(f"WARN: MaaS gateway HTTPS diagnostics failed: {exc}", file=sys.stderr, flush=True)
     mark_maas_gateway_https_failed(msg)
     raise RuntimeError(msg)
 

--- a/integration-tests/olminstall/components/ogx/__init__.py
+++ b/integration-tests/olminstall/components/ogx/__init__.py
@@ -1,0 +1,1 @@
+"""OGX component helpers for olminstall Konflux smokes."""

--- a/integration-tests/olminstall/components/ogx/platform_smoke.py
+++ b/integration-tests/olminstall/components/ogx/platform_smoke.py
@@ -1,0 +1,142 @@
+"""OGX platform diagnostics when pytest selects zero product tests (JP4: no hollow SUCCESS)."""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from xml.sax.saxutils import escape, quoteattr
+
+from install.dsc_install import oc_run
+
+
+_OGX_CRD_NEEDLES = ("ogx.io", "ogxservers", "ogxdistributions")
+
+
+def _list_ogx_crds() -> list[str]:
+    r = oc_run(["get", "crd", "-o", "name"], check=False, capture_output=True, timeout=60)
+    if r.returncode != 0:
+        return []
+    names: list[str] = []
+    for line in (r.stdout or "").splitlines():
+        name = line.strip().removeprefix("customresourcedefinition.apiextensions.k8s.io/")
+        low = name.lower()
+        if any(n in low for n in _OGX_CRD_NEEDLES):
+            names.append(name)
+    return names
+
+
+def _crd_present(name: str) -> tuple[bool, str]:
+    r = oc_run(["get", "crd", name], check=False, capture_output=True, timeout=30)
+    if r.returncode == 0:
+        return True, f"CRD {name} registered"
+    err = (r.stderr or r.stdout or "").strip() or f"oc get crd {name} exit {r.returncode}"
+    return False, err
+
+
+def _dsc_ogx_or_llamastack_state() -> tuple[bool, str]:
+    """llamastackoperator must stay Removed for EA OGX."""
+    from install.dsc_install import dsc_component_management_state
+
+    try:
+        llama = dsc_component_management_state("llamastackoperator")
+    except Exception as exc:
+        return False, f"llamastackoperator state unreadable: {exc}"
+    if llama == "Managed":
+        return False, "llamastackoperator is Managed (conflicts with OGX EA.2)"
+    return True, f"llamastackoperator={llama or 'absent/Removed'}"
+
+
+def run_ogx_platform_checks() -> list[tuple[str, bool, str]]:
+    """Return (name, passed, detail) for lightweight OGX platform assertions."""
+    results: list[tuple[str, bool, str]] = []
+    crds = _list_ogx_crds()
+    if crds:
+        results.append(("ogx_crds_present", True, f"found {', '.join(crds[:5])}"))
+    else:
+        # Fall back to known EA.2 names when listing fails or CRDs absent.
+        any_ok = False
+        details: list[str] = []
+        for crd in ("ogxservers.ogx.io", "ogxdistributions.ogx.io"):
+            ok, detail = _crd_present(crd)
+            details.append(detail)
+            any_ok = any_ok or ok
+        results.append(
+            (
+                "ogx_crds_present",
+                any_ok,
+                "; ".join(details) if details else "no ogx.* CRDs found",
+            )
+        )
+    ok, detail = _dsc_ogx_or_llamastack_state()
+    results.append(("llamastackoperator_not_managed", ok, detail))
+    return results
+
+
+def write_ogx_platform_junit(artifacts_dir: Path, *, prefix: str = "ogx-smoke") -> Path:
+    """Write platform-check JUnit used when vector_stores smoke is deselected on EaaS."""
+    checks = run_ogx_platform_checks()
+    failures = sum(1 for _, ok, _ in checks if not ok)
+    cases: list[str] = []
+    for name, ok, detail in checks:
+        name_attr = quoteattr(name)
+        if ok:
+            cases.append(
+                f'  <testcase classname="ogx.platform" name={name_attr} time="0.1"/>\n'
+            )
+            print(f"✓ OGX platform: {name} — {detail}", flush=True)
+        else:
+            msg = quoteattr(detail)
+            cases.append(
+                f'  <testcase classname="ogx.platform" name={name_attr} time="0.1">\n'
+                f'    <failure message={msg}>{escape(detail)}</failure>\n'
+                f"  </testcase>\n"
+            )
+            print(f"✗ OGX platform: {name} — {detail}", flush=True)
+    xml = (
+        '<?xml version="1.0" encoding="utf-8"?>\n'
+        f'<testsuite name="ogx" tests="{len(checks)}" failures="{failures}" errors="0" skipped="0" '
+        f'time="{0.1 * len(checks):g}" timestamp="{time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())}">\n'
+        f"{''.join(cases)}"
+        "</testsuite>\n"
+    )
+    out = artifacts_dir / f"{prefix}.xml"
+    out.write_text(xml, encoding="utf-8")
+    print(f"JUnit (ogx platform): {out} ({len(checks) - failures} passed, {failures} failed)", flush=True)
+    return out
+
+
+def should_write_ogx_platform_smoke() -> bool:
+    """Always False: do not write platform CRD JUnit as SUCCESS when pytest selected nothing."""
+    return False
+
+
+def ensure_ogx_junit_after_pytest(artifacts_dir: Path, *, prefix: str = "ogx-smoke") -> None:
+    """Log platform diagnostics when pytest selected nothing; do not fake SUCCESS JUnit.
+
+    Jenkins/Konflux parity: empty selection must stay a real failure (unreadable/empty
+    JUnit → component red) on EaaS and external clusters. Optional CRD checks are
+    printed for operators only.
+    """
+    junit = artifacts_dir / f"{prefix}.xml"
+    if junit.is_file():
+        text = junit.read_text(encoding="utf-8", errors="replace")
+        has_product_tests = (
+            "<testcase" in text
+            and 'classname="ogx.platform"' not in text
+            and 'name="timeout"' not in text
+        )
+        if has_product_tests:
+            return
+    print(
+        "NOTE: OGX pytest left no product testcases (filter deselected all or empty suite); "
+        "not writing platform CRD JUnit as SUCCESS (JP4)",
+        flush=True,
+    )
+    try:
+        for name, passed, detail in run_ogx_platform_checks():
+            mark = "✓" if passed else "✗"
+            print(f"{mark} OGX platform diagnostic: {name} - {detail}", flush=True)
+    except Exception as exc:
+        print(f"WARN: OGX platform diagnostics failed: {exc}", flush=True)
+    if should_write_ogx_platform_smoke():
+        write_ogx_platform_junit(artifacts_dir, prefix=prefix)

--- a/integration-tests/olminstall/config/olminstall-components-smoke.yaml
+++ b/integration-tests/olminstall/config/olminstall-components-smoke.yaml
@@ -164,12 +164,12 @@ components:
       id: model_runtime
       description: >
         Model Runtime smoke tests. Opt-in on external clusters; many cases need cloud credentials.
-      pytestExtraArgs: "--tc use_unprivileged_client:False"
+      pytestExtraArgs: "--tc use_unprivileged_client:False -k 'not TestMLServerModelCar and not TestLLMDSmoke and not TestVllmCpuX86S3Inference and not TestVllmProbeHealth'"
       minPassRateForSuccess: 0.9
       nonBlockingOnTimeout: true
       requiresShiftLeftEnv: true
       componentTestTimeoutByGate:
-        smoke: 15m
+        smoke: 25m
         tier1: 45m
 
   - component:
@@ -197,6 +197,8 @@ components:
       description: >
         Models-as-a-Service billing smoke tests. May fail on external pooled clusters until
         MaaS auth gateway setup completes within the task timeout.
+        EaaS HyperShift blocks OAuth IdP patches — keep unprivileged client off (admin SA).
+      pytestExtraArgs: "--tc use_unprivileged_client:False"
       minPassRateForSuccess: 0.9
       nonBlockingOnTimeout: true
       componentTestTimeoutByGate:
@@ -327,15 +329,17 @@ components:
     konflux:
       id: ogx
       description: >
-        Red Hat OGX Distribution smoke tests. pgvector cases stay excluded until embedding
-        endpoints are available in the tenant environment.
+        Red Hat OGX Distribution smoke tests. Catalog keeps Jenkins baseline (-k not pgvector).
+        verify_images skips apply on EaaS and EXTERNAL (mirrored) clusters via the
+        pytest runner, not this catalog -k. Do not add runner `-k not vector_stores`
+        (empties smoke under not pgvector).
       shiftLeftEnvSecret: envfile-ogx
       pytestExtraArgs: "--tc use_unprivileged_client:False --tc distribution_name:rh-dev -k 'not pgvector'"
       requiresShiftLeftEnv: true
       minPassRateForSuccess: 0.9
       nonBlockingOnTimeout: true
       componentTestTimeoutByGate:
-        smoke: 12m
+        smoke: 15m
         tier1: 45m
 
   - component:

--- a/integration-tests/olminstall/helpers/hypershift_admission_webhooks.py
+++ b/integration-tests/olminstall/helpers/hypershift_admission_webhooks.py
@@ -1,0 +1,165 @@
+"""Neutralize broken HyperShift guest admission webhooks.
+
+HyperShift sometimes projects Validating/MutatingWebhookConfigurations into the
+guest cluster with ``clientConfig.service.name=xxx-invalid-service-xxx`` (or another
+missing Service). Those fail closed and block Deployment/Service creates — breaking
+OGX fixtures and OpenShift Gateway controller reconciliation on EaaS.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+from install.dsc_install import oc_run
+
+_STUB_SERVICE_NAMES = frozenset({"xxx-invalid-service-xxx"})
+_WEBHOOK_KINDS = (
+    "validatingwebhookconfiguration",
+    "mutatingwebhookconfiguration",
+)
+
+
+def _webhook_service(webhook: dict[str, Any]) -> tuple[str, str]:
+    client = webhook.get("clientConfig") or {}
+    service = client.get("service") or {}
+    name = str(service.get("name") or "").strip()
+    namespace = str(service.get("namespace") or "default").strip() or "default"
+    return name, namespace
+
+
+def _service_name(webhook: dict[str, Any]) -> str:
+    return _webhook_service(webhook)[0]
+
+
+def _oc_output_is_not_found(output: str) -> bool:
+    low = output.lower()
+    return "notfound" in low.replace(" ", "") or "not found" in low
+
+
+def _service_probe(*, name: str, namespace: str) -> bool | None:
+    """Return True if Service exists, False if NotFound, None if probe failed."""
+    if not name or not namespace:
+        return False
+    r = oc_run(
+        ["get", "svc", name, "-n", namespace, "-o", "name"],
+        check=False,
+        capture_output=True,
+        timeout=20,
+    )
+    if r.returncode == 0:
+        return True
+    if _oc_output_is_not_found(f"{r.stderr or ''}{r.stdout or ''}"):
+        return False
+    print(
+        f"WARN: could not probe svc/{name} -n {namespace} "
+        f"(exit {r.returncode}); not treating webhook as broken",
+        file=sys.stderr,
+        flush=True,
+    )
+    return None
+
+
+def _webhook_is_broken(webhook: dict[str, Any]) -> bool:
+    name, namespace = _webhook_service(webhook)
+    if not name:
+        return False
+    if name in _STUB_SERVICE_NAMES:
+        return True
+    exists = _service_probe(name=name, namespace=namespace)
+    return exists is False
+
+
+def _list_webhook_configs(kind: str) -> list[dict[str, Any]]:
+    r = oc_run(
+        ["get", kind, "-o", "json"],
+        check=False,
+        capture_output=True,
+        timeout=60,
+    )
+    if r.returncode != 0:
+        return []
+    try:
+        doc = json.loads(r.stdout or "{}")
+    except json.JSONDecodeError:
+        return []
+    items = doc.get("items") or []
+    return [i for i in items if isinstance(i, dict)]
+
+
+def _delete_webhook_config(*, kind: str, name: str) -> bool:
+    r = oc_run(
+        ["delete", kind, name, "--ignore-not-found"],
+        check=False,
+        capture_output=True,
+        timeout=60,
+    )
+    if r.returncode != 0:
+        err = (r.stderr or r.stdout or "").strip()
+        print(
+            f"WARN: could not delete broken {kind}/{name}: {err[:200]}",
+            file=sys.stderr,
+            flush=True,
+        )
+        return False
+    print(f"✓ Removed broken HyperShift admission {kind}/{name}", flush=True)
+    return True
+
+
+def _hypershift_webhook_cleanup_enabled() -> bool:
+    from install.rosa_hcp_pull_setup import is_hypershift_managed_cluster
+    from install.gateway_config import cluster_source_is_eaas
+
+    return cluster_source_is_eaas() or is_hypershift_managed_cluster()
+
+
+def neutralize_broken_hypershift_admission_webhooks() -> int:
+    """Delete guest webhook configs whose clientConfig Service is a stub or missing.
+
+    Returns the number of webhook configs removed.
+    """
+    if not _hypershift_webhook_cleanup_enabled():
+        return 0
+
+    removed = 0
+    for kind in _WEBHOOK_KINDS:
+        for cfg in _list_webhook_configs(kind):
+            meta = cfg.get("metadata") or {}
+            name = str(meta.get("name") or "").strip()
+            if not name:
+                continue
+            webhooks = cfg.get("webhooks") or []
+            if not isinstance(webhooks, list) or not webhooks:
+                continue
+            if any(
+                isinstance(wh, dict) and _webhook_is_broken(wh) for wh in webhooks
+            ):
+                # One broken webhook in the list fails closed for the whole config.
+                if _delete_webhook_config(kind=kind, name=name):
+                    removed += 1
+    if removed:
+        print(
+            f"✓ Neutralized {removed} broken HyperShift admission webhook config(s)",
+            flush=True,
+        )
+    return removed
+
+
+def broken_hypershift_admission_webhook_reason(*, probe: bool = True) -> str:
+    """Return infra reason when a stub/missing HyperShift admission webhook remains."""
+    if not probe or not _hypershift_webhook_cleanup_enabled():
+        return ""
+    for kind in _WEBHOOK_KINDS:
+        for cfg in _list_webhook_configs(kind):
+            meta = cfg.get("metadata") or {}
+            name = str(meta.get("name") or "").strip() or "?"
+            for wh in cfg.get("webhooks") or []:
+                if not isinstance(wh, dict) or not _webhook_is_broken(wh):
+                    continue
+                svc = _service_name(wh) or "missing-service"
+                return (
+                    f"broken HyperShift admission webhook: {kind}/{name} → "
+                    f"service {svc!r}"
+                )
+    return ""

--- a/integration-tests/olminstall/install/dependency_operators.py
+++ b/integration-tests/olminstall/install/dependency_operators.py
@@ -683,6 +683,16 @@ def finalize_dependency_operators_after_setup_script(olm_dir: Path, setup_rc: in
                 file=sys.stderr,
                 flush=True,
             )
+            # Still ensure JobSet/LWS CRs after CLEANUP — early return used to skip this and
+            # leave TrainerReady=False (JobSetOperator/cluster missing) on product reinstall.
+            try:
+                ensure_jobset_and_lws_operator_crs(olm_dir=olm_dir)
+            except Exception as exc:  # noqa: BLE001 - oc timeouts must not crash finalize
+                print(
+                    f"ERROR: JobSet/LWS operator CR ensure failed ({exc})",
+                    file=sys.stderr,
+                    flush=True,
+                )
             return rc
         print(
             f"WARN: dependency setup exited {rc} but Authorino CRD is available; continuing",
@@ -695,7 +705,7 @@ def finalize_dependency_operators_after_setup_script(olm_dir: Path, setup_rc: in
 
     try:
         ensure_jobset_and_lws_operator_crs(olm_dir=olm_dir)
-    except RuntimeError as exc:
+    except Exception as exc:  # noqa: BLE001 - oc timeouts must not crash finalize
         print(f"ERROR: JobSet/LWS operator CR ensure failed ({exc})", file=sys.stderr)
         return 1
 

--- a/integration-tests/olminstall/install/dsc_install.py
+++ b/integration-tests/olminstall/install/dsc_install.py
@@ -834,6 +834,19 @@ def _dsc_condition_status(cond_type: str) -> str:
 def wait_dsc_ready(timeout_s: int = 600) -> bool:
     """Poll until DataScienceCluster/default-dsc has Ready==True (and TrainerReady when selected)."""
     need_trainer = _trainer_selected_for_gate()
+    if need_trainer:
+        # After CLEANUP, JobSetOperator/cluster is often missing until post-install; ensure
+        # again here once CRDs exist (dep-operators may have skipped when setup exited ≠0).
+        try:
+            from install.dependency_operators import ensure_jobset_and_lws_operator_crs
+
+            ensure_jobset_and_lws_operator_crs()
+        except Exception as exc:
+            print(
+                f"WARN: JobSet/LWS ensure before DSC wait failed ({exc}); continuing poll",
+                file=sys.stderr,
+                flush=True,
+            )
     print(
         f"Waiting for DataScienceCluster/default-dsc Ready"
         f"{' + TrainerReady' if need_trainer else ''} (up to {timeout_s}s)...",

--- a/integration-tests/olminstall/k8s/smoke_ci_s3_test_dir.py
+++ b/integration-tests/olminstall/k8s/smoke_ci_s3_test_dir.py
@@ -27,6 +27,7 @@ _MODEL_RUNTIME_MARKERS: tuple[tuple[str, str], ...] = (
     ("triton/model_repository/inceptiongraphdef", f"{_OVMS_VERSION}/model.graphdef"),
     ("opt-125m", "config.json"),
 )
+_VLLM_CPU_SMOKE_TESTS = ("TestVllmCpuX86S3Inference", "TestVllmProbeHealth")
 
 
 def _resolve_ci_bucket() -> tuple[str, str, str | None, str, str]:
@@ -144,11 +145,40 @@ def log_model_runtime_ci_s3_layout() -> None:
     _log_ci_s3_layout(component="model_runtime", markers=_MODEL_RUNTIME_MARKERS)
 
 
+def _skip_vllm_on_eaas_or_hypershift() -> list[str]:
+    """EaaS/HyperShift workers cannot schedule vLLM CPU (8 CPU / 10Gi); suites hang until timeout."""
+    from suite.its_trigger_params import CLUSTER_SOURCE_EAAS
+
+    if os.environ.get("CLUSTER_SOURCE", "").strip() == CLUSTER_SOURCE_EAAS:
+        return list(_VLLM_CPU_SMOKE_TESTS)
+    try:
+        from install.rosa_hcp_pull_setup import is_hypershift_managed_cluster
+
+        if is_hypershift_managed_cluster():
+            return list(_VLLM_CPU_SMOKE_TESTS)
+    except Exception as exc:
+        print(
+            f"WARN: HyperShift detection failed ({exc}); "
+            "relying on catalog model_runtime -k for vLLM skips",
+            flush=True,
+        )
+    return []
+
+
 def model_runtime_pytest_extra_args(*, skip_s3_probe: bool = False) -> str:
     """Skip model_runtime smoke tests when required S3 objects are missing."""
+    skips: list[str] = _skip_vllm_on_eaas_or_hypershift()
+    if skips:
+        print(
+            "✓ EaaS/HyperShift — skipping vLLM CPU smoke "
+            f"({', '.join(skips)}; unschedulable resource requests)",
+            flush=True,
+        )
     if skip_s3_probe:
-        return ""
-    skips: list[str] = []
+        if not skips:
+            return ""
+        expr = " or ".join(dict.fromkeys(skips))
+        return f"-k 'not ({expr})'"
     try:
         bucket, region, endpoint, access_key, secret_key = _resolve_ci_bucket()
         client = _s3_client(
@@ -182,6 +212,6 @@ def model_runtime_pytest_extra_args(*, skip_s3_probe: bool = False) -> str:
         )
     if not skips:
         return ""
-    expr = " or ".join(skips)
+    expr = " or ".join(dict.fromkeys(skips))
     print(f"✓ model_runtime pytest skip filter: not ({expr})", flush=True)
     return f"-k 'not ({expr})'"

--- a/integration-tests/olminstall/runners/component_prereqs.py
+++ b/integration-tests/olminstall/runners/component_prereqs.py
@@ -516,6 +516,19 @@ def prepare_components_for_smoke(component_ids: set[str]) -> bool:
         )
         return True
     try:
+        from helpers.hypershift_admission_webhooks import (
+            neutralize_broken_hypershift_admission_webhooks,
+        )
+
+        neutralize_broken_hypershift_admission_webhooks()
+    except Exception as exc:
+        print(
+            f"WARN: HyperShift admission webhook neutralize failed ({exc}); "
+            "OGX/Deployment creates may fail on stub webhooks",
+            file=sys.stderr,
+            flush=True,
+        )
+    try:
         _ensure_maas_database_before_smoke_prep(component_ids)
     except Exception as exc:
         print(

--- a/integration-tests/olminstall/runners/run_bvt_pytest.py
+++ b/integration-tests/olminstall/runners/run_bvt_pytest.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import os
 import shlex
 import shutil
+import signal
 import subprocess
 import sys
 import threading
@@ -258,12 +259,17 @@ def _run_with_tee(
                 f"ERROR: command timed out after {timeout_s}s ({COMPONENT_TEST_TIMEOUT_SECS_ENV}): {' '.join(cmd)}",
                 file=sys.stderr,
             )
-            proc.terminate()
+            # Prefer SIGINT so pytest can flush junitxml before hard kill.
             try:
-                proc.wait(timeout=10)
-            except subprocess.TimeoutExpired:
-                proc.kill()
-                proc.wait(timeout=30)
+                proc.send_signal(signal.SIGINT)
+                proc.wait(timeout=60)
+            except (subprocess.TimeoutExpired, OSError, ValueError):
+                proc.terminate()
+                try:
+                    proc.wait(timeout=10)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+                    proc.wait(timeout=30)
             reader.join(timeout=5)
             return 124
         reader.join()

--- a/integration-tests/olminstall/runners/run_component_pytest.py
+++ b/integration-tests/olminstall/runners/run_component_pytest.py
@@ -66,7 +66,11 @@ from steps.tekton_util import (
 )
 from suite.its_trigger_params import CLUSTER_SOURCE_EAAS, is_external_cluster_source
 
-_EAAS_SKIP_IMAGE_VALIDATION = "-k 'not image_validation'"
+# EaaS/HCP quay mirrors fail registry.redhat.io-only checks (nodeids vary by suite).
+_EAAS_SKIP_IMAGE_VALIDATION = "-k 'not image_validation and not verify_images'"
+# Do not add `-k 'not vector_stores'` here: under smoke+`not pgvector` that empties the
+# suite (A2 kbbjt: 35 deselected / 0 selected → JP4 hollow fail). Keep Jenkins catalog
+# baseline only; vector_stores client-ready hangs stay FailureIgnored until embeddings fix.
 _CLUSTER_SANITY_SKIP_RHOAI = "--cluster-sanity-skip-rhoai-check"
 
 
@@ -314,8 +318,33 @@ def _return_infra_junit_failure(
 
 
 def _ensure_timeout_junit(comp: dict[str, str], artifacts_dir: Path, timeout_seconds: float | None) -> None:
-    """If timeout killed pytest before writing xUnit, write a synthetic suite for imports."""
+    """If timeout killed pytest before writing xUnit, write a synthetic suite for imports.
+
+    Prefer keeping a partial JUnit that already has real testcases (timeout mid-suite).
+    Else salvage PASSED/FAILED/ERROR lines from the component console log.
+    """
     if timeout_seconds is None:
+        return
+    # artifact_prefix already ends in -smoke (e.g. ogx-smoke); do not append another -smoke.
+    prefix = (comp.get("artifact_prefix") or "").strip()
+    for candidate in (
+        artifacts_dir / f"{comp.get('id', 'unknown')}-smoke.xml",
+        artifacts_dir / f"{prefix}.xml" if prefix else None,
+    ):
+        if candidate is None or not candidate.is_file() or not candidate.name.endswith(".xml"):
+            continue
+        try:
+            text = candidate.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        if "<testcase" in text and 'name="timeout"' not in text:
+            print(
+                f"NOTE: keeping partial JUnit after timeout ({candidate.name}); "
+                "not overwriting with synthetic failure",
+                flush=True,
+            )
+            return
+    if prefix and _salvage_junit_from_console_log(comp, artifacts_dir, prefix):
         return
     cid = comp.get("id", "unknown")
     tests_subdir = comp.get("tests_subdir", "")
@@ -331,6 +360,86 @@ def _ensure_timeout_junit(comp: dict[str, str], artifacts_dir: Path, timeout_sec
         ),
         time_seconds=timeout_seconds,
     )
+
+
+_TEST_STATUS_RE = re.compile(
+    r"TEST:\s+(\S+)\s+STATUS:\s+(?:\x1b\[[0-9;]*m)*\s*(PASSED|FAILED|ERROR|SKIPPED)",
+    re.IGNORECASE,
+)
+
+
+def _salvage_junit_from_console_log(
+    comp: dict[str, str], artifacts_dir: Path, prefix: str
+) -> bool:
+    """Build JUnit from pytest console STATUS lines when session XML was never flushed."""
+    log_path = artifacts_dir / f"{prefix}.console.log"
+    if not log_path.is_file():
+        # Some runners only tee to stdout; also try pytest-tests.log under results/
+        for alt in (
+            artifacts_dir / "pytest-tests.log",
+            artifacts_dir / "results" / "pytest-tests.log",
+        ):
+            if alt.is_file():
+                log_path = alt
+                break
+        else:
+            return False
+    try:
+        text = log_path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return False
+    # Strip ANSI for matching
+    plain = re.sub(r"\x1b\[[0-9;]*m", "", text)
+    # Keep last status per test name (console logs often reprint the same TEST: line).
+    status_by_test: dict[str, str] = {}
+    for match in _TEST_STATUS_RE.finditer(plain):
+        status_by_test[match.group(1)] = match.group(2).upper()
+    if not status_by_test:
+        return False
+    cid = comp.get("id", "unknown")
+    failures = sum(1 for st in status_by_test.values() if st == "FAILED")
+    errors = sum(1 for st in status_by_test.values() if st == "ERROR")
+    skipped = sum(1 for st in status_by_test.values() if st == "SKIPPED")
+    cases: list[str] = []
+    for name, status in status_by_test.items():
+        name_attr = quoteattr(name)
+        if status == "PASSED":
+            cases.append(f'  <testcase classname={quoteattr(cid)} name={name_attr} time="1"/>\n')
+        elif status == "SKIPPED":
+            cases.append(
+                f'  <testcase classname={quoteattr(cid)} name={name_attr} time="0">\n'
+                f'    <skipped message="salvaged from console after timeout"/>\n'
+                f"  </testcase>\n"
+            )
+        elif status == "ERROR":
+            cases.append(
+                f'  <testcase classname={quoteattr(cid)} name={name_attr} time="1">\n'
+                f'    <error message="salvaged from console after timeout"/>\n'
+                f"  </testcase>\n"
+            )
+        else:
+            cases.append(
+                f'  <testcase classname={quoteattr(cid)} name={name_attr} time="1">\n'
+                f'    <failure message="salvaged from console after timeout"/>\n'
+                f"  </testcase>\n"
+            )
+    junit_path = artifacts_dir / f"{prefix}.xml"
+    passed = len(status_by_test) - failures - errors - skipped
+    xml = (
+        '<?xml version="1.0" encoding="utf-8"?>\n'
+        f'<testsuite name={quoteattr(cid)} tests="{len(status_by_test)}" failures="{failures}" '
+        f'errors="{errors}" skipped="{skipped}" time="0" '
+        f'timestamp="{time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())}">\n'
+        f"{''.join(cases)}"
+        "</testsuite>\n"
+    )
+    junit_path.write_text(xml, encoding="utf-8")
+    print(
+        f"NOTE: salvaged {len(status_by_test)} testcase(s) from {log_path.name} after timeout "
+        f"({passed} passed, {failures} failed, {errors} errors)",
+        flush=True,
+    )
+    return True
 
 
 def _apply_non_blocking_timeout(comp: dict[str, str], ec: int, raw_ec: int) -> int:
@@ -744,6 +853,20 @@ def _run_one_component(
         if apply_ogx_ea_distribution_patch():
             print("✓ Patched tests.ogx.server_config for rh-dev (EA.2)", flush=True)
     raw_ec = run_single_pytest(extra_env=pytest_extra_env or None)
+    if not collect_only and cid == "ogx":
+        from components.ogx.platform_smoke import ensure_ogx_junit_after_pytest
+
+        try:
+            ensure_ogx_junit_after_pytest(
+                artifacts_dir,
+                prefix=comp.get("artifact_prefix", "ogx-smoke") or "ogx-smoke",
+            )
+        except Exception as exc:  # noqa: BLE001 - never let post-processing mask the real result
+            print(
+                f"WARN: ensure_ogx_junit_after_pytest failed ({exc}); keeping raw pytest result",
+                file=sys.stderr,
+                flush=True,
+            )
     if not collect_only and cid == "maas_billing":
         from steps.tekton_util import OLMINSTALL_HTPASSWD_KUBECONFIG_ENV
 
@@ -756,9 +879,12 @@ def _run_one_component(
         raw_ec=raw_ec,
         artifacts_dir=artifacts_dir,
     )
-    strict_ec = _apply_non_blocking_timeout(comp, strict_ec, raw_ec)
-    if raw_ec == 124 and strict_ec == 0:
-        tekton_ec = 0
+    if raw_ec == 124:
+        # Keep timeout red even when partial JUnit pass rate would green the component;
+        # nonBlockingOnTimeout may still downgrade to 0.
+        timeout_strict = 124 if strict_ec == 0 else strict_ec
+        strict_ec = _apply_non_blocking_timeout(comp, timeout_strict, raw_ec)
+        tekton_ec = 0 if strict_ec == 0 else strict_ec
     if _filter_component_id():
         _accumulate_exit_file(strict_ec)
     prefix_by_id[cid] = comp["artifact_prefix"]

--- a/integration-tests/olminstall/suite/cluster_api_health.py
+++ b/integration-tests/olminstall/suite/cluster_api_health.py
@@ -206,5 +206,8 @@ def is_definitive_infra_error(message: str) -> bool:
         "kuadrant/authorino dependency operators are missing",
         "webhook has no endpoints",
         "openshift console unavailable",
+        "broken hypershift admission webhook",
+        "xxx-invalid-service-xxx",
+        "block-resources.hypershift.openshift.io",
     )
     return any(m in lower for m in markers)

--- a/integration-tests/olminstall/suite/its_registry.py
+++ b/integration-tests/olminstall/suite/its_registry.py
@@ -18,6 +18,7 @@ _ITS_RUN_ITS_SNAPSHOT_BY_NAME: dict[str, str] = {
 _ITS_DEFAULT_KONFLUX_APP_BY_NAME: dict[str, str] = {
     "rhoai-e2e-rh-nightly-pm-ocp420": "rhoai-fbc-fragment-ocp-420",
     "rhoai-e2e-eaas-ocp421": "rhoai-fbc-fragment-ocp-421",
+    "rhoai-e2e-eaas-ocp422": "rhoai-fbc-fragment-ocp-422",
 }
 
 

--- a/integration-tests/olminstall/tekton/its/its-rhoai-e2e-eaas-ocp422.yaml
+++ b/integration-tests/olminstall/tekton/its/its-rhoai-e2e-eaas-ocp422.yaml
@@ -1,20 +1,20 @@
 ---
-# EaaS smoke slice A: auto on rhoai-fbc-fragment-ocp-421 (pairs with ocp422 = B: cypress+platform).
-# COMPONENTS match playpen-a (all smoke except dashboard_cypress + platform).
-# Debug: --run-its rhoai-e2e-eaas-ocp421 --konflux-app testops-playpen
-#   (or --run-its rhoai-e2e-eaas-playpen-a). Re-apply on FBC only after upstream merge.
+# EaaS smoke slice B: auto on rhoai-fbc-fragment-ocp-422 (pairs with ocp421 = A).
+# COMPONENTS match playpen-b: dashboard_cypress + platform only.
+# Debug: --run-its rhoai-e2e-eaas-ocp422 --konflux-app testops-playpen
+#   (or --run-its rhoai-e2e-eaas-playpen-b). Enable on FBC only after upstream merge.
 apiVersion: appstudio.redhat.com/v1beta2
 kind: IntegrationTestScenario
 metadata:
   labels:
     test.appstudio.openshift.io/optional: "true"
-  name: rhoai-e2e-eaas-ocp421
+  name: rhoai-e2e-eaas-ocp422
   namespace: rhoai-tenant
 spec:
-  application: rhoai-fbc-fragment-ocp-421
+  application: rhoai-fbc-fragment-ocp-422
   contexts:
-    - description: RHOAI EaaS smoke slice A when rhoai-fbc-fragment-ocp-421 builds
-      name: component_rhoai-fbc-fragment-ocp-421
+    - description: RHOAI EaaS smoke slice B when rhoai-fbc-fragment-ocp-422 builds
+      name: component_rhoai-fbc-fragment-ocp-422
   params:
     - name: CLUSTER_SOURCE
       value: "EAAS"
@@ -29,7 +29,7 @@ spec:
     - name: OPERATOR_NAME
       value: "rhods-operator"
     - name: RHOAI_FBC_NAME
-      value: "rhoai-fbc-fragment-ocp-421"
+      value: "rhoai-fbc-fragment-ocp-422"
     - name: RHOAI_FBC_IMAGE
       value: "unspecified (default)"
     - name: MIN_RHOAI_VERSION
@@ -37,7 +37,7 @@ spec:
     - name: TEST_GATES
       value: "bvt,smoke"
     - name: COMPONENTS
-      value: "workbenches,model_registry,model_server,model_runtime,maas_billing,ai_pipelines,kuberay,mlflow,ogx,ai_safety,ai_safety_evalhub,ai_safety_guardrails,ai_safety_lmeval,ai_safety_trustyai_operator,ai_safety_trustyai_service,llama_stack,trainer,distributed_workloads,spark_operator,workbench_images,codeflare_sdk"
+      value: "dashboard_cypress,platform"
     - name: QUAY_PULL_SECRET_NAME
       value: "rhoai-quay-secret"
     - name: SCRIPTS_REPO_URL

--- a/integration-tests/olminstall/tekton/its/its-rhoai-e2e-eaas-playpen-a.yaml
+++ b/integration-tests/olminstall/tekton/its/its-rhoai-e2e-eaas-playpen-a.yaml
@@ -1,20 +1,20 @@
 ---
-# EaaS smoke slice A: auto on rhoai-fbc-fragment-ocp-421 (pairs with ocp422 = B: cypress+platform).
-# COMPONENTS match playpen-a (all smoke except dashboard_cypress + platform).
-# Debug: --run-its rhoai-e2e-eaas-ocp421 --konflux-app testops-playpen
-#   (or --run-its rhoai-e2e-eaas-playpen-a). Re-apply on FBC only after upstream merge.
+# Playpen-only EaaS smoke slice A: all smoke COMPONENTS except platform + dashboard_cypress (slice B).
+# Targets testops-playpen — do NOT map to rhoai-fbc-fragment-* until A/B is proven.
+# Trigger: --run-its rhoai-e2e-eaas-playpen-a --konflux-app testops-playpen
+#   or --enable-its (applies to playpen; context push = manual Snapshot only).
 apiVersion: appstudio.redhat.com/v1beta2
 kind: IntegrationTestScenario
 metadata:
   labels:
     test.appstudio.openshift.io/optional: "true"
-  name: rhoai-e2e-eaas-ocp421
+  name: rhoai-e2e-eaas-playpen-a
   namespace: rhoai-tenant
 spec:
-  application: rhoai-fbc-fragment-ocp-421
+  application: testops-playpen
   contexts:
-    - description: RHOAI EaaS smoke slice A when rhoai-fbc-fragment-ocp-421 builds
-      name: component_rhoai-fbc-fragment-ocp-421
+    - description: Manual playpen Snapshot / CLI --run-its (not FBC fragment auto-trigger)
+      name: push
   params:
     - name: CLUSTER_SOURCE
       value: "EAAS"

--- a/integration-tests/olminstall/tekton/its/its-rhoai-e2e-eaas-playpen-b.yaml
+++ b/integration-tests/olminstall/tekton/its/its-rhoai-e2e-eaas-playpen-b.yaml
@@ -1,20 +1,20 @@
 ---
-# EaaS smoke slice A: auto on rhoai-fbc-fragment-ocp-421 (pairs with ocp422 = B: cypress+platform).
-# COMPONENTS match playpen-a (all smoke except dashboard_cypress + platform).
-# Debug: --run-its rhoai-e2e-eaas-ocp421 --konflux-app testops-playpen
-#   (or --run-its rhoai-e2e-eaas-playpen-a). Re-apply on FBC only after upstream merge.
+# Playpen-only EaaS smoke slice B: platform + dashboard_cypress only (everything else on slice A).
+# Targets testops-playpen — do NOT map to rhoai-fbc-fragment-* until A/B is proven.
+# Trigger: --run-its rhoai-e2e-eaas-playpen-b --konflux-app testops-playpen
+#   or --enable-its (applies to playpen; context push = manual Snapshot only).
 apiVersion: appstudio.redhat.com/v1beta2
 kind: IntegrationTestScenario
 metadata:
   labels:
     test.appstudio.openshift.io/optional: "true"
-  name: rhoai-e2e-eaas-ocp421
+  name: rhoai-e2e-eaas-playpen-b
   namespace: rhoai-tenant
 spec:
-  application: rhoai-fbc-fragment-ocp-421
+  application: testops-playpen
   contexts:
-    - description: RHOAI EaaS smoke slice A when rhoai-fbc-fragment-ocp-421 builds
-      name: component_rhoai-fbc-fragment-ocp-421
+    - description: Manual playpen Snapshot / CLI --run-its (not FBC fragment auto-trigger)
+      name: push
   params:
     - name: CLUSTER_SOURCE
       value: "EAAS"
@@ -37,7 +37,7 @@ spec:
     - name: TEST_GATES
       value: "bvt,smoke"
     - name: COMPONENTS
-      value: "workbenches,model_registry,model_server,model_runtime,maas_billing,ai_pipelines,kuberay,mlflow,ogx,ai_safety,ai_safety_evalhub,ai_safety_guardrails,ai_safety_lmeval,ai_safety_trustyai_operator,ai_safety_trustyai_service,llama_stack,trainer,distributed_workloads,spark_operator,workbench_images,codeflare_sdk"
+      value: "dashboard_cypress,platform"
     - name: QUAY_PULL_SECRET_NAME
       value: "rhoai-quay-secret"
     - name: SCRIPTS_REPO_URL

--- a/integration-tests/olminstall/tekton/pipelines/olminstall-pipeline.yaml
+++ b/integration-tests/olminstall/tekton/pipelines/olminstall-pipeline.yaml
@@ -2589,9 +2589,9 @@ spec:
         Model Runtime smoke tests. Opt-in on external clusters; many cases need cloud credentials.
 
         - Test framework: opendatahub-tests (pytest).
-        - Command: pytest tests/model_serving/model_runtime -m 'smoke' -svv -o junit_suite_name=model_runtime --tc use_unprivileged_client:False --supported-accelerator-type CPU_x86.
+        - Command: pytest tests/model_serving/model_runtime -m 'smoke' -svv -o junit_suite_name=model_runtime --tc use_unprivileged_client:False -k 'not TestMLServerModelCar and not TestLLMDSmoke and not TestVllmCpuX86S3Inference and not TestVllmProbeHealth' --supported-accelerator-type CPU_x86.
         - Requires tenant credentials supplied by the pipeline.
-        - Timeouts: smoke 15m, tier1 45m.
+        - Timeouts: smoke 25m, tier1 45m.
         - Non-blocking on pytest timeout (records failure without failing Tekton when configured).
       timeout: 69m0s
       workspaces:
@@ -2648,10 +2648,10 @@ spec:
       onError: continue
       displayName: "Test — maas billing"
       description: |
-        Models-as-a-Service billing smoke tests. May fail on external pooled clusters until MaaS auth gateway setup completes within the task timeout.
+        Models-as-a-Service billing smoke tests. May fail on external pooled clusters until MaaS auth gateway setup completes within the task timeout. EaaS HyperShift blocks OAuth IdP patches — keep unprivileged client off (admin SA).
 
         - Test framework: opendatahub-tests (pytest).
-        - Command: pytest tests/model_serving/maas_billing -m 'smoke' -svv -o junit_suite_name=maas_billing.
+        - Command: pytest tests/model_serving/maas_billing -m 'smoke' -svv -o junit_suite_name=maas_billing --tc use_unprivileged_client:False.
         - Requires tenant credentials supplied by the pipeline.
         - Timeouts: smoke 20m, tier1 45m.
         - Version gate: minRhoai 3.3.
@@ -2897,12 +2897,12 @@ spec:
       onError: continue
       displayName: "Test — ogx"
       description: |
-        Red Hat OGX Distribution smoke tests. pgvector cases stay excluded until embedding endpoints are available in the tenant environment.
+        Red Hat OGX Distribution smoke tests. Catalog keeps Jenkins baseline (-k not pgvector). verify_images skips apply on EaaS and EXTERNAL (mirrored) clusters via the pytest runner, not this catalog -k. Do not add runner `-k not vector_stores` (empties smoke under not pgvector).
 
         - Test framework: opendatahub-tests (pytest).
         - Command: pytest tests/ogx -m 'smoke' -svv -o junit_suite_name=ogx --tc use_unprivileged_client:False --tc distribution_name:rh-dev -k 'not pgvector'.
         - Requires tenant credentials supplied by the pipeline.
-        - Timeouts: smoke 12m, tier1 45m.
+        - Timeouts: smoke 15m, tier1 45m.
         - Version gate: minRhoai 3.5.
         - Non-blocking on pytest timeout (records failure without failing Tekton when configured).
       timeout: 69m0s

--- a/integration-tests/olminstall/tekton/tasks/generated/component-maas_billing.yaml
+++ b/integration-tests/olminstall/tekton/tasks/generated/component-maas_billing.yaml
@@ -6,10 +6,10 @@ metadata:
   name: olminstall-component-maas-billing
 spec:
   description: |
-    Models-as-a-Service billing smoke tests. May fail on external pooled clusters until MaaS auth gateway setup completes within the task timeout.
+    Models-as-a-Service billing smoke tests. May fail on external pooled clusters until MaaS auth gateway setup completes within the task timeout. EaaS HyperShift blocks OAuth IdP patches — keep unprivileged client off (admin SA).
 
     - Test framework: opendatahub-tests (pytest).
-    - Command: pytest tests/model_serving/maas_billing -m 'smoke' -svv -o junit_suite_name=maas_billing.
+    - Command: pytest tests/model_serving/maas_billing -m 'smoke' -svv -o junit_suite_name=maas_billing --tc use_unprivileged_client:False.
     - Requires tenant credentials supplied by the pipeline.
     - Timeouts: smoke 20m, tier1 45m.
     - Version gate: minRhoai 3.3.

--- a/integration-tests/olminstall/tekton/tasks/generated/component-model_runtime.yaml
+++ b/integration-tests/olminstall/tekton/tasks/generated/component-model_runtime.yaml
@@ -9,9 +9,9 @@ spec:
     Model Runtime smoke tests. Opt-in on external clusters; many cases need cloud credentials.
 
     - Test framework: opendatahub-tests (pytest).
-    - Command: pytest tests/model_serving/model_runtime -m 'smoke' -svv -o junit_suite_name=model_runtime --tc use_unprivileged_client:False --supported-accelerator-type CPU_x86.
+    - Command: pytest tests/model_serving/model_runtime -m 'smoke' -svv -o junit_suite_name=model_runtime --tc use_unprivileged_client:False -k 'not TestMLServerModelCar and not TestLLMDSmoke and not TestVllmCpuX86S3Inference and not TestVllmProbeHealth' --supported-accelerator-type CPU_x86.
     - Requires tenant credentials supplied by the pipeline.
-    - Timeouts: smoke 15m, tier1 45m.
+    - Timeouts: smoke 25m, tier1 45m.
     - Non-blocking on pytest timeout (records failure without failing Tekton when configured).
   params:
   - name: COMPONENT_ID

--- a/integration-tests/olminstall/tekton/tasks/generated/component-ogx.yaml
+++ b/integration-tests/olminstall/tekton/tasks/generated/component-ogx.yaml
@@ -6,12 +6,12 @@ metadata:
   name: olminstall-component-ogx
 spec:
   description: |
-    Red Hat OGX Distribution smoke tests. pgvector cases stay excluded until embedding endpoints are available in the tenant environment.
+    Red Hat OGX Distribution smoke tests. Catalog keeps Jenkins baseline (-k not pgvector). verify_images skips apply on EaaS and EXTERNAL (mirrored) clusters via the pytest runner, not this catalog -k. Do not add runner `-k not vector_stores` (empties smoke under not pgvector).
 
     - Test framework: opendatahub-tests (pytest).
     - Command: pytest tests/ogx -m 'smoke' -svv -o junit_suite_name=ogx --tc use_unprivileged_client:False --tc distribution_name:rh-dev -k 'not pgvector'.
     - Requires tenant credentials supplied by the pipeline.
-    - Timeouts: smoke 12m, tier1 45m.
+    - Timeouts: smoke 15m, tier1 45m.
     - Version gate: minRhoai 3.5.
     - Non-blocking on pytest timeout (records failure without failing Tekton when configured).
   params:

--- a/integration-tests/olminstall/unit_tests/components/test_codeflare_kueue_prep.py
+++ b/integration-tests/olminstall/unit_tests/components/test_codeflare_kueue_prep.py
@@ -45,9 +45,9 @@ class CodeflareKueuePrepTest(unittest.TestCase):
         ):
             self.assertEqual(_kueue_dsc_management_state(), "Unmanaged")
 
-    def test_ensure_codeflare_kueue_ready_skips_when_api_up(self) -> None:
+    def test_ensure_codeflare_kueue_ready_skips_when_smoke_ready(self) -> None:
         with mock.patch(
-            "components.codeflare_sdk.kueue_prep._kueue_api_available",
+            "components.codeflare_sdk.kueue_prep._kueue_smoke_ready",
             return_value=True,
         ):
             with mock.patch(
@@ -56,7 +56,7 @@ class CodeflareKueuePrepTest(unittest.TestCase):
                 ensure_codeflare_kueue_ready()
         patch_state.assert_not_called()
 
-    def test_ensure_codeflare_kueue_ready_waits_for_api(self) -> None:
+    def test_ensure_codeflare_kueue_ready_waits_for_api_and_webhook(self) -> None:
         with mock.patch(
             "components.codeflare_sdk.kueue_prep._kueue_dsc_management_state",
             return_value="Unmanaged",
@@ -68,11 +68,25 @@ class CodeflareKueuePrepTest(unittest.TestCase):
                     "components.codeflare_sdk.kueue_prep._clear_stuck_openshift_kueue_cluster"
                 ):
                     with mock.patch(
-                        "components.codeflare_sdk.kueue_prep._kueue_api_available",
+                        "components.codeflare_sdk.kueue_prep._kueue_smoke_ready",
                         side_effect=[False, True],
                     ):
-                        with mock.patch("components.codeflare_sdk.kueue_prep.time.sleep"):
-                            ensure_codeflare_kueue_ready(timeout_sec=30)
+                        with mock.patch(
+                            "components.codeflare_sdk.kueue_prep._kueue_api_available",
+                            return_value=True,
+                        ):
+                            with mock.patch(
+                                "components.codeflare_sdk.kueue_prep._kueue_webhook_ready",
+                                return_value=False,
+                            ):
+                                with mock.patch(
+                                    "components.codeflare_sdk.kueue_prep._dsc_condition",
+                                    return_value=("False", "Progressing", ""),
+                                ):
+                                    with mock.patch(
+                                        "components.codeflare_sdk.kueue_prep.time.sleep"
+                                    ):
+                                        ensure_codeflare_kueue_ready(timeout_sec=30)
         patch_state.assert_called_once_with("kueue", "Unmanaged")
 
 if __name__ == "__main__":

--- a/integration-tests/olminstall/unit_tests/components/test_maas_billing_htpasswd.py
+++ b/integration-tests/olminstall/unit_tests/components/test_maas_billing_htpasswd.py
@@ -142,7 +142,8 @@ class MaasBillingHtpasswdTest(unittest.TestCase):
             apply_maas_billing_htpasswd_test_user_overrides()
         read_vault.assert_not_called()
 
-    def test_eaas_keeps_vault_ldap_user_without_htpasswd_idp(self) -> None:
+    def test_eaas_skips_vault_ldap_without_htpasswd_idp(self) -> None:
+        """HyperShift often blocks OAuth IdP; vault LDAP cannot log in — use admin SA only."""
         vault = {
             "TEST_USER_USERNAME": "ldap-user1",
             "TEST_USER_PASSWORD": "ldap-pass",
@@ -164,9 +165,8 @@ class MaasBillingHtpasswdTest(unittest.TestCase):
             mock.patch.dict(os.environ, {"CLUSTER_SOURCE": "EAAS"}, clear=False),
         ):
             overlay = apply_maas_billing_htpasswd_test_user_overrides()
-            self.assertEqual(os.environ["TEST_USER_USERNAME"], "ldap-user1")
-        self.assertEqual(overlay["TEST_USER_USERNAME"], "ldap-user1")
-        self.assertEqual(overlay["TEST_USER_PASSWORD"], "ldap-pass")
+            self.assertNotIn("TEST_USER_USERNAME", os.environ)
+        self.assertEqual(overlay, {})
 
     def test_byoidc_overlay_when_credentials_ready(self) -> None:
         with (
@@ -259,9 +259,24 @@ class MaasBillingRosaHcpPytestSkipTest(unittest.TestCase):
             extra = maas_billing_aitenant_bootstrap_pytest_extra_args()
             self.assertIn("test_aitenant_bootstrap_creates_tenant_environment", extra)
 
-    def test_no_skip_aitenant_bootstrap_on_eaas(self) -> None:
+    def test_skip_aitenant_bootstrap_on_eaas(self) -> None:
         from components.maas_billing.oidc_users import maas_billing_aitenant_bootstrap_pytest_extra_args
 
         with mock.patch.dict(os.environ, {"CLUSTER_SOURCE": "EAAS"}, clear=False):
-            self.assertEqual(maas_billing_aitenant_bootstrap_pytest_extra_args(), "")
+            extra = maas_billing_aitenant_bootstrap_pytest_extra_args()
+            self.assertIn("test_aitenant_bootstrap_creates_tenant_environment", extra)
+
+    def test_eaas_hypershift_skips_oauth_idp_tests(self) -> None:
+        with (
+            mock.patch("components.maas_billing.oidc_users._cluster_is_byoidc", return_value=False),
+            mock.patch("install.ldap._cluster_is_rosa_hcp", return_value=False),
+            mock.patch("install.ldap.cluster_has_htpasswd_identity", return_value=False),
+            mock.patch(
+                "install.rosa_hcp_pull_setup.is_hypershift_managed_cluster",
+                return_value=True,
+            ),
+            mock.patch.dict(os.environ, {"CLUSTER_SOURCE": "EAAS"}, clear=False),
+        ):
+            self.assertTrue(maas_billing_rosa_hcp_skip_htpasswd_oauth_idp())
+            self.assertIn("TestAPIKeyCRUD", maas_billing_rosa_hcp_pytest_extra_args())
 

--- a/integration-tests/olminstall/unit_tests/components/test_maas_gateway_class_and_clusterip.py
+++ b/integration-tests/olminstall/unit_tests/components/test_maas_gateway_class_and_clusterip.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""GatewayClass + EaaS HTTPS ClusterIP fallback."""
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import patch
+
+from components.maas_billing.gateway import (
+    ensure_maas_gateway_https_service_clusterip,
+    ensure_openshift_default_gateway_class,
+)
+
+
+class GatewayClassEnsureTest(unittest.TestCase):
+    @patch("components.maas_billing.gateway.oc_run")
+    def test_skips_when_accepted(self, oc_run: object) -> None:
+        oc_run.return_value.returncode = 0
+        oc_run.return_value.stdout = "True"
+        ensure_openshift_default_gateway_class()
+        self.assertEqual(oc_run.call_count, 1)
+        self.assertEqual(oc_run.call_args[0][0][1], "gatewayclass")
+
+    @patch("components.maas_billing.gateway.oc_run")
+    def test_applies_when_missing(self, oc_run: object) -> None:
+        get_r = type("R", (), {"returncode": 1, "stdout": "", "stderr": "not found"})()
+        apply_r = type("R", (), {"returncode": 0, "stdout": "created", "stderr": ""})()
+        oc_run.side_effect = [get_r, apply_r]
+        ensure_openshift_default_gateway_class()
+        self.assertEqual(oc_run.call_count, 2)
+        apply_args = oc_run.call_args_list[1]
+        self.assertEqual(apply_args[0][0][:2], ["apply", "-f"])
+        stdin = apply_args.kwargs.get("stdin_text") or ""
+        self.assertIn("kind: GatewayClass", stdin)
+        self.assertIn("name: openshift-default", stdin)
+
+
+class EaasHttpsClusterIpTest(unittest.TestCase):
+    @patch("install.gateway_config.cluster_source_is_eaas", return_value=True)
+    @patch(
+        "install.rosa_hcp_pull_setup.is_hypershift_managed_cluster",
+        return_value=True,
+    )
+    @patch(
+        "components.maas_billing.common._maas_gateway_https_service_ready",
+        side_effect=[(False, "missing"), (True, "openshift-ingress/svc")],
+    )
+    @patch("components.maas_billing.gateway.oc_run")
+    def test_creates_clusterip_when_pods_exist(
+        self,
+        oc_run: object,
+        *_mocks: object,
+    ) -> None:
+        pods = type(
+            "R",
+            (),
+            {"returncode": 0, "stdout": "gw-pod-1", "stderr": ""},
+        )()
+        apply = type("R", (), {"returncode": 0, "stdout": "created", "stderr": ""})()
+        oc_run.side_effect = [pods, apply]
+        self.assertTrue(ensure_maas_gateway_https_service_clusterip())
+        stdin = oc_run.call_args_list[1].kwargs.get("stdin_text") or ""
+        self.assertIn("kind: Service", stdin)
+        self.assertIn("type: ClusterIP", stdin)
+        self.assertIn("port: 443", stdin)
+
+    @patch("install.gateway_config.cluster_source_is_eaas", return_value=False)
+    @patch(
+        "install.rosa_hcp_pull_setup.is_hypershift_managed_cluster",
+        return_value=False,
+    )
+    def test_skips_non_eaas(self, *_mocks: object) -> None:
+        self.assertFalse(ensure_maas_gateway_https_service_clusterip())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/integration-tests/olminstall/unit_tests/components/test_ogx_platform_smoke.py
+++ b/integration-tests/olminstall/unit_tests/components/test_ogx_platform_smoke.py
@@ -1,0 +1,67 @@
+"""Unit tests for OGX platform diagnostics (no hollow SUCCESS JUnit)."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from components.ogx.platform_smoke import (
+    ensure_ogx_junit_after_pytest,
+    should_write_ogx_platform_smoke,
+    write_ogx_platform_junit,
+)
+
+
+class OgxPlatformSmokeTest(unittest.TestCase):
+    def test_write_platform_junit_all_pass(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            with mock.patch(
+                "components.ogx.platform_smoke.run_ogx_platform_checks",
+                return_value=[
+                    ("ogx_crds_present", True, "found ogxservers.ogx.io"),
+                    ("llamastackoperator_not_managed", True, "Removed"),
+                ],
+            ):
+                out = write_ogx_platform_junit(Path(tmp))
+            text = out.read_text(encoding="utf-8")
+            self.assertIn('name="ogx_crds_present"', text)
+            self.assertIn('failures="0"', text)
+            self.assertNotIn("<failure", text)
+
+    def test_hollow_fill_disabled(self) -> None:
+        self.assertFalse(should_write_ogx_platform_smoke())
+
+    def test_ensure_keeps_real_pytest_junit(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            junit = root / "ogx-smoke.xml"
+            junit.write_text(
+                '<?xml version="1.0"?>\n'
+                '<testsuite tests="1" failures="1">\n'
+                '  <testcase name="vector"><failure message="x"/></testcase>\n'
+                "</testsuite>\n",
+                encoding="utf-8",
+            )
+            with mock.patch.dict(os.environ, {"CLUSTER_SOURCE": "EAAS"}, clear=False):
+                ensure_ogx_junit_after_pytest(root)
+            self.assertIn("vector", junit.read_text(encoding="utf-8"))
+
+    def test_ensure_does_not_write_success_when_empty(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            with (
+                mock.patch.dict(os.environ, {"CLUSTER_SOURCE": "EAAS"}, clear=False),
+                mock.patch(
+                    "components.ogx.platform_smoke.run_ogx_platform_checks",
+                    return_value=[("ogx_crds_present", True, "ok")],
+                ),
+            ):
+                ensure_ogx_junit_after_pytest(root)
+            self.assertFalse((root / "ogx-smoke.xml").is_file())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/integration-tests/olminstall/unit_tests/helpers/test_hypershift_admission_webhooks.py
+++ b/integration-tests/olminstall/unit_tests/helpers/test_hypershift_admission_webhooks.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""HyperShift stub admission webhook neutralization."""
+
+from __future__ import annotations
+
+import json
+import unittest
+from unittest.mock import patch
+
+from helpers.hypershift_admission_webhooks import (
+    broken_hypershift_admission_webhook_reason,
+    neutralize_broken_hypershift_admission_webhooks,
+)
+
+
+def _vwc(*, name: str, svc_name: str, svc_ns: str = "default") -> dict:
+    return {
+        "metadata": {"name": name},
+        "webhooks": [
+            {
+                "name": "block-resources.hypershift.openshift.io",
+                "clientConfig": {
+                    "service": {"name": svc_name, "namespace": svc_ns, "path": "/validate"}
+                },
+            }
+        ],
+    }
+
+
+class HypershiftAdmissionWebhooksTest(unittest.TestCase):
+    @patch("install.gateway_config.cluster_source_is_eaas", return_value=True)
+    @patch(
+        "install.rosa_hcp_pull_setup.is_hypershift_managed_cluster",
+        return_value=True,
+    )
+    @patch("helpers.hypershift_admission_webhooks.oc_run")
+    def test_deletes_stub_service_webhook(
+        self,
+        oc_run: object,
+        *_mocks: object,
+    ) -> None:
+        listed = {
+            "items": [_vwc(name="hypershift-block", svc_name="xxx-invalid-service-xxx")]
+        }
+
+        def _side_effect(args: list[str], **_kwargs: object) -> object:
+            if args[:2] == ["get", "validatingwebhookconfiguration"]:
+                return type("R", (), {"returncode": 0, "stdout": json.dumps(listed), "stderr": ""})()
+            if args[:2] == ["get", "mutatingwebhookconfiguration"]:
+                return type("R", (), {"returncode": 0, "stdout": '{"items":[]}', "stderr": ""})()
+            if args[:2] == ["delete", "validatingwebhookconfiguration"]:
+                return type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+            return type("R", (), {"returncode": 1, "stdout": "", "stderr": "not found"})()
+
+        oc_run.side_effect = _side_effect
+        removed = neutralize_broken_hypershift_admission_webhooks()
+        self.assertEqual(removed, 1)
+        delete_calls = [
+            c
+            for c in oc_run.call_args_list
+            if c.args and c.args[0][:2] == ["delete", "validatingwebhookconfiguration"]
+        ]
+        self.assertEqual(len(delete_calls), 1)
+        self.assertEqual(delete_calls[0].args[0][2], "hypershift-block")
+
+    @patch("install.gateway_config.cluster_source_is_eaas", return_value=False)
+    @patch(
+        "install.rosa_hcp_pull_setup.is_hypershift_managed_cluster",
+        return_value=False,
+    )
+    @patch("helpers.hypershift_admission_webhooks.oc_run")
+    def test_skips_non_hypershift(
+        self,
+        oc_run: object,
+        *_mocks: object,
+    ) -> None:
+        self.assertEqual(neutralize_broken_hypershift_admission_webhooks(), 0)
+        oc_run.assert_not_called()
+
+    @patch("install.gateway_config.cluster_source_is_eaas", return_value=True)
+    @patch(
+        "install.rosa_hcp_pull_setup.is_hypershift_managed_cluster",
+        return_value=True,
+    )
+    @patch("helpers.hypershift_admission_webhooks.oc_run")
+    def test_reason_reports_stub(
+        self,
+        oc_run: object,
+        *_mocks: object,
+    ) -> None:
+        listed = {
+            "items": [_vwc(name="hypershift-block", svc_name="xxx-invalid-service-xxx")]
+        }
+
+        def _side_effect(args: list[str], **_kwargs: object) -> object:
+            if args[:2] == ["get", "validatingwebhookconfiguration"]:
+                return type("R", (), {"returncode": 0, "stdout": json.dumps(listed), "stderr": ""})()
+            if args[:2] == ["get", "mutatingwebhookconfiguration"]:
+                return type("R", (), {"returncode": 0, "stdout": '{"items":[]}', "stderr": ""})()
+            return type("R", (), {"returncode": 1, "stdout": "", "stderr": ""})()
+
+        oc_run.side_effect = _side_effect
+        reason = broken_hypershift_admission_webhook_reason()
+        self.assertIn("broken HyperShift admission webhook", reason)
+        self.assertIn("xxx-invalid-service-xxx", reason)
+
+    @patch("install.gateway_config.cluster_source_is_eaas", return_value=True)
+    @patch(
+        "install.rosa_hcp_pull_setup.is_hypershift_managed_cluster",
+        return_value=True,
+    )
+    @patch("helpers.hypershift_admission_webhooks.oc_run")
+    def test_skips_delete_when_service_probe_errors(
+        self,
+        oc_run: object,
+        *_mocks: object,
+    ) -> None:
+        listed = {
+            "items": [_vwc(name="real-webhook", svc_name="real-admission-svc", svc_ns="openshift")]
+        }
+
+        def _side_effect(args: list[str], **_kwargs: object) -> object:
+            if args[:2] == ["get", "validatingwebhookconfiguration"]:
+                return type("R", (), {"returncode": 0, "stdout": json.dumps(listed), "stderr": ""})()
+            if args[:2] == ["get", "mutatingwebhookconfiguration"]:
+                return type("R", (), {"returncode": 0, "stdout": '{"items":[]}', "stderr": ""})()
+            if args[:2] == ["get", "svc"]:
+                return type(
+                    "R",
+                    (),
+                    {"returncode": 1, "stdout": "", "stderr": "Unable to connect to the server"},
+                )()
+            if args[:1] == ["delete"]:
+                raise AssertionError("must not delete when svc probe fails transiently")
+            return type("R", (), {"returncode": 1, "stdout": "", "stderr": ""})()
+
+        oc_run.side_effect = _side_effect
+        self.assertEqual(neutralize_broken_hypershift_admission_webhooks(), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/integration-tests/olminstall/unit_tests/install/test_dependency_operators_finalize.py
+++ b/integration-tests/olminstall/unit_tests/install/test_dependency_operators_finalize.py
@@ -80,6 +80,38 @@ class FinalizeDependencyOperatorsTest(unittest.TestCase):
             self.assertEqual(reconcile.call_count, 2)
             authorino.assert_called_once()
 
+    def test_product_install_hard_fail_still_ensures_jobset_crs(self) -> None:
+        """After CLEANUP, setup-dependencies often exits ≠0; JobSet CR must still be ensured."""
+        with tempfile.TemporaryDirectory() as tmp:
+            olm_dir = Path(tmp) / "olminstall"
+            olm_dir.mkdir()
+            (olm_dir / "odh-gitops").mkdir()
+            with (
+                patch("install.dependency_operators.ensure_setup_dependency_namespaces_ready"),
+                patch(
+                    "install.dependency_operators._reconcile_rhcl_after_gitops_with_warning",
+                    return_value=False,
+                ),
+                patch(
+                    "install.dependency_operators._run_odh_gitops_make",
+                    return_value=2,
+                ),
+                patch(
+                    "install.dependency_operators._authorino_crd_available",
+                    return_value=True,
+                ),
+                patch(
+                    "install.dependency_operators.product_install_path",
+                    return_value=True,
+                ),
+                patch(
+                    "install.dependency_operators.ensure_jobset_and_lws_operator_crs",
+                ) as ensure_js,
+            ):
+                rc = finalize_dependency_operators_after_setup_script(olm_dir, 2)
+            self.assertEqual(rc, 2)
+            ensure_js.assert_called_once_with(olm_dir=olm_dir)
+
     def test_partial_failure_reconciles_rhcl_before_gitops_retry(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             olm_dir = Path(tmp) / "olminstall"

--- a/integration-tests/olminstall/unit_tests/k8s/test_smoke_ci_s3_test_dir.py
+++ b/integration-tests/olminstall/unit_tests/k8s/test_smoke_ci_s3_test_dir.py
@@ -67,8 +67,30 @@ class TestModelRuntimePytestExtraArgs(unittest.TestCase):
         self.assertIn("TestTritonGRPC", extra)
 
     def test_skip_s3_probe_defers_all_s3_skips(self) -> None:
-        extra = s3_probe.model_runtime_pytest_extra_args(skip_s3_probe=True)
+        with mock.patch.dict(os.environ, {"CLUSTER_SOURCE": ""}, clear=False):
+            with mock.patch(
+                "k8s.smoke_ci_s3_test_dir._skip_vllm_on_eaas_or_hypershift",
+                return_value=[],
+            ):
+                extra = s3_probe.model_runtime_pytest_extra_args(skip_s3_probe=True)
         self.assertEqual(extra, "")
+
+    def test_eaas_always_skips_vllm(self) -> None:
+        client = mock.Mock()
+        client.head_object.return_value = {}
+        with (
+            mock.patch.dict(os.environ, {"CLUSTER_SOURCE": "EAAS"}, clear=False),
+            mock.patch.object(
+                s3_probe,
+                "_resolve_ci_bucket",
+                return_value=("b", "us-east-1", None, "k", "s"),
+            ),
+            mock.patch.object(s3_probe, "_s3_client", return_value=client),
+            mock.patch.object(s3_probe, "ci_s3_object_ready", return_value=True),
+        ):
+            extra = s3_probe.model_runtime_pytest_extra_args()
+        self.assertIn("TestVllmCpuX86S3Inference", extra)
+        self.assertNotIn("TestTritonGRPC", extra)
 
     def test_allows_triton_grpc_when_inception_model_present(self) -> None:
         client = mock.Mock()

--- a/integration-tests/olminstall/unit_tests/runners/test_run_component_cypress_runtime.py
+++ b/integration-tests/olminstall/unit_tests/runners/test_run_component_cypress_runtime.py
@@ -949,19 +949,38 @@ class DashboardCypressRuntimeTest(unittest.TestCase):
         with mock.patch(
             "install.ldap._cluster_is_byoidc",
             return_value=False,
+        ), mock.patch(
+            "install.ldap.cluster_has_ldap_identity",
+            return_value=False,
+        ), mock.patch(
+            "install.ldap.cluster_has_htpasswd_identity",
+            return_value=False,
         ):
             extra = eaas_bearer_extra_cypress_skip_tags(odh_dashboard_url=eaas_url)
-        self.assertIn("@ModelTrainingCI", extra)
-        self.assertIn("@HardwareProfilesCI", extra)
-        self.assertIn("@ODS-1877", extra)
-        self.assertIn("@NonConcurrent", extra)
-        self.assertIn("@ModelRegistryCI", extra)
+        self.assertEqual(extra, "")
         self.assertEqual(
             eaas_bearer_extra_cypress_skip_tags(
                 odh_dashboard_url="https://rh-ai.apps.rosa.example.com",
             ),
             "",
         )
+
+    def test_htpasswd_skips_not_applied_on_eaas_bearer(self) -> None:
+        eaas_url = "https://rh-ai.apps.abc123.prod.konfluxeaas.com"
+        with mock.patch(
+            "install.ldap._cluster_is_byoidc",
+            return_value=False,
+        ), mock.patch(
+            "install.ldap.cluster_has_ldap_identity",
+            return_value=False,
+        ), mock.patch(
+            "install.ldap.cluster_has_htpasswd_identity",
+            return_value=False,
+        ):
+            extra = cypress_extra_skip_tags(odh_dashboard_url=eaas_url)
+        self.assertNotIn("@ModelServingCI", extra)
+        self.assertNotIn("@ProjectsCI", extra)
+        self.assertNotIn("@ModelTrainingCI", extra)
 
     def test_cypress_extra_skip_tags_merges_byoidc_and_konflux(self) -> None:
         with mock.patch(

--- a/integration-tests/olminstall/unit_tests/runners/test_run_component_pytest_single.py
+++ b/integration-tests/olminstall/unit_tests/runners/test_run_component_pytest_single.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import shlex
 from pathlib import Path
 from unittest import mock
 
@@ -17,7 +18,7 @@ def test_eaas_pytest_extra_args_skip_image_validation() -> None:
             run_component_pytest._apply_cluster_source_pytest_extra_args(
                 "--tc use_unprivileged_client:False"
             )
-            == "--tc use_unprivileged_client:False -k 'not image_validation'"
+            == "--tc use_unprivileged_client:False -k 'not image_validation and not verify_images'"
         )
         workbenches_extra = (
             "--tc use_unprivileged_client:False "
@@ -77,7 +78,7 @@ def test_external_existing_pytest_extra_args_skip_rhoai_cluster_sanity() -> None
             run_component_pytest._apply_cluster_source_pytest_extra_args(
                 "--tc use_unprivileged_client:False"
             )
-            == "--tc use_unprivileged_client:False -k 'not image_validation' --cluster-sanity-skip-rhoai-check"
+            == "--tc use_unprivileged_client:False -k 'not image_validation and not verify_images' --cluster-sanity-skip-rhoai-check"
         )
 
 
@@ -314,6 +315,30 @@ def test_ogx_forces_rh_dev_distribution_after_shift_left(monkeypatch: pytest.Mon
     assert "distribution_name:rh-dev" in extra
     assert "-p ogx_ea_distribution_plugin" in extra
     assert os.environ["distribution_name"] == "rh-dev"
+
+
+def test_ogx_eaas_keeps_vector_stores_in_k_filter(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Smoke+not pgvector already narrows to vector_stores; extra skip empties the suite."""
+    monkeypatch.setenv("CLUSTER_SOURCE", "EAAS")
+    monkeypatch.setenv("distribution_name", "rh-dev")
+    extra = run_component_pytest._apply_ogx_pytest_extra_args("-k 'not pgvector'")
+    assert "vector_stores" not in extra
+    assert "not pgvector" in extra
+
+
+def test_ogx_external_keeps_vector_stores_in_k_filter(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CLUSTER_SOURCE", "EXTERNAL")
+    monkeypatch.setenv("distribution_name", "rh-dev")
+    extra = run_component_pytest._apply_ogx_pytest_extra_args("-k 'not pgvector'")
+    assert "vector_stores" not in extra
+
+
+def test_ogx_unset_cluster_keeps_vector_stores(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("CLUSTER_SOURCE", raising=False)
+    monkeypatch.setenv("distribution_name", "rh-dev")
+    extra = run_component_pytest._apply_ogx_pytest_extra_args("-k 'not pgvector'")
+    assert "vector_stores" not in extra
+
 
 
 def test_ensure_olminstall_on_pythonpath(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/integration-tests/olminstall/unit_tests/suite/test_its_registry.py
+++ b/integration-tests/olminstall/unit_tests/suite/test_its_registry.py
@@ -170,7 +170,60 @@ def test_resolve_unknown_manifest() -> None:
 def test_list_manifests_includes_playpen_its() -> None:
     names = list_integration_test_scenario_manifests(_ROOT)
     assert "rhoai-e2e-eaas-ocp421" in names
+    assert "rhoai-e2e-eaas-ocp422" in names
     assert "rhoai-e2e-rh-nightly-pm-ocp420" in names
+    assert "rhoai-e2e-eaas-playpen-a" in names
+    assert "rhoai-e2e-eaas-playpen-b" in names
+    assert "rhoai-e2e-eaas-ocp420-a" not in names
+    assert "rhoai-e2e-eaas-ocp420-b" not in names
+    assert "rhoai-e2e-eaas-ocp422-a" not in names
+    assert "rhoai-e2e-eaas-ocp422-b" not in names
+
+
+def test_resolve_eaas_playpen_slice_manifests() -> None:
+    path_a = resolve_integration_test_scenario_manifest(_ROOT, "rhoai-e2e-eaas-playpen-a")
+    path_b = resolve_integration_test_scenario_manifest(_ROOT, "rhoai-e2e-eaas-playpen-b")
+    assert path_a.name == "its-rhoai-e2e-eaas-playpen-a.yaml"
+    assert path_b.name == "its-rhoai-e2e-eaas-playpen-b.yaml"
+    assert integration_test_scenario_application(path_a) == "testops-playpen"
+    assert integration_test_scenario_application(path_b) == "testops-playpen"
+    from suite.its_registry import its_manifest_param
+
+    comps_a = its_manifest_param(path_a, "COMPONENTS")
+    comps_b = its_manifest_param(path_b, "COMPONENTS")
+    assert comps_b.split(",") == ["dashboard_cypress", "platform"]
+    assert "ogx" in comps_a.split(",")
+    assert "codeflare_sdk" in comps_a.split(",")
+    assert "ai_safety" in comps_a.split(",")
+    assert "platform" not in comps_a.split(",")
+    assert "dashboard_cypress" not in comps_a.split(",")
+    assert integration_test_scenario_default_konflux_app("rhoai-e2e-eaas-playpen-a") == ""
+
+
+def test_resolve_eaas_fbc_slice_a_on_421_b_on_422() -> None:
+    from suite.its_registry import its_manifest_param
+
+    path_a = resolve_integration_test_scenario_manifest(_ROOT, "rhoai-e2e-eaas-ocp421")
+    path_b = resolve_integration_test_scenario_manifest(_ROOT, "rhoai-e2e-eaas-ocp422")
+    assert integration_test_scenario_application(path_a) == "rhoai-fbc-fragment-ocp-421"
+    assert integration_test_scenario_application(path_b) == "rhoai-fbc-fragment-ocp-422"
+    assert its_manifest_param(path_a, "RHOAI_FBC_NAME") == "rhoai-fbc-fragment-ocp-421"
+    assert its_manifest_param(path_b, "RHOAI_FBC_NAME") == "rhoai-fbc-fragment-ocp-422"
+    playpen_a = resolve_integration_test_scenario_manifest(_ROOT, "rhoai-e2e-eaas-playpen-a")
+    playpen_b = resolve_integration_test_scenario_manifest(_ROOT, "rhoai-e2e-eaas-playpen-b")
+    assert its_manifest_param(path_a, "COMPONENTS") == its_manifest_param(playpen_a, "COMPONENTS")
+    assert its_manifest_param(path_b, "COMPONENTS") == its_manifest_param(playpen_b, "COMPONENTS")
+    assert its_manifest_param(path_b, "COMPONENTS") == "dashboard_cypress,platform"
+    assert "ogx" in its_manifest_param(path_a, "COMPONENTS").split(",")
+    assert "dashboard_cypress" in its_manifest_param(path_b, "COMPONENTS").split(",")
+    assert "dashboard_cypress" not in its_manifest_param(path_a, "COMPONENTS").split(",")
+    assert "platform" not in its_manifest_param(path_a, "COMPONENTS").split(",")
+    assert integration_test_scenario_default_konflux_app("rhoai-e2e-eaas-ocp421") == (
+        "rhoai-fbc-fragment-ocp-421"
+    )
+    assert integration_test_scenario_default_konflux_app("rhoai-e2e-eaas-ocp422") == (
+        "rhoai-fbc-fragment-ocp-422"
+    )
 
 
 def test_eaas_pipelinerun_wrapper_prefix() -> None:


### PR DESCRIPTION
olminstall Konflux E2E (BVT/smoke) on EaaS HyperShift, with smoke split across FBC apps after merge:

- **ocp-421 / playpen-a (slice A):** all smoke COMPONENTS except Cypress + platform
- **ocp-422 / playpen-b (slice B):** `dashboard_cypress` + `platform` only
- **ocp-420:** rh-nightly-pm external full matrix (unchanged)

<img width="1404" height="130" alt="image" src="https://github.com/user-attachments/assets/98417daf-52a4-4f8f-bcaa-1a07926d9038" />

### Changes
- Neutralize HyperShift block-resources stub webhooks and ensure openshift-default GatewayClass + HTTPS ClusterIP for MaaS
- Fix EaaS MaaS/OGX smoke auth and filters after HyperShift OAuth blocks
- Skip EaaS OAuth-blocked MaaS suites and keep partial JUnit on timeout
- Skip EaaS vLLM/vector_stores hangs and salvage real JUnit on timeout
- Align OGX filters with Jenkins (`-k 'not pgvector'`) and restore JobSet/LWS CRs after CLEANUP
- Keep component timeouts red and harden post-pytest recovery
- Skip OGX vector_stores on EaaS and EXTERNAL after client-ready timeouts
- Sync generated OGX task description with catalog EaaS skip notes
- Wait for Kueue conversion webhook before codeflare SDK smoke
- Restore EaaS OGX smoke selection and Cypress SmokeSet parity
- Add playpen-only EaaS A/B smoke ITS; rebalance then narrow B to Cypress + platform
- Map in-tree FBC ITS: ocp-421 = A, ocp-422 = B (enable after upstream merge)
- Harden HyperShift webhook probes (NotFound-only delete)

### Jira
- https://redhat.atlassian.net/browse/RHOAIENG-78049
- https://redhat.atlassian.net/browse/RHOAIENG-77604

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional EaaS smoke-test slices for OCP 4.21 and 4.22, plus playpen scenarios for manual validation.
  * Added targeted component selections and improved smoke-test coverage.

* **Bug Fixes**
  * Improved recovery from HyperShift admission webhook and operator setup issues.
  * Enhanced timeout handling to preserve or recover test results and terminate stalled tests more gracefully.
  * Added recognition of additional infrastructure failure conditions.

* **Documentation**
  * Expanded guidance for configuring, enabling, running, and debugging EaaS slice scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->