### PR TITLE
Enable hermetic builds for MCP lifecycle operators

### DIFF
--- a/pipelineruns/mcp-lifecycle-module-operator/odh-mcp-lifecycle-module-operator-pull-request.yaml
+++ b/pipelineruns/mcp-lifecycle-module-operator/odh-mcp-lifecycle-module-operator-pull-request.yaml
@@ -34,6 +34,10 @@ spec:
     - 'odh-pr-{{revision}}'
   - name: pipeline-type
     value: pull-request
+  - name: hermetic
+    value: "true"
+  - name: prefetch-input
+    value: '[{"type": "gomod", "path": "."}]'
   pipelineRef:
     resolver: git
     params:

--- a/pipelineruns/mcp-lifecycle-module-operator/odh-mcp-lifecycle-module-operator-push.yaml
+++ b/pipelineruns/mcp-lifecycle-module-operator/odh-mcp-lifecycle-module-operator-push.yaml
@@ -29,6 +29,10 @@ spec:
     value: Dockerfile.konflux
   - name: path-context
     value: .
+  - name: hermetic
+    value: "true"
+  - name: prefetch-input
+    value: '[{"type": "gomod", "path": "."}]'
   pipelineRef:
     resolver: git
     params:

--- a/pipelineruns/mcp-lifecycle-operator/odh-mcp-lifecycle-operator-e2e-pull-request.yaml
+++ b/pipelineruns/mcp-lifecycle-operator/odh-mcp-lifecycle-operator-e2e-pull-request.yaml
@@ -33,6 +33,10 @@ spec:
   - name: additional-tags
     value:
     - 'odh-pr-{{revision}}'
+  - name: hermetic
+    value: "true"
+  - name: prefetch-input
+    value: '[{"type": "gomod", "path": "."}]'
   - name: pipeline-type
     value: pull-request
   pipelineRef:

--- a/pipelineruns/mcp-lifecycle-operator/odh-mcp-lifecycle-operator-e2e-push.yaml
+++ b/pipelineruns/mcp-lifecycle-operator/odh-mcp-lifecycle-operator-e2e-push.yaml
@@ -29,6 +29,10 @@ spec:
     value: test/e2e/Dockerfile
   - name: path-context
     value: .
+  - name: hermetic
+    value: "true"
+  - name: prefetch-input
+    value: '[{"type": "gomod", "path": "."}]'
   pipelineRef:
     resolver: git
     params:

--- a/pipelineruns/mcp-lifecycle-operator/odh-mcp-lifecycle-operator-pull-request.yaml
+++ b/pipelineruns/mcp-lifecycle-operator/odh-mcp-lifecycle-operator-pull-request.yaml
@@ -33,6 +33,10 @@ spec:
   - name: additional-tags
     value:
     - 'odh-pr-{{revision}}'
+  - name: hermetic
+    value: "true"
+  - name: prefetch-input
+    value: '[{"type": "gomod", "path": "."}]'
   - name: pipeline-type
     value: pull-request
   pipelineRef:

--- a/pipelineruns/mcp-lifecycle-operator/odh-mcp-lifecycle-operator-push.yaml
+++ b/pipelineruns/mcp-lifecycle-operator/odh-mcp-lifecycle-operator-push.yaml
@@ -29,6 +29,10 @@ spec:
     value: Dockerfile.konflux
   - name: path-context
     value: .
+  - name: hermetic
+    value: "true"
+  - name: prefetch-input
+    value: '[{"type": "gomod", "path": "."}]'
   pipelineRef:
     resolver: git
     params:


### PR DESCRIPTION
## Description
Add hermetic and prefetch-input params to all MCP lifecycle PipelineRuns to support vendorless builds with Cachi2 gomod.

Companion to:
- https://github.com/opendatahub-io/mcp-lifecycle-operator/pull/58
- https://github.com/opendatahub-io/mcp-lifecycle-module-operator/pull/83

## Changes
- `pipelineruns/mcp-lifecycle-operator/` -- all 4 PipelineRuns (pull-request, push, e2e-pull-request, e2e-push)
- `pipelineruns/mcp-lifecycle-module-operator/` -- both PipelineRuns (pull-request, push)

Each gets:
```yaml
- name: hermetic
  value: "true"
- name: prefetch-input
  value: '[{"type": "gomod", "path": "."}]'
```

Assisted-by: 🤖 claude-opus-4-6