### PR TITLE
chore: add gotestsum to trainer toolset image

### DIFF
--- a/integration-tests/trainer/Dockerfile.trainer
+++ b/integration-tests/trainer/Dockerfile.trainer
@@ -12,3 +12,5 @@ RUN dnf install -y \
 
 RUN wget https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable/openshift-client-linux.tar.gz && \
     tar xvf openshift-client-linux.tar.gz && chmod +x oc kubectl && mv oc kubectl /usr/local/bin/
+
+RUN GOBIN=/usr/local/bin go install gotest.tools/gotestsum@v1.13.0


### PR DESCRIPTION
## Summary
- Adds `gotestsum` to the `rhoai-task-toolset:trainer` image for JUnit XML test report generation
- Enables per-test pass/fail results in PR comments (used by upcoming ITS pipeline changes)
- Consistent with existing components — uses `@latest` like `oc`/`kubectl` and the base image

## Test plan
- [ ] Verify the image builds successfully with the new `gotestsum` binary
- [ ] Confirm `gotestsum --version` works in the built image