### PR TITLE
fix: skip trigger-early-gate-build on push pipelines

### DIFF
--- a/pipeline/multi-arch-container-build.yaml
+++ b/pipeline/multi-arch-container-build.yaml
@@ -724,6 +724,10 @@ spec:
       operator: in
       values:
       - "true"
+    - input: $(params.pipeline-type)
+      operator: in
+      values:
+      - "pull-request"
   - name: trigger-operator-build
     workspaces:
     - name: basic-auth

--- a/pipeline/multi-arch-operator-build.yaml
+++ b/pipeline/multi-arch-operator-build.yaml
@@ -892,6 +892,10 @@ spec:
       operator: in
       values:
       - "true"
+    - input: $(params.pipeline-type)
+      operator: in
+      values:
+      - "pull-request"
   workspaces:
   - name: git-auth
     optional: true


### PR DESCRIPTION
The trigger-early-gate-build finally task was firing on push pipelines (merges to main), causing the bot to post /early-gate-build comments on already-merged PRs. Added a pipeline-type guard so it only runs on pull-request pipelines.