### PR TITLE
[RHOAIENG-79440] kserve: use Makefile e2e suite targets

### DIFF
--- a/integration-tests/kserve/pr-group-testing-pipeline.yaml
+++ b/integration-tests/kserve/pr-group-testing-pipeline.yaml
@@ -841,7 +841,7 @@ spec:
             export STORAGE_INITIALIZER_IMAGE=$(jq -r --arg component_name "${COMPONENT_NAME}" '.[$component_name].image' <<< "${SNAPSHOT}")
 
             export GITHUB_SHA=stable
-            ./test/scripts/openshift-ci/run-e2e-tests.sh graph 2 raw
+            make e2e-graph-ocp E2E_PARALLELISM=2 RUNNING_LOCAL=false
 
             echo "success" > "$STATUS_FILE"
         - name: must-gather
@@ -1079,7 +1079,7 @@ spec:
             COMPONENT_NAME=kserve-storage-initializer-ci
             export STORAGE_INITIALIZER_IMAGE=$(jq -r --arg component_name "${COMPONENT_NAME}" '.[$component_name].image' <<< "${SNAPSHOT}")
 
-            ./test/scripts/openshift-ci/run-e2e-tests.sh raw
+            make e2e-raw-ocp E2E_PARALLELISM=2 RUNNING_LOCAL=false
             echo "success" > "$STATUS_FILE"
         - name: must-gather
           onError: continue
@@ -1315,7 +1315,7 @@ spec:
             COMPONENT_NAME=kserve-storage-initializer-ci
             export STORAGE_INITIALIZER_IMAGE=$(jq -r --arg component_name "${COMPONENT_NAME}" '.[$component_name].image' <<< "${SNAPSHOT}")
 
-            ./test/scripts/openshift-ci/run-e2e-tests.sh "predictor or kserve_on_openshift"
+            make e2e-predictor-ocp E2E_PARALLELISM=2 RUNNING_LOCAL=false
             echo "success" > "$STATUS_FILE"
         - name: must-gather
           onError: continue
@@ -1560,7 +1560,7 @@ spec:
             COMPONENT_NAME=odh-kserve-llmisvc-controller-ci
             export LLMISVC_CONTROLLER_IMAGE=$(jq -r --arg component_name "${COMPONENT_NAME}" '.[$component_name].image' <<< "${SNAPSHOT}")
 
-            ./test/scripts/openshift-ci/run-e2e-tests.sh "llminferenceservice and cluster_cpu and not autoscaling and not tracing" 2 "llm-d"
+            make e2e-llmisvc-ocp RUNNING_LOCAL=false
             echo "success" > "$STATUS_FILE"
         - name: must-gather
           onError: continue

--- a/integration-tests/odh-model-controller/pr-test-pipelinerun.yaml
+++ b/integration-tests/odh-model-controller/pr-test-pipelinerun.yaml
@@ -300,7 +300,7 @@ spec:
                   echo "LLMD_ROUTING_SIDECAR_IMAGE=${LLMD_ROUTING_SIDECAR_IMAGE}"
                   echo "KUBE_RBAC_PROXY_IMAGE=${KUBE_RBAC_PROXY_IMAGE}"
 
-                  make e2e-raw-ocp E2E_PARALLELISM=2 RUNNING_LOCAL=false
+                  ./test/scripts/openshift-ci/run-e2e-tests.sh raw 2 raw
                 popd
             - name: must-gather
               onError: continue
@@ -535,7 +535,7 @@ spec:
                   echo "LLMD_ROUTING_SIDECAR_IMAGE=${LLMD_ROUTING_SIDECAR_IMAGE}"
                   echo "KUBE_RBAC_PROXY_IMAGE=${KUBE_RBAC_PROXY_IMAGE}"
 
-                  make e2e-llmisvc-ocp RUNNING_LOCAL=false
+                  ./test/scripts/openshift-ci/run-e2e-tests.sh "llminferenceservice and (cluster_cpu and cluster_single_node) and not autoscaling and not tracing" 2 "llm-d"
                 popd
             - name: must-gather
               onError: continue

--- a/integration-tests/odh-model-controller/pr-test-pipelinerun.yaml
+++ b/integration-tests/odh-model-controller/pr-test-pipelinerun.yaml
@@ -300,7 +300,7 @@ spec:
                   echo "LLMD_ROUTING_SIDECAR_IMAGE=${LLMD_ROUTING_SIDECAR_IMAGE}"
                   echo "KUBE_RBAC_PROXY_IMAGE=${KUBE_RBAC_PROXY_IMAGE}"
 
-                  ./test/scripts/openshift-ci/run-e2e-tests.sh raw 2 raw
+                  make e2e-raw-ocp E2E_PARALLELISM=2 RUNNING_LOCAL=false
                 popd
             - name: must-gather
               onError: continue
@@ -535,7 +535,7 @@ spec:
                   echo "LLMD_ROUTING_SIDECAR_IMAGE=${LLMD_ROUTING_SIDECAR_IMAGE}"
                   echo "KUBE_RBAC_PROXY_IMAGE=${KUBE_RBAC_PROXY_IMAGE}"
 
-                  ./test/scripts/openshift-ci/run-e2e-tests.sh "llminferenceservice and (cluster_cpu and cluster_single_node) and not autoscaling and not tracing" 2 "llm-d"
+                  make e2e-llmisvc-ocp RUNNING_LOCAL=false
                 popd
             - name: must-gather
               onError: continue


### PR DESCRIPTION
## Summary
- Replace inline `run-e2e-tests.sh` invocations with `make e2e-*-ocp` targets from kserve's `Makefile.ocp.mk`
- Fixes marker drift: llmisvc markers now match Prow canonical (`llmisvc_core` not `llminferenceservice`)
- Adds missing rawcipn phase to raw suite
- Parallelism overridden to 2 for Konflux cluster sizing
- Applies to kserve group-test pipeline and omc test pipeline

## Depends on
- opendatahub-io/kserve adding named suite targets (must merge first)

## Test plan
- Konflux group-test pipeline run after kserve PR merges