### PR TITLE
Add multi-arch build-platforms for supervisor

### DIFF
--- a/pipelineruns/openshell/odh-openshell-supervisor-pull-request.yaml
+++ b/pipelineruns/openshell/odh-openshell-supervisor-pull-request.yaml
@@ -30,6 +30,10 @@ spec:
     value: .
   - name: hermetic
     value: "true"
+  - name: build-platforms
+    value:
+    - linux/x86_64
+    - linux/arm64
   - name: prefetch-input
     value: |
       [

--- a/pipelineruns/openshell/odh-openshell-supervisor-push.yaml
+++ b/pipelineruns/openshell/odh-openshell-supervisor-push.yaml
@@ -31,6 +31,10 @@ spec:
     value: .
   - name: hermetic
     value: "true"
+  - name: build-platforms
+    value:
+    - linux/x86_64
+    - linux/arm64
   - name: prefetch-input
     value: |
       [


### PR DESCRIPTION
Add build-platforms param with linux/x86_64 and linux/arm64 to the supervisor pull-request and push PipelineRuns, matching the gateway's multi-arch configuration.
