### PR TITLE
feat: add rhaiv tag-triggered builds for openshell

### DIFF
--- a/pipelineruns/openshell/odh-openshell-gateway-tag.yaml
+++ b/pipelineruns/openshell/odh-openshell-gateway-tag.yaml
@@ -1,0 +1,61 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+#
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/openshell?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "push"
+      && git_tag.matches("^v[0-9]+\\.[0-9]+\\.[0-9]+-rhaiv\\.[0-9]+$")
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: opendatahub-builds
+    appstudio.openshift.io/component: odh-openshell-gateway-ci
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-openshell-gateway-on-tag
+  namespace: open-data-hub-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/opendatahub/odh-openshell-gateway:{{git_tag}}
+  - name: dockerfile
+    value: deploy/docker/Dockerfile.konflux.gateway
+  - name: path-context
+    value: .
+  - name: hermetic
+    value: "true"
+  - name: build-platforms
+    value:
+    - linux-m2xlarge/amd64
+    - linux-m2xlarge/arm64
+  - name: prefetch-input
+    value: |
+      [
+        {"type": "cargo", "path": "."},
+        {"type": "rpm", "path": "deploy/konflux/gateway"},
+        {"type": "generic", "path": "deploy/konflux/gateway", "lockfile": "generic-fetcher.yaml"}
+      ]
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/opendatahub-io/odh-konflux-central.git
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipeline/multi-arch-container-build.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-odh-openshell-gateway-ci
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/pipelineruns/openshell/odh-openshell-gateway-tag.yaml
+++ b/pipelineruns/openshell/odh-openshell-gateway-tag.yaml
@@ -43,6 +43,9 @@ spec:
         {"type": "rpm", "path": "deploy/konflux/gateway"},
         {"type": "generic", "path": "deploy/konflux/gateway", "lockfile": "generic-fetcher.yaml"}
       ]
+  - name: build-args
+    value:
+    - "OPENSHELL_VERSION={{git_tag}}"
   pipelineRef:
     resolver: git
     params:

--- a/pipelineruns/openshell/odh-openshell-supervisor-tag.yaml
+++ b/pipelineruns/openshell/odh-openshell-supervisor-tag.yaml
@@ -1,0 +1,61 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+#
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/openshell?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "push"
+      && git_tag.matches("^v[0-9]+\\.[0-9]+\\.[0-9]+-rhaiv\\.[0-9]+$")
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: opendatahub-builds
+    appstudio.openshift.io/component: odh-openshell-supervisor-ci
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-openshell-supervisor-on-tag
+  namespace: open-data-hub-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/opendatahub/odh-openshell-supervisor:{{git_tag}}
+  - name: dockerfile
+    value: deploy/docker/Dockerfile.konflux.supervisor
+  - name: path-context
+    value: .
+  - name: hermetic
+    value: "true"
+  - name: build-platforms
+    value:
+    - linux/x86_64
+    - linux/arm64
+  - name: prefetch-input
+    value: |
+      [
+        {"type": "cargo", "path": "."},
+        {"type": "rpm", "path": "deploy/konflux/supervisor"},
+        {"type": "generic", "path": "deploy/konflux/supervisor", "lockfile": "generic-fetcher.yaml"}
+      ]
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/opendatahub-io/odh-konflux-central.git
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipeline/multi-arch-container-build.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-odh-openshell-supervisor-ci
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/pipelineruns/openshell/odh-openshell-supervisor-tag.yaml
+++ b/pipelineruns/openshell/odh-openshell-supervisor-tag.yaml
@@ -43,6 +43,9 @@ spec:
         {"type": "rpm", "path": "deploy/konflux/supervisor"},
         {"type": "generic", "path": "deploy/konflux/supervisor", "lockfile": "generic-fetcher.yaml"}
       ]
+  - name: build-args
+    value:
+    - "OPENSHELL_VERSION={{git_tag}}"
   pipelineRef:
     resolver: git
     params:


### PR DESCRIPTION
## What

Adds two PipelineRun templates that build the openshell **supervisor** and **gateway** images automatically on every rhaiv tag push (`vX.Y.Z-rhaiv.N`):

- `pipelineruns/openshell/odh-openshell-supervisor-tag.yaml`
- `pipelineruns/openshell/odh-openshell-gateway-tag.yaml`

## How it triggers

Self-limiting Pipelines-as-Code CEL matcher:

```
event == "push"
&& git_tag.matches("^v[0-9]+\\.[0-9]+\\.[0-9]+-rhaiv\\.[0-9]+$")
```

`git_tag` is empty on branch pushes, so no `target_branch` clause is needed — the matcher only fires for tag pushes whose tag matches the rhaiv format. The output image is tagged with the git tag verbatim (`{{git_tag}}`), e.g. `quay.io/opendatahub/odh-openshell-supervisor:v0.0.93-rhaiv.0`.

This is why the rhaiv tags were switched from `+rhaiv.N` to `-rhaiv.N` (opendatahub-io/openshell#16): `+` is not a valid container image tag character, whereas a dash tag can be used as the image tag directly with no string manipulation.

## Design notes

- **No `$$...$$` placeholders.** The onboarder treats a `*-tag.yaml` file (no `pull`/`push` in the name) as a generic file and copies it to the component's `.tekton/` as-is with no substitution, so these templates are fully concrete.
- **Reuses the existing `-ci` Component and service account** (`build-pipeline-odh-openshell-{supervisor,gateway}-ci`). No new Konflux Component/Application onboarding is required; the tag build simply pushes to a versioned image tag instead of `odh-stable`.
- Mirrors the existing `-push.yaml` templates for dockerfile, prefetch, hermetic, and build-platforms settings.
- `config/component_repo_map.json` is unaffected (its generator only reads `*-push.yaml`).

## Dependencies / follow-ups

- Requires opendatahub-io/openshell#16 (dash tags) to merge first for the matcher to fire.
- After merge, run the onboarder (CI build) for `openshell` to sync these into the openshell repo's `.tekton/`.
- The `-rhaiv.N` → `+rhaiv.N` PEP 440 conversion for the Python package version is handled in the Python build infrastructure (out of scope here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)