### PR TITLE
fix: match openshell rhaiv tags via target_branch, not git_tag

### DIFF
--- a/pipelineruns/openshell/odh-openshell-gateway-tag.yaml
+++ b/pipelineruns/openshell/odh-openshell-gateway-tag.yaml
@@ -10,7 +10,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
-      && git_tag.matches("^v[0-9]+\\.[0-9]+\\.[0-9]+-rhaiv\\.[0-9]+$")
+      && target_branch.matches("^refs/tags/v[0-9]+\\.[0-9]+\\.[0-9]+-rhaiv\\.[0-9]+$")
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: opendatahub-builds

--- a/pipelineruns/openshell/odh-openshell-supervisor-tag.yaml
+++ b/pipelineruns/openshell/odh-openshell-supervisor-tag.yaml
@@ -10,7 +10,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
-      && git_tag.matches("^v[0-9]+\\.[0-9]+\\.[0-9]+-rhaiv\\.[0-9]+$")
+      && target_branch.matches("^refs/tags/v[0-9]+\\.[0-9]+\\.[0-9]+-rhaiv\\.[0-9]+$")
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: opendatahub-builds


### PR DESCRIPTION
## Problem

The Konflux PaC bot rejected both openshell `-on-tag` PipelineRuns (synced by the onboarder) with:

```
CEL expression evaluation error: ... undeclared reference to 'git_tag'
```

so neither tag-triggered build could fire.

## Root cause

The deployed Konflux Pipelines-as-Code is **v0.46.0**. Its `on-cel-expression` matcher (`pkg/matcher/cel.go`) only declares these CEL variables: `event, event_type, headers, body, event_title, target_branch, source_branch, target_url, source_url, files`. It does **not** declare `git_tag` (that CEL variable lives in a different feature's code path). So `git_tag.matches(...)` fails to compile.

## Fix

Match on `target_branch` instead. For a tag push, PaC sets `target_branch` to the full ref `refs/tags/<tag>` — only `refs/heads/` is stripped, never `refs/tags/` — so the version-safe matcher is:

```yaml
pipelinesascode.tekton.dev/on-cel-expression: |
  event == "push"
  && target_branch.matches("^refs/tags/v[0-9]+\\.[0-9]+\\.[0-9]+-rhaiv\\.[0-9]+$")
```

`output-image: …:{{git_tag}}` and `build-args: ["OPENSHELL_VERSION={{git_tag}}"]` are unchanged: `{{git_tag}}` is a **template variable** (from `customparams`, present since ~v0.34.0) and resolves fine on v0.46.0 — only the CEL matcher couldn't use `git_tag`.

Resolves https://github.com/opendatahub-io/openshell/pull/18#issuecomment-5143248538

## Validation

Regex checked against `refs/tags/` values: matches `v0.0.93-rhaiv.0` and `v1.2.3-rhaiv.15`; rejects plain `v0.0.93`, legacy `v0.0.93+rhaiv.0`, `main`, and `refs/heads/main`.

## Follow-up

The openshell repo's `.tekton` files (previously synced via the erroring PR) will be re-synced from these corrected templates separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)