### PR TITLE
Add odh-trustyai-module-operator-ci PipelineRuns

### DIFF
--- a/pipelineruns/trustyai-service-operator/odh-trustyai-module-operator-pull-request.yaml
+++ b/pipelineruns/trustyai-service-operator/odh-trustyai-module-operator-pull-request.yaml
@@ -27,7 +27,7 @@ spec:
   - name: dockerfile
     value: Dockerfile
   - name: path-context
-    value: .
+    value: ./trustyai-operator-module/
   #add these additional params
   - name: additional-tags
     value:

--- a/pipelineruns/trustyai-service-operator/odh-trustyai-module-operator-pull-request.yaml
+++ b/pipelineruns/trustyai-service-operator/odh-trustyai-module-operator-pull-request.yaml
@@ -1,0 +1,52 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/trustyai-service-operator?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
+      == "$$TARGET_BRANCH$$"
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: opendatahub-builds
+    appstudio.openshift.io/component: odh-trustyai-module-operator-ci
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-trustyai-module-operator-on-pull-request
+  namespace: open-data-hub-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/opendatahub/odh-trustyai-module-operator:$$OUTPUT_IMAGE_TAG$$
+  - name: dockerfile
+    value: Dockerfile
+  - name: path-context
+    value: .
+  #add these additional params
+  - name: additional-tags
+    value:
+    - 'odh-pr-{{revision}}'
+  - name: pipeline-type
+    value: pull-request
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/opendatahub-io/odh-konflux-central.git
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipeline/multi-arch-container-build.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-odh-trustyai-module-operator-ci
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/pipelineruns/trustyai-service-operator/odh-trustyai-module-operator-push.yaml
+++ b/pipelineruns/trustyai-service-operator/odh-trustyai-module-operator-push.yaml
@@ -28,7 +28,7 @@ spec:
   - name: dockerfile
     value: Dockerfile
   - name: path-context
-    value: .
+    value: ./trustyai-operator-module/
   pipelineRef:
     resolver: git
     params:

--- a/pipelineruns/trustyai-service-operator/odh-trustyai-module-operator-push.yaml
+++ b/pipelineruns/trustyai-service-operator/odh-trustyai-module-operator-push.yaml
@@ -1,0 +1,47 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+#
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/trustyai-service-operator?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "$$TARGET_BRANCH$$"
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: opendatahub-builds
+    appstudio.openshift.io/component: odh-trustyai-module-operator-ci
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-trustyai-module-operator-on-push
+  namespace: open-data-hub-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/opendatahub/odh-trustyai-module-operator:$$OUTPUT_IMAGE_TAG$$
+  - name: dockerfile
+    value: Dockerfile
+  - name: path-context
+    value: .
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/opendatahub-io/odh-konflux-central.git
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipeline/multi-arch-container-build.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-odh-trustyai-module-operator-ci
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}


### PR DESCRIPTION
Adds push and pull-request PipelineRun YAMLs for 'odh-trustyai-module-operator-ci'.

Component repo: https://github.com/opendatahub-io/trustyai-service-operator
Jira: https://redhat.atlassian.net/browse/RHOAIENG-80231