### PR TITLE
Add group testing support for early gate pipelines

### DIFF
--- a/early-gate/docs/early-gate-group-testing-design.md
+++ b/early-gate/docs/early-gate-group-testing-design.md
@@ -1,0 +1,482 @@
+# Early Gate Group Testing Design
+**PR-Attached Configuration for Multi-Component Integration Testing**
+
+---
+
+## Table of Contents
+
+1. [Problem Statement](#1-problem-statement)
+2. [Architecture Overview](#2-architecture-overview)
+3. [Configuration Format](#3-configuration-format)
+4. [Workflow](#4-workflow)
+5. [Image Availability & Snapshot Resolution](#5-image-availability--snapshot-resolution)
+6. [Examples & Use Cases](#6-examples--use-cases)
+7. [Error Handling](#7-error-handling)
+8. [Appendix: Quick Reference](#8-appendix-quick-reference)
+
+---
+
+## 1. Problem Statement
+
+### Requirements
+
+| ID | Requirement | Constraint |
+|---|---|---|
+| **R1** | Test multiple related PRs together as a cohesive unit | PRs may be in different repositories |
+| **R2** | Self-service model without approval gates | Teams manage groups independently |
+| **R3** | Configuration visible to PR reviewers | Must be in PR description |
+| **R4** | Automatic lifecycle management | Config removed when PR closes/merges |
+| **R5** | Backward compatible with single-PR testing | Zero impact on existing workflows |
+
+### Solution Approach
+
+**PR-Attached Configuration**: Teams add a markdown heading with PR URLs directly in the leader PR's description. The early-gate pipeline detects this configuration, resolves the specified PR URLs to component images, and builds a combined snapshot for testing.
+
+```mermaid
+graph LR
+    A[PR with config] -->|Pipeline reads| B[Resolve components]
+    B -->|Query Quay| C[Build snapshot]
+    C -->|Test| D[Report results]
+    
+    style A fill:#e1f5ff
+    style C fill:#fff4e6
+```
+
+### Key Benefits
+
+- No central maintenance burden
+- Configuration co-located with code
+- Reviewers see which PRs are grouped
+- Automatic cleanup on PR lifecycle end
+- Graceful fallback to single-PR mode
+
+---
+
+## 2. Architecture Overview
+
+### Three-Layer Design
+
+```mermaid
+flowchart TB
+    subgraph L1["Layer 1: Configuration Storage"]
+        PR[GitHub PR Description<br/>Heading + PR URLs]
+    end
+    
+    subgraph L2["Layer 2: Pipeline Resolution"]
+        Resolve[resolve-group-configuration<br/>Fetch + parse config]
+        Snapshot[generate-snapshot<br/>Query images]
+    end
+    
+    subgraph L3["Layer 3: Testing"]
+        Test[early-gate-test<br/>Deploy + test]
+    end
+    
+    PR -->|GitHub API| Resolve
+    Resolve -->|group-components| Snapshot
+    Snapshot -->|snapshot.json| Test
+    
+    style PR fill:#e1f5ff
+    style Resolve fill:#fff4e6
+    style Snapshot fill:#e8f5e9
+    style Test fill:#f3e5f5
+```
+
+### Component Resolution Flow
+
+```mermaid
+sequenceDiagram
+    participant PR as GitHub PR
+    participant Pipeline as Pipeline
+    participant GitHub as GitHub API
+    participant Map as component_repo_map.json
+    participant Quay as Quay Registry
+    
+    Pipeline->>GitHub: Fetch PR description
+    GitHub-->>Pipeline: PR body text
+    Pipeline->>Pipeline: Find heading, extract PR URLs
+    Pipeline->>Map: Lookup repos → components
+    Map-->>Pipeline: Component list
+    
+    loop For each component
+        Pipeline->>Quay: Query odh-pr-{number} tag
+        alt Image exists
+            Quay-->>Pipeline: SHA digest (immutable ref)
+            Pipeline->>Pipeline: Add to snapshot
+        else Image not built yet
+            Quay-->>Pipeline: 404 Not Found
+            Pipeline->>Quay: Fallback: Query odh-stable
+            Quay-->>Pipeline: SHA digest (stable)
+            Pipeline->>Pipeline: Add to snapshot (using stable)
+        end
+    end
+    
+    Pipeline->>Pipeline: Build snapshot.json
+```
+
+### Data Transformation
+
+| Stage | Input | Output |
+|-------|-------|--------|
+| **URL Parsing** | `github.com/opendatahub-io/kserve/pull/123` | `{org: opendatahub-io, repo: kserve, pr: 123}` |
+| **Component Lookup** | `component_repo_map.json["kserve"]` | `{"kserve-agent-ci": "...", "kserve-controller-ci": "..."}` |
+| **Metadata Merge** | Components + PR number | `{"kserve-agent-ci": {"quay_path": "...", "pr": "123"}}` |
+| **Image Resolution** | Component metadata | `quay.io/.../kserve-agent:odh-pr-123 → sha256:abc...` |
+
+---
+
+## 3. Configuration Format
+
+### Heading-Based Detection
+
+The pipeline searches for any markdown heading containing "earlygate" (case-insensitive), with PR URLs listed on separate lines underneath:
+
+```markdown
+## Early Gate Testing
+https://github.com/opendatahub-io/kserve/pull/123
+https://github.com/opendatahub-io/feast/pull/456
+```
+
+### Detection Rules
+
+| Rule | Detail |
+|------|--------|
+| **Heading** | Any markdown heading (`#`, `##`, `###`, etc.) containing "earlygate" (case-insensitive) |
+| **Matching examples** | `## Early Gate Testing`, `# EarlyGateTesting`, `## earlygate`, `### Early-Gate Config` |
+| **PR URLs** | One GitHub PR URL per line under the heading |
+| **URL format** | `https://github.com/{org}/{repo}/pull/{number}` |
+| **Section end** | The config block ends at the next markdown heading |
+| **Flexible formatting** | Bullets, dashes, and whitespace before URLs are accepted |
+| **Leader PR** | Automatically included — don't list it in the config |
+
+### PR Description Example
+
+```markdown
+## Summary
+This PR updates the KServe API to support OAuth2 authentication.
+
+## Early Gate Testing
+https://github.com/opendatahub-io/feast/pull/456
+
+## Test Plan
+- [ ] Unit tests pass
+- [ ] Integration tests with Feast
+```
+
+---
+
+## 4. Workflow
+
+### Team Workflow
+
+```mermaid
+flowchart LR
+    A[Create PRs] --> B[Add heading +<br/>URLs to leader PR]
+    B --> C[Add cross-refs<br/>to other PRs]
+    C --> D[Push triggers<br/>pipeline]
+    D --> E[Review results]
+    E --> F[Remove config<br/>when done]
+    
+    style B fill:#e1f5ff
+    style D fill:#fff4e6
+```
+
+**Steps:**
+1. Create PRs in the relevant repositories
+2. Add `## Early Gate Testing` heading with collaborator PR URLs to the leader PR description
+3. Optionally add cross-references in collaborator PRs
+4. Pipeline runs automatically on push
+
+### Pipeline Execution Flow
+
+```mermaid
+flowchart TD
+    A[Push to leader PR] --> B{Fetch PR description}
+    B -->|GitHub API| C{Search for heading}
+    C -->|Found| D[Extract PR URLs]
+    C -->|Not found| Z[Single-PR mode]
+    D --> F[Parse org/repo/pr]
+    F --> G[Lookup components]
+    G --> H[Query Quay images]
+    H --> I[Build snapshot]
+    I --> J[Run tests]
+    J --> K[Report results]
+    
+    style C fill:#fff4e6
+    style I fill:#e1f5ff
+    style Z fill:#ffebee
+```
+
+### Pipeline Steps
+
+| Step | Action | Artifacts |
+|------|--------|-----------|
+| 1 | Extract PR metadata from PipelinesAsCode labels | `REPO_NAME`, `PR_NUMBER` |
+| 2 | Fetch PR description via GitHub API | PR body text |
+| 3 | Search for heading containing "earlygate" | Config section or null |
+| 4 | Extract PR URLs from section | List of URLs |
+| 5 | Parse each URL → extract org/repo/pr | Structured metadata |
+| 6 | Download `component_repo_map.json` | Component mappings |
+| 7 | Lookup components for each repo | Component list per repo |
+| 8 | Merge leader + collaborator components with PR numbers | `group-components` JSON |
+| 9 | Query Quay for each component's PR image | Image digests |
+| 10 | Build `snapshot.json` with all images | Snapshot artifact |
+| 11 | Run early-gate tests with snapshot | Test results |
+| 12 | Post results to leader PR | PR comment |
+
+---
+
+## 5. Image Availability & Snapshot Resolution
+
+### Overview
+
+When the pipeline builds a snapshot for group testing, it must resolve the **latest built image** for each PR in the group. This section explains how the pipeline queries Quay registry and handles scenarios where PR images may not be available yet.
+
+### Image Tagging Convention
+
+Each PR build in the early-gate pipeline produces container images tagged with:
+
+```
+quay.io/<org>/<component>:odh-pr-{number}
+```
+
+**Example:**
+- PR #123 in kserve repo → `quay.io/opendatahub/kserve-agent:odh-pr-123`
+- PR #456 in feast repo → `quay.io/opendatahub/feast-operator:odh-pr-456`
+
+### Image Availability Check Logic
+
+```mermaid
+flowchart TD
+    A[Component: kserve-agent-ci<br/>PR: 123] --> B{Query Quay for<br/>odh-pr-123 tag}
+    B -->|Image exists| C[Get SHA digest]
+    B -->|404 Not Found| D{Fallback: Query<br/>odh-stable tag}
+    C --> E[Use PR image<br/>sha256:abc123...]
+    D -->|Found| F[Use stable image<br/>sha256:stable789...]
+    D -->|Not Found| G[ERROR: Critical failure]
+    E --> H[Add to snapshot.json]
+    F --> I[Add to snapshot.json<br/>Log warning]
+    
+    style B fill:#fff4e6
+    style E fill:#e8f5e9
+    style F fill:#ffe0b2
+    style G fill:#ffebee
+```
+
+### Resolution Strategy
+
+| Scenario | Image Tag Query | Result | Action |
+|----------|----------------|--------|--------|
+| **PR build complete** | `odh-pr-123` exists | Found | Use PR image (immutable SHA digest) |
+| **PR build in progress** | `odh-pr-123` not found | Not ready | Fallback to `odh-stable` + log warning |
+| **Stable fallback available** | `odh-stable` exists | Found | Use stable image + warning in PR comment |
+| **Both missing** | Neither tag exists | Critical | Pipeline fails (component not testable) |
+
+### Immutable Image References
+
+All images in the snapshot use **SHA digest references** instead of tags to ensure reproducibility:
+
+**Tag reference (mutable):**
+```
+quay.io/opendatahub/kserve-agent:odh-pr-123
+```
+
+**SHA reference (immutable):**
+```
+quay.io/opendatahub/kserve-agent@sha256:abc123def456...
+```
+
+The pipeline:
+1. Queries image by tag (`odh-pr-123`)
+2. Extracts SHA digest from manifest
+3. Stores SHA digest in `snapshot.json`
+4. Testing uses SHA reference (guarantees same image is tested)
+
+### Snapshot JSON Structure
+
+Example snapshot with multiple PR images:
+
+```json
+{
+  "kserve-agent-ci": {
+    "image": "quay.io/opendatahub/kserve-agent@sha256:abc123...",
+    "image_tag": "odh-pr-123",
+    "git.url": "https://github.com/opendatahub-io/kserve",
+    "git.commit": "abc123def456..."
+  },
+  "feast-operator-ci": {
+    "image": "quay.io/opendatahub/feast-operator@sha256:def456...",
+    "image_tag": "odh-pr-456",
+    "git.url": "https://github.com/opendatahub-io/feast",
+    "git.commit": "789abc012def..."
+  },
+  "notebook-controller-ci": {
+    "image": "quay.io/opendatahub/notebook-controller@sha256:stable789...",
+    "image_tag": "odh-stable",
+    "git.url": "https://github.com/opendatahub-io/notebook-controller",
+    "git.commit": "main-branch-commit..."
+  }
+}
+```
+
+**Note:** In this example:
+- `kserve-agent-ci` and `feast-operator-ci` use PR-specific builds
+- `notebook-controller-ci` fell back to `odh-stable` (PR build not ready)
+
+### Build Timing Considerations
+
+| Scenario | Behavior |
+|----------|----------|
+| All PR builds complete before group test triggers | Optimal - all PRs tested with their latest code |
+| Some PR builds still in progress | Those components use `odh-stable`, test proceeds with partial group |
+| Leader PR build triggers immediately after push | Collaborator PR images may not be ready - fallback to stable |
+
+**Best practice:** Teams should ensure all PR builds in the group have completed before triggering the leader PR's group test. Re-trigger with `/retest` after all collaborator builds finish.
+
+### Warning Messages
+
+When fallback occurs, the pipeline logs warnings and includes them in the PR comment:
+
+```
+⚠️  WARNING: Component 'feast-operator-ci' does not have PR image for tag odh-pr-456
+   Quay query returned: 404 Not Found
+   Reason: PR build may still be in progress
+   Action: Falling back to odh-stable tag
+   Impact: Group test will use stable image instead of PR #456 code
+```
+
+---
+
+## 6. Examples & Use Cases
+
+### Example 1: Two-Component Integration
+
+**Scenario:** KServe API changes require Feast adapter updates.
+
+**Leader PR (kserve #123) description:**
+```markdown
+## Early Gate Testing
+https://github.com/opendatahub-io/feast/pull/456
+```
+
+**Pipeline behavior:**
+1. Push to kserve #123 triggers pipeline
+2. Detects Early Gate Testing heading → resolves both repos
+3. Builds snapshot with images from PR #123 + #456
+4. Runs integration tests
+5. Reports to kserve #123
+
+---
+
+### Example 2: Multi-Service Refactor
+
+**Scenario:** Authentication refactor across 3 services.
+
+**Leader PR (operator #111) description:**
+```markdown
+## Early Gate Testing
+https://github.com/opendatahub-io/kubeflow/pull/222
+https://github.com/opendatahub-io/notebook-controller/pull/333
+```
+
+**Pipeline behavior:**
+- Resolves components from all 3 repos (leader + 2 collaborators)
+- Builds snapshot with 3 PR images
+- Runs end-to-end auth flow tests
+- Reports to operator #111
+
+---
+
+### Example 3: Single PR (No Config)
+
+**Scenario:** Standard PR without grouping.
+
+**PR description:** (No Early Gate Testing heading)
+
+**Pipeline behavior:**
+1. Searches for heading → not found
+2. Falls back to single-PR mode
+3. Resolves components for current repo only
+4. Business as usual
+
+---
+
+## 7. Error Handling
+
+### Graceful Degradation Principle
+
+> **Core principle:** Every error (except missing `component_repo_map.json`) falls back to **single-PR mode**, ensuring pipelines never fail due to group testing issues.
+
+### Error Scenarios
+
+| Error | Detection | Fallback Action | Status |
+|-------|-----------|-----------------|--------|
+| No config heading | Heading absent in PR body | Single-PR mode | Continue |
+| Invalid PR URL | Regex mismatch | Skip entry, process others | Continue |
+| Non-ODH organization | URL org check | Skip entry, log warning | Continue |
+| Repo not in component map | Lookup returns null | Skip repo, log warning | Continue |
+| GitHub API error | Fetch failure | Single-PR mode | Continue |
+| **component_repo_map.json missing** | **Download fails** | **Cannot proceed** | **Fail** |
+| Quay image missing | Image query 404 | Use `odh-stable` tag | Continue |
+| Empty Early Gate section | Heading found but no URLs | Single-PR mode + format help | Continue |
+
+### Format Help Warnings
+
+The pipeline posts helpful PR comments when it detects common configuration mistakes:
+
+| Scenario | Comment Posted |
+|----------|---------------|
+| "earlygate" mentioned but not in a heading | Format issue warning with correct format example |
+| GitHub PR URLs found but no Early Gate heading | Info suggesting group testing is available |
+| Early Gate heading found but no URLs listed | Empty section warning with format example |
+
+### Partial Success Handling
+
+Pipeline continues if:
+- Some PR URLs are invalid (processes valid ones)
+- Some repos not in component map (uses others)
+- Some images missing from Quay (falls back to stable)
+
+Pipeline fails only if:
+- Component map unavailable (critical dependency)
+
+---
+
+## 8. Appendix: Quick Reference
+
+### Quick Start
+
+Add this to your leader PR description:
+
+```markdown
+## Early Gate Testing
+https://github.com/opendatahub-io/REPO/pull/NUMBER
+```
+
+### Pipeline Flow Summary
+
+```
+1. Fetch PR description (GitHub API)
+2. Find heading containing "earlygate"
+3. Extract PR URLs from section
+4. Parse org/repo/pr from URLs
+5. Lookup components (component_repo_map.json)
+6. Merge leader + collaborator components with PR metadata
+7. Query Quay for PR images (fallback to odh-stable)
+8. Build snapshot.json
+9. Run tests
+10. Post results to leader PR
+```
+
+### Key Files
+
+| File | Purpose |
+|------|---------|
+| `early-gate/tasks/resolve-group-configuration.yaml` | Reads PR description, resolves group config |
+| `early-gate/tasks/check-group-config.yaml` | Extracts repo list for test pipeline |
+| `early-gate/tasks/generate-snapshot-for-group-testing.yaml` | Queries Quay, builds snapshot |
+| `early-gate/tasks/post-build-complete-comment.yaml` | Posts build + group testing summary to PR |
+| `config/component_repo_map.json` | Maps repo names to Quay component paths |
+
+---
+
+**Document prepared by:** MohammadiIram

--- a/early-gate/docs/early-gate-user-guide.md
+++ b/early-gate/docs/early-gate-user-guide.md
@@ -314,7 +314,91 @@ merge:
     ]
 ```
 
-## 7. Onboarding a Repository to Early Gate
+## 7. Group Testing (Multi-PR)
+
+Group testing allows you to test multiple PRs from different repositories together in a single early gate run. This validates cross-component changes as a cohesive set before any of them are merged.
+
+### How It Works
+
+One PR acts as the **leader** — it contains the group testing configuration in its description and receives the test results. Other PRs in the group are **collaborators**.
+
+When the leader PR's early gate build pipeline runs, it:
+1. Reads the group testing configuration from the leader PR description
+2. Fetches PR-specific images for each collaborator from Quay
+3. Builds a combined snapshot with all PR images (falling back to stable images for any components whose PR build hasn't completed yet)
+4. Runs smoke tests against the combined set
+5. Posts a group testing summary and test results on the leader PR
+
+### Configuring Group Testing
+
+Add an `## Early Gate Testing` section to your **leader PR description** listing collaborator PR URLs:
+
+```markdown
+## Early Gate Testing
+https://github.com/opendatahub-io/feast/pull/456
+https://github.com/opendatahub-io/notebook-controller/pull/789
+```
+
+**Rules:**
+- Use any markdown heading (`#`, `##`, `###`, etc.) containing "earlygate" (case-insensitive) — e.g., `## Early Gate Testing`, `# EarlyGateTesting`, `## earlygate`, `### Early-Gate Config`
+- List one collaborator PR URL per line under the heading
+- The leader PR is automatically included — don't list it
+- Only `opendatahub-io` organization PRs are supported
+- The config block ends at the next markdown heading
+- Formatting is flexible — bullets, dashes, and whitespace are all accepted
+
+### Example
+
+**In kserve PR #123 description:**
+
+```markdown
+## Summary
+This PR updates the KServe API to support OAuth2 authentication.
+
+## Early Gate Testing
+https://github.com/opendatahub-io/feast/pull/456
+
+## Test Plan
+- [ ] Unit tests pass
+- [ ] Integration tests with Feast
+```
+
+This tests kserve PR #123 images together with feast PR #456 images. All other components use their latest stable versions.
+
+### Group Testing PR Comment
+
+When a group test runs, the bot posts a summary comment on the leader PR showing which components are included and whether PR images or stable fallbacks were used:
+
+> **Group Testing Summary**
+>
+> Testing multiple PRs together:
+>
+> | PR | Component | Tag | Status | Digest |
+> |---|---|---|---|---|
+> | [#123](https://github.com/opendatahub-io/kserve/pull/123) | kserve-controller | odh-pr-123 | PR build ready | sha256:abc... |
+> | [#456](https://github.com/opendatahub-io/feast/pull/456) | feast-operator | odh-pr-456 | PR build ready | sha256:def... |
+
+If any collaborator's PR build hasn't completed, the pipeline falls back to the stable image for that component and the comment includes a warning to re-trigger after builds finish.
+
+### Best Practices
+
+- Add the config to the **leader PR** only — don't add it to multiple PRs in the group
+- Add cross-references in collaborator PRs (e.g., "Part of group: kserve#123")
+- Ensure all PR builds have completed before triggering the group test
+- Remove the config section when done or when the PR closes
+
+### Group Testing Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| Config not detected | Ensure you have a markdown heading (`#` or `##`) containing "earlygate" (case-insensitive) and URLs are on separate lines in the PR **description** (not a comment) |
+| Invalid repo warning | The collaborator repo is not onboarded for early gate — the pipeline continues with valid repos only |
+| PR image not found | Collaborator PR builds may not have completed — pipeline falls back to stable images and logs a warning. Re-trigger with `/retest` after builds finish |
+| Format help comment posted | The pipeline detected text that looks like a group testing config but couldn't parse it — check the format guidance in the comment |
+
+---
+
+## 8. Onboarding a Repository to Early Gate
 
 To enable early gate on a new repository, use the **ODH Early Gate Onboarder** workflow in the `odh-konflux-central` repository.
 
@@ -379,7 +463,7 @@ Teams who want to enable early gate on their repository should add their request
 
 ---
 
-## 8. Pros and Cons
+## 9. Pros and Cons
 
 ### Pros
 
@@ -395,18 +479,16 @@ Teams who want to enable early gate on their repository should add their request
 
 ---
 
-## 9. Limitations
+## 10. Limitations
 
 - **ODH repos only** — early gate currently supports only ODH repository builds. RHDS and RHOAI builds are not supported yet.
 - **Single architecture only** — early gate currently supports x86 architecture only.
-- **Repo-scoped testing** — each early gate run builds & tests a single PR from a single repository. Testing multiple PRs from various repositories together (group testing) is planned for a future phase.
+- **Group testing is leader-only** — group testing configuration must be added to a single leader PR. There is no way to automatically sync group configs across multiple PRs.
 - **Only configured branches supported** — early gate build & test are by default enabled only for main/master branch, and can be requested to cover any additional branches required for a repo. Need to limit the infra to only few branches to contain the cloud cost.
 
 ---
 
-## 10. Future Plans
-
-- **Early Gate Group Tests** — currently, each early gate run build & tests a single PR from a single repository. Group testing will enable testing multiple PRs from different repositories together in a single early gate run, validating cross-component changes as a cohesive set before any of them are merged.
+## 11. Future Plans
 
 - **Konflux Integration Test Scenarios (ITS)** — the current early gate test execution relies on Jenkins for smoke test orchestration. A future iteration will migrate test execution to Konflux Integration Test Scenarios (ITS), bringing the entire early gate pipeline — build and test — fully within the Konflux platform.
 
@@ -416,7 +498,7 @@ Teams who want to enable early gate on their repository should add their request
 
 ---
 
-## 11. FAQ
+## 12. FAQ
 
 ### What is early gate and why should I care?
 
@@ -436,7 +518,7 @@ No. Early gate tests are required for all onboarded repositories. They run autom
 
 ### Does early gate work for all repositories?
 
-Early gate currently supports ODH repositories only (not RHDS/RHOAI builds yet). Your repository must be onboarded first — see [Section 7: Onboarding a Repository to Early Gate](#7-onboarding-a-repository-to-early-gate) for details. During the initial rollout, the DevTestOps team handles onboarding.
+Early gate currently supports ODH repositories only (not RHDS/RHOAI builds yet). Your repository must be onboarded first — see [Section 8: Onboarding a Repository to Early Gate](#8-onboarding-a-repository-to-early-gate) for details. During the initial rollout, the DevTestOps team handles onboarding.
 
 ### How much does early gate cost to run?
 
@@ -444,7 +526,7 @@ Each early gate run provisions a dedicated ROSA HCP cluster on AWS, which incurs
 
 ### Can I test multiple PRs together?
 
-Not yet. Currently, each early gate run tests a single PR from a single repository. Group testing (testing multiple PRs from different repos together) is planned for a future phase — see [Section 10: Future Plans](#10-future-plans).
+Yes! Use **group testing** to test PRs from multiple repositories together in a single early gate run. Add an `## Early Gate Testing` section to one PR's description (the "leader") listing the other PR URLs. See [Section 7: Group Testing](#7-group-testing-multi-pr) for details.
 
 ### Where can I find more technical details?
 
@@ -452,6 +534,7 @@ For detailed technical documentation about the early gate pipelines:
 
 - **[Early Gate Build Pipeline Design](early-gate-build-pipeline-design.md)** — architecture, implementation details, and build flow for the early gate build pipeline (stage 2)
 - **[Early Gate Test Pipeline Design](early-gate-test-pipeline-design.md)** — architecture, implementation details, and test orchestration for the early gate test pipeline (stage 3)
+- **[Group Testing Design](early-gate-group-testing-design.md)** — design and architecture for multi-PR group testing
 
 ### How do I enable must-gather diagnostics for my tests?
 

--- a/early-gate/early-gate-component-pipeline.yaml
+++ b/early-gate/early-gate-component-pipeline.yaml
@@ -9,10 +9,8 @@ spec:
     a single Tekton pipeline for quick feature-branch validation before pushing to stable.
   params:
   # --- Group snapshot ---
-  - name: group-components
-    type: string
-    description: List of components in the group (JSON)
-    default: ""
+  # NOTE: group-components is now auto-resolved from PR description via resolve-group-configuration task
+  # To enable group testing, add ## Early Gate Testing section to PR description (see docs/early-gate-user-guide.md)
 
   # --- General ---
   - description: Source Repository URL
@@ -221,12 +219,31 @@ spec:
   # Group snapshot block
   # --------------------------------------------------------------------------
 
-  - name: generate-snapshot
+  # NOTE: resolve-group-configuration task reads PR description and resolves group config
+  # It automatically includes leader PR components + collaborator PRs from config
+  # PipelinesAsCode labels (PR_NUMBER, REPO_NAME) are available to the task
+  - name: resolve-group-configuration
     runAfter:
     - init
+    workspaces:
+    - name: basic-auth
+      workspace: git-auth
+    taskRef:
+      resolver: git
+      params:
+      - name: url
+        value: https://github.com/opendatahub-io/odh-konflux-central.git
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: early-gate/tasks/resolve-group-configuration.yaml
+
+  - name: generate-snapshot
+    runAfter:
+    - resolve-group-configuration
     params:
     - name: COMPONENTS
-      value: $(params.group-components)
+      value: $(tasks.resolve-group-configuration.results.group-components)
     - name: ociStorage
       value: $(params.operator-output-image).snapshot
     - name: ociArtifactExpiresAfter
@@ -1002,6 +1019,7 @@ spec:
     runAfter:
     - validate-fbc
     - apply-tags-fbc
+    - generate-snapshot
     params:
     - name: catalog-image-url
       value: $(tasks.build-fbc-container.results.IMAGE_URL)
@@ -1009,6 +1027,16 @@ spec:
       value: $(tasks.build-fbc-container.results.IMAGE_DIGEST)
     - name: unique-tag
       value: $(tasks.rhoai-init.results.unique-tag)
+    - name: has-group-config
+      value: $(tasks.resolve-group-configuration.results.has-group-config)
+    - name: component-table
+      value: $(tasks.generate-snapshot.results.component-table)
+    - name: fallback-warning
+      value: $(tasks.generate-snapshot.results.fallback-warning)
+    - name: invalid-repo-warnings
+      value: $(tasks.resolve-group-configuration.results.invalid-repo-warnings)
+    - name: format-help-warning
+      value: $(tasks.resolve-group-configuration.results.format-help-warning)
     taskRef:
       resolver: git
       params:

--- a/early-gate/early-gate-operator-pipeline.yaml
+++ b/early-gate/early-gate-operator-pipeline.yaml
@@ -9,10 +9,8 @@ spec:
     a single Tekton pipeline for quick feature-branch validation before pushing to stable.
   params:
   # --- Group snapshot ---
-  - name: group-components
-    type: string
-    description: List of components in the group (JSON)
-    default: ""
+  # NOTE: group-components is now auto-resolved from PR description via resolve-group-configuration task
+  # To enable group testing, add ## Early Gate Testing section to PR description (see docs/early-gate-user-guide.md)
 
   # --- General ---
   - description: Source Repository URL
@@ -221,12 +219,28 @@ spec:
   # Group snapshot block
   # --------------------------------------------------------------------------
 
-  - name: generate-snapshot
+  - name: resolve-group-configuration
     runAfter:
     - init
+    workspaces:
+    - name: basic-auth
+      workspace: git-auth
+    taskRef:
+      resolver: git
+      params:
+      - name: url
+        value: https://github.com/opendatahub-io/odh-konflux-central.git
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: early-gate/tasks/resolve-group-configuration.yaml
+
+  - name: generate-snapshot
+    runAfter:
+    - resolve-group-configuration
     params:
     - name: COMPONENTS
-      value: $(params.group-components)
+      value: $(tasks.resolve-group-configuration.results.group-components)
     - name: ociStorage
       value: $(params.operator-output-image).snapshot
     - name: ociArtifactExpiresAfter
@@ -759,6 +773,7 @@ spec:
     runAfter:
     - validate-fbc
     - apply-tags-fbc
+    - generate-snapshot
     params:
     - name: catalog-image-url
       value: $(tasks.build-fbc-container.results.IMAGE_URL)
@@ -766,6 +781,16 @@ spec:
       value: $(tasks.build-fbc-container.results.IMAGE_DIGEST)
     - name: unique-tag
       value: $(tasks.rhoai-init.results.unique-tag)
+    - name: has-group-config
+      value: $(tasks.resolve-group-configuration.results.has-group-config)
+    - name: component-table
+      value: $(tasks.generate-snapshot.results.component-table)
+    - name: fallback-warning
+      value: $(tasks.generate-snapshot.results.fallback-warning)
+    - name: invalid-repo-warnings
+      value: $(tasks.resolve-group-configuration.results.invalid-repo-warnings)
+    - name: format-help-warning
+      value: $(tasks.resolve-group-configuration.results.format-help-warning)
     taskRef:
       resolver: git
       params:

--- a/early-gate/early-gate-test-pipeline.yaml
+++ b/early-gate/early-gate-test-pipeline.yaml
@@ -111,11 +111,27 @@ spec:
         value: early-gate/tasks/check-prerequisites.yaml
 
   # --------------------------------------------------------------------------
-  # 2. Check for ongoing jobs — scan PR comments for idempotency
+  # 2. Check group config — read Early Gate section from PR description
+  # --------------------------------------------------------------------------
+  - name: check-group-config
+    runAfter:
+    - check-prerequisites
+    taskRef:
+      resolver: git
+      params:
+      - name: url
+        value: https://github.com/opendatahub-io/odh-konflux-central.git
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: early-gate/tasks/check-group-config.yaml
+
+  # --------------------------------------------------------------------------
+  # 3. Check for ongoing jobs — scan PR comments for idempotency
   # --------------------------------------------------------------------------
   - name: check-ongoing-jobs
     runAfter:
-    - check-prerequisites
+    - check-group-config
     taskRef:
       resolver: git
       params:
@@ -144,7 +160,7 @@ spec:
       value: $(params.jenkins-url-secret-key)
 
   # --------------------------------------------------------------------------
-  # 3. Trigger test pipeline — dispatch GitHub workflow, post queue-url-comment
+  # 4. Trigger test pipeline — dispatch GitHub workflow, post queue-url-comment
   #    Skipped when a previous run left an active queue-url or job-url comment
   # --------------------------------------------------------------------------
   - name: trigger-test-pipeline
@@ -182,9 +198,11 @@ spec:
       value: $(params.jenkins-url-secret-key)
     - name: delete-intermediate-comments
       value: $(params.delete-intermediate-comments)
+    - name: repositories
+      value: $(tasks.check-group-config.results.repositories)
 
   # --------------------------------------------------------------------------
-  # 4a. Monitor (fresh) — runs after trigger-test-pipeline for new jobs
+  # 5a. Monitor (fresh) — runs after trigger-test-pipeline for new jobs
   #     Receives queue-url and correlation-id from trigger-test-pipeline results
   # --------------------------------------------------------------------------
   - name: monitor-fresh
@@ -235,7 +253,7 @@ spec:
       value: $(params.jenkins-url-secret-key)
 
   # --------------------------------------------------------------------------
-  # 4b. Monitor (resume) — runs when check-ongoing-jobs found an active job
+  # 5b. Monitor (resume) — runs when check-ongoing-jobs found an active job
   #     Receives job-url and correlation-id from check-ongoing-jobs results
   # --------------------------------------------------------------------------
   - name: monitor-resume

--- a/early-gate/tasks/check-group-config.yaml
+++ b/early-gate/tasks/check-group-config.yaml
@@ -1,0 +1,105 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: check-group-config
+spec:
+  description: |
+    Extracts repository names from Early Gate Testing section in PR description
+    for passing to Jenkins trigger workflow
+  results:
+    - name: repositories
+      description: Comma-separated list of repository names (leader + collaborators)
+    - name: has-group-config
+      description: true if group config found, false otherwise
+  steps:
+    - name: extract-repos
+      image: quay.io/konflux-ci/konflux-test:stable
+      env:
+        - name: PR_NUMBER
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['pipelinesascode.tekton.dev/pull-request']
+        - name: REPO_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['pipelinesascode.tekton.dev/url-repository']
+        - name: GITHUB_ORG
+          value: "opendatahub-io"
+      script: |
+        #!/bin/bash
+        set -e
+
+        echo "=== Extract Group Repos Task ===" >&2
+        echo "PR_NUMBER=${PR_NUMBER}" >&2
+        echo "REPO_NAME=${REPO_NAME}" >&2
+
+        EARLYGATE_SECTION_PATTERN="early.*gate"  # Matches "earlygate", "early gate", "early-gate", etc.
+        ALLOWED_ORG="opendatahub-io"
+
+        # --- Fetch PR description from GitHub API ---
+        echo "Fetching PR description from GitHub..." >&2
+        GITHUB_API_URL="https://api.github.com/repos/${GITHUB_ORG}/${REPO_NAME}/pulls/${PR_NUMBER}"
+
+        # Unauthenticated call (rate limited but sufficient for most cases)
+        PR_DATA=$(curl -sSf "${GITHUB_API_URL}" 2>&1 || echo "")
+
+        if [[ -z "${PR_DATA}" ]]; then
+          echo "Failed to fetch PR description" >&2
+          echo -n "false" > "$(results.has-group-config.path)"
+          echo -n "${REPO_NAME}" > "$(results.repositories.path)"
+          exit 0
+        fi
+
+        PR_BODY=$(echo "${PR_DATA}" | jq -r '.body // ""')
+
+        # Remove Windows line endings (CR) if present
+        PR_BODY=$(echo "${PR_BODY}" | tr -d '\r')
+
+        # --- Check for Early Gate section ---
+        if ! echo "${PR_BODY}" | grep -qi "^#.*${EARLYGATE_SECTION_PATTERN}"; then
+          echo "No Early Gate section found" >&2
+          echo -n "false" > "$(results.has-group-config.path)"
+          echo -n "${REPO_NAME}" > "$(results.repositories.path)"
+          exit 0
+        fi
+
+        echo "✓ Early Gate section found" >&2
+        echo -n "true" > "$(results.has-group-config.path)"
+
+        # --- Extract PR URLs ---
+        # Allow flexible formatting: whitespace, bullets, dashes, etc.
+        PR_URLS=$(echo "${PR_BODY}" | awk -v IGNORECASE=1 "
+          /^#+.*${EARLYGATE_SECTION_PATTERN}/ { found=1; next }
+          found && /^#+/ { exit }
+          found && /https:\/\/github\.com\/[^\/]+\/[^\/]+\/pull\/[0-9]+/ {
+            match(\$0, /https:\/\/github\.com\/[^\/]+\/[^\/]+\/pull\/[0-9]+/)
+            print substr(\$0, RSTART, RLENGTH)
+          }
+        " || true)
+
+        # --- Start with leader repo ---
+        REPOS="${REPO_NAME}"
+
+        # --- Extract repo names from URLs ---
+        while IFS= read -r url; do
+          if [[ ! "${url}" =~ ^https://github\.com/([^/]+)/([^/]+)/pull/([0-9]+)$ ]]; then
+            continue
+          fi
+
+          ORG="${BASH_REMATCH[1]}"
+          REPO="${BASH_REMATCH[2]}"
+
+          # Security: only ODH repos
+          if [[ "${ORG}" != "${ALLOWED_ORG}" ]]; then
+            echo "⚠️  Skipping non-ODH repo: ${ORG}/${REPO}" >&2
+            continue
+          fi
+
+          # Add to list (avoid duplicates)
+          if ! echo ",${REPOS}," | grep -q ",${REPO},"; then
+            REPOS="${REPOS},${REPO}"
+          fi
+        done <<< "${PR_URLS}"
+
+        echo "Final repository list: ${REPOS}" >&2
+        echo -n "${REPOS}" > "$(results.repositories.path)"

--- a/early-gate/tasks/generate-snapshot-for-group-testing.yaml
+++ b/early-gate/tasks/generate-snapshot-for-group-testing.yaml
@@ -1,14 +1,18 @@
 apiVersion: tekton.dev/v1
 kind: Task
 metadata:
-  name: trigger-group-testing
+  name: generate-snapshot-for-group-testing
 spec:
   workspaces:
     - name: basic-auth
       optional: true
   params:
     - name: COMPONENTS
-      description: List of components in the group (JSON). If empty, fetched from component_repo_map.json using REPO_NAME.
+      description: |
+        List of components in the group (JSON).
+        Format: {"comp1": "path1", "comp2": "path2"} OR
+                {"comp1": {"quay_path": "path1", "pr": "123"}, "comp2": {...}}
+        If empty, fetched from component_repo_map.json using REPO_NAME.
       default: ""
     - name: fallback-tag
       type: string
@@ -26,6 +30,10 @@ spec:
     name: SNAPSHOT_ARTIFACT
   - description: Resolved COMPONENTS JSON used to generate the snapshot
     name: group-components
+  - description: Warning message if any components fell back to stable (empty if all PRs found)
+    name: fallback-warning
+  - description: Component summary table for PR comment (TSV format - PR component tag status digest)
+    name: component-table
   volumes:
   - name: workdir
     emptyDir: {}
@@ -80,28 +88,62 @@ spec:
 
         json_string="$COMPONENTS"
         echo ${COMPONENTS}
-        
+
         # Temporary file to store results
         temp_file=$(mktemp)
         echo "{}" > "$temp_file"
 
+        # Track fallback warnings and component table (use temp files to avoid subshell issues)
+        FALLBACK_WARNINGS_FILE=$(mktemp)
+        COMPONENT_TABLE_FILE=$(mktemp)
+        > "$FALLBACK_WARNINGS_FILE"
+        > "$COMPONENT_TABLE_FILE"
+
+        DEFAULT_PR_NUMBER="${PR_NUMBER}"
+
         # Parse JSON and iterate through each component
         while IFS= read -r row; do
-            # Tag to search for
-            TAG="odh-pr-${PR_NUMBER}"
-        
             # Decode the base64 encoded row
             component=$(echo "$row" | base64 -d | jq -r '.key')
-            repo_path=$(echo "$row" | base64 -d | jq -r '.value')
-            
-            echo "component=${component}"
-            echo "repo_path=${repo_path}"
-        
-            if skopeo inspect "docker://quay.io/${repo_path}:${TAG}" &>/dev/null; then
-              echo "found the image with tag ${TAG}"
+            value_raw=$(echo "$row" | base64 -d | jq -c '.value')
+
+            # Check if value is a string (old format) or object (new format with PR metadata)
+            value_type=$(echo "$value_raw" | jq -r 'type')
+
+            if [[ "$value_type" == "object" ]]; then
+              # New format: {"quay_path": "...", "pr": "123"}
+              repo_path=$(echo "$value_raw" | jq -r '.quay_path')
+              component_pr=$(echo "$value_raw" | jq -r '.pr')
+              TAG="odh-pr-${component_pr}"
+              echo "component=${component} (from PR #${component_pr})"
             else
-              echo "No image found with tag ${TAG}, falling back to the ${FALLBACK_TAG} image for ${repo_path}"
+              # Old format: string path
+              repo_path=$(echo "$value_raw" | jq -r '.')
+              TAG="odh-pr-${DEFAULT_PR_NUMBER}"
+              echo "component=${component} (using default PR #${DEFAULT_PR_NUMBER})"
+            fi
+
+            echo "repo_path=${repo_path}"
+
+            # Check if PR-specific image exists
+            IMAGE_STATUS=""
+            if skopeo inspect "docker://quay.io/${repo_path}:${TAG}" &>/dev/null; then
+              echo "✓ Found image with tag ${TAG}"
+              IMAGE_STATUS="ready"
+            else
+              echo "⚠️  WARNING: Component '${component}' does not have PR image for tag ${TAG}" >&2
+              echo "   Quay query returned: 404 Not Found" >&2
+              echo "   Reason: PR build may still be in progress" >&2
+              echo "   Action: Falling back to ${FALLBACK_TAG} tag" >&2
+              echo "   Impact: Group test will use stable image instead of PR code" >&2
+
+              # Track this fallback for PR comment
+              if [[ "$value_type" == "object" ]]; then
+                echo "- Component \`${component}\` from PR #${component_pr}: using \`${FALLBACK_TAG}\` (PR build not ready)" >> "$FALLBACK_WARNINGS_FILE"
+              fi
+
               TAG=${FALLBACK_TAG}
+              IMAGE_STATUS="fallback"
             fi
                 
             
@@ -191,6 +233,15 @@ spec:
                '. + {($key): {image: $image, "git.url": $giturl, "git.commit": $gitcommit, "image_tag": $image_tag}}' \
                "$temp_file" > "${temp_file}.tmp" && mv "${temp_file}.tmp" "$temp_file"
 
+            # Add to component table for PR comment (only for group testing components)
+            if [[ "$value_type" == "object" ]]; then
+              SHORT_DIGEST=$(echo "$manifest_digest" | cut -c 1-12)
+              if [[ -z "$SHORT_DIGEST" ]]; then
+                SHORT_DIGEST="N/A"
+              fi
+              echo "${component_pr}|${component}|${TAG}|${IMAGE_STATUS}|${SHORT_DIGEST}" >> "$COMPONENT_TABLE_FILE"
+            fi
+
             echo "" >&2
         done < <(echo "$json_string" | jq -r 'to_entries[] | @base64')
 
@@ -203,8 +254,18 @@ spec:
         cp "$temp_file" /var/workdir/snapshot/snapshot.json
         echo "Snapshot written to /var/workdir/snapshot/snapshot.json" >&2
 
+        # Output fallback warnings
+        if [[ -s "$FALLBACK_WARNINGS_FILE" ]]; then
+          cat "$FALLBACK_WARNINGS_FILE" > "$(results.fallback-warning.path)"
+        else
+          echo "" > "$(results.fallback-warning.path)"
+        fi
+
+        # Output component table
+        cat "$COMPONENT_TABLE_FILE" > "$(results.component-table.path)"
+
         # Cleanup
-        rm -f "$temp_file"
+        rm -f "$temp_file" "$FALLBACK_WARNINGS_FILE" "$COMPONENT_TABLE_FILE"
 
     - name: create-trusted-artifact
       image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:81c4864dae6bb11595f657be887e205262e70086a05ed16ada827fd6391926ac

--- a/early-gate/tasks/post-build-complete-comment.yaml
+++ b/early-gate/tasks/post-build-complete-comment.yaml
@@ -19,6 +19,26 @@ spec:
   - name: unique-tag
     description: Unique tag to use in the FBC image reference
     type: string
+  - name: has-group-config
+    description: Whether this is a group testing run (true/false)
+    type: string
+    default: "false"
+  - name: component-table
+    description: Component summary table (TSV format) from group testing
+    type: string
+    default: ""
+  - name: fallback-warning
+    description: Warning message from generate-snapshot (empty if no fallbacks)
+    type: string
+    default: ""
+  - name: invalid-repo-warnings
+    description: Warning messages for repos not found in component_repo_map.json
+    type: string
+    default: ""
+  - name: format-help-warning
+    description: Helpful message when earlygate format is incorrect
+    type: string
+    default: ""
   - name: pr-token-secret-name
     description: Name of the Kubernetes secret containing the GitHub token for PR comment operations
     type: string
@@ -57,6 +77,16 @@ spec:
       value: $(params.catalog-image-digest)
     - name: UNIQUE_TAG
       value: $(params.unique-tag)
+    - name: HAS_GROUP_CONFIG
+      value: $(params.has-group-config)
+    - name: COMPONENT_TABLE
+      value: $(params.component-table)
+    - name: FALLBACK_WARNING
+      value: $(params.fallback-warning)
+    - name: INVALID_REPO_WARNINGS
+      value: $(params.invalid-repo-warnings)
+    - name: FORMAT_HELP_WARNING
+      value: $(params.format-help-warning)
     script: |
       #!/bin/bash
       set -euo pipefail
@@ -69,15 +99,102 @@ spec:
       echo "FBC_IMAGE: ${FBC_IMAGE}"
       printf '%s' "${FBC_IMAGE}" > "$(results.fbc-image.path)"
 
-      COMMENT_BODY=$(printf '<!-- early-gate-build-complete -->\n:white_check_mark: **Early Gate Build - Complete**\n\n| Field | Value |\n|-------|-------|\n| **Status** | :white_check_mark: SUCCESS |\n| **FBC Image** | %s |' \
+      # --- Debug: Show parameters ---
+      echo "=== Post Build Complete Comment Parameters ===" >&2
+      echo "HAS_GROUP_CONFIG='${HAS_GROUP_CONFIG}'" >&2
+      echo "COMPONENT_TABLE length: ${#COMPONENT_TABLE}" >&2
+      echo "COMPONENT_TABLE (first 200 chars): ${COMPONENT_TABLE:0:200}" >&2
+      echo "FALLBACK_WARNING: ${FALLBACK_WARNING}" >&2
+      echo "INVALID_REPO_WARNINGS: ${INVALID_REPO_WARNINGS}" >&2
+      echo "FORMAT_HELP_WARNING length: ${#FORMAT_HELP_WARNING}" >&2
+
+      # --- Build the FBC build complete section (always included) ---
+      BUILD_SECTION=$(printf ':white_check_mark: **Early Gate Build - Complete**\n\n| Field | Value |\n|-------|-------|\n| **Status** | :white_check_mark: SUCCESS |\n| **FBC Image** | %s |' \
         "${FBC_IMAGE}")
 
+      # --- Build the group testing section (if applicable) ---
+      GROUP_TESTING_SECTION=""
+
+      # Check for format help warning (posted even when not group testing)
+      TRIMMED_FORMAT_HELP=$(echo "${FORMAT_HELP_WARNING}" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+
+      if [[ "${HAS_GROUP_CONFIG}" == "true" && -n "${COMPONENT_TABLE}" ]]; then
+        # --- Group Testing Summary ---
+        echo "Including group testing summary" >&2
+
+        # Check if there are fallbacks
+        HAS_FALLBACKS="false"
+        TRIMMED_WARNING=$(echo "${FALLBACK_WARNING}" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+        if [[ -n "${TRIMMED_WARNING}" ]]; then
+          HAS_FALLBACKS="true"
+        fi
+
+        # Build component table
+        COMPONENT_MAP_URL="https://raw.githubusercontent.com/opendatahub-io/odh-konflux-central/main/config/component_repo_map.json"
+        COMPONENT_MAP=$(curl -sSf "${COMPONENT_MAP_URL}" 2>/dev/null || echo "{}")
+
+        declare -A PR_TO_REPO
+
+        while IFS='|' read -r pr comp tag status digest; do
+          if [[ -z "$pr" ]]; then continue; fi
+          REPO_FOUND=$(echo "${COMPONENT_MAP}" | jq -r --arg comp "${comp}" 'to_entries[] | select(.value | has($comp)) | .key' | head -1)
+          if [[ -n "$REPO_FOUND" ]]; then
+            PR_TO_REPO[$pr]="$REPO_FOUND"
+          fi
+        done <<< "${COMPONENT_TABLE}"
+
+        TABLE_HEADER="| PR | Component | Tag | Status | Digest |\n|---|---|---|---|---|\n"
+        TABLE_ROWS=""
+
+        while IFS='|' read -r pr comp tag status digest; do
+          if [[ -z "$pr" ]]; then continue; fi
+
+          REPO_FOUND="${PR_TO_REPO[$pr]}"
+          if [[ -n "$REPO_FOUND" ]]; then
+            PR_LINK="[#${pr}](https://github.com/opendatahub-io/${REPO_FOUND}/pull/${pr})"
+          else
+            PR_LINK="#${pr}"
+          fi
+
+          if [[ "$status" == "ready" ]]; then
+            STATUS_TEXT="PR build ready"
+          else
+            STATUS_TEXT="Using stable"
+          fi
+
+          TABLE_ROWS="${TABLE_ROWS}| ${PR_LINK} | ${comp} | ${tag} | ${STATUS_TEXT} | ${digest} |\n"
+        done <<< "${COMPONENT_TABLE}"
+
+        # Build warnings
+        WARNING_NOTE=""
+        if [[ "$HAS_FALLBACKS" == "true" ]]; then
+          WARNING_NOTE="\n\n⚠️ Some components fell back to stable images because PR builds have not completed yet. Re-trigger with /retest after all builds finish.\n"
+        fi
+
+        INVALID_REPO_NOTE=""
+        TRIMMED_INVALID_WARNINGS=$(echo "${INVALID_REPO_WARNINGS}" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+        if [[ -n "${TRIMMED_INVALID_WARNINGS}" ]]; then
+          INVALID_REPO_NOTE="\n\n### Configuration Warnings\n\n${INVALID_REPO_WARNINGS}\n"
+        fi
+
+        GROUP_TESTING_SECTION="\n\n---\n\n**Group Testing Summary**\n\nTesting multiple PRs together:\n\n${TABLE_HEADER}${TABLE_ROWS}${WARNING_NOTE}${INVALID_REPO_NOTE}"
+
+      elif [[ -n "${TRIMMED_FORMAT_HELP}" ]]; then
+        # --- Format Help Warning ---
+        echo "Including format help warning" >&2
+        GROUP_TESTING_SECTION="\n\n---\n\n${FORMAT_HELP_WARNING}"
+      fi
+
+      # --- Combine sections ---
+      COMMENT_BODY="<!-- early-gate-build-complete -->\n${BUILD_SECTION}${GROUP_TESTING_SECTION}\n\n---\nPosted by Early-Gate"
+
+      # --- Post comment ---
       curl -sSf \
         -X POST \
         -H "Authorization: Bearer ${PR_GITHUB_TOKEN}" \
         -H "Accept: application/vnd.github+json" \
         "https://api.github.com/repos/${OWNER}/${REPO}/issues/${PR_NUMBER}/comments" \
-        -d "{\"body\":$(echo "${COMMENT_BODY}" | jq -Rs .)}" \
+        -d "{\"body\":$(echo -e "${COMMENT_BODY}" | jq -Rs .)}" \
         2>/dev/null || echo "WARNING: Failed to post PR comment (non-fatal)"
 
-      echo "Posted build-complete comment on PR #${PR_NUMBER}"
+      echo "Posted consolidated build + group testing comment on PR #${PR_NUMBER}"

--- a/early-gate/tasks/resolve-group-configuration.yaml
+++ b/early-gate/tasks/resolve-group-configuration.yaml
@@ -1,0 +1,353 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: resolve-group-configuration
+spec:
+  workspaces:
+    - name: basic-auth
+      optional: true
+  results:
+    - name: group-components
+      description: Resolved components JSON with PR metadata for group testing
+    - name: has-group-config
+      description: true if group config found, false otherwise
+    - name: invalid-repo-warnings
+      description: Warning messages for repos not found in component_repo_map.json
+    - name: format-help-warning
+      description: Helpful message when earlygate is mentioned incorrectly or PR URLs found outside section
+  volumes:
+    - name: workdir
+      emptyDir: {}
+  stepTemplate:
+    volumeMounts:
+      - mountPath: /var/workdir
+        name: workdir
+  steps:
+    - name: resolve-configuration
+      image: quay.io/konflux-ci/konflux-test:stable
+      workingDir: /workspace
+      env:
+        - name: PR_NUMBER
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['pipelinesascode.tekton.dev/pull-request']
+        - name: REPO_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['pipelinesascode.tekton.dev/url-repository']
+        - name: GITHUB_ORG
+          value: "opendatahub-io"
+        - name: WORKSPACE_BASIC_AUTH_DIRECTORY_BOUND
+          value: $(workspaces.basic-auth.bound)
+        - name: WORKSPACE_BASIC_AUTH_DIRECTORY_PATH
+          value: $(workspaces.basic-auth.path)
+      script: |
+        #!/bin/bash
+        set -e
+
+        echo "=== Resolve Group Configuration Task ===" >&2
+        echo "PR_NUMBER=${PR_NUMBER}" >&2
+        echo "REPO_NAME=${REPO_NAME}" >&2
+        echo "GITHUB_ORG=${GITHUB_ORG}" >&2
+
+        # --- Constants ---
+        EARLYGATE_SECTION_PATTERN="early.*gate"  # Matches "earlygate", "early gate", "early-gate", etc.  # Case-insensitive search in ## headings
+        COMPONENT_MAP_URL="https://raw.githubusercontent.com/opendatahub-io/odh-konflux-central/main/config/component_repo_map.json"
+        ALLOWED_ORG="opendatahub-io"  # Only accept PRs from this GitHub org
+
+        # --- Fetch component_repo_map.json (critical dependency) ---
+        echo "Fetching component_repo_map.json..." >&2
+        COMPONENT_MAP=$(curl -sSf "${COMPONENT_MAP_URL}")
+        if [[ -z "${COMPONENT_MAP}" ]]; then
+          echo "ERROR: Failed to fetch component_repo_map.json" >&2
+          exit 1
+        fi
+        echo "Component map loaded successfully" >&2
+
+        # --- Fetch PR description from GitHub API ---
+        echo "Fetching PR description from GitHub..." >&2
+        GITHUB_API_URL="https://api.github.com/repos/${GITHUB_ORG}/${REPO_NAME}/pulls/${PR_NUMBER}"
+
+        # Use authentication if available
+        GITHUB_TOKEN=""
+        if [[ "${WORKSPACE_BASIC_AUTH_DIRECTORY_BOUND}" == "true" ]]; then
+          echo "Checking for GitHub token in workspace..." >&2
+          if [[ -f "${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/.git-credentials" ]]; then
+            echo "Found .git-credentials file" >&2
+            # Format examples:
+            # https://TOKEN:x-oauth-basic@github.com
+            # https://x-access-token:TOKEN@github.com
+            # https://username:TOKEN@github.com
+            CREDS_LINE=$(cat "${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/.git-credentials" | grep github.com | head -1)
+
+            # Try different extraction patterns
+            # Pattern 1: https://TOKEN:x-oauth-basic@github.com
+            GITHUB_TOKEN=$(echo "${CREDS_LINE}" | sed -n 's|https://\([^:]*\):x-oauth-basic@github\.com.*|\1|p')
+
+            # Pattern 2: https://x-access-token:TOKEN@github.com
+            if [[ -z "${GITHUB_TOKEN}" ]]; then
+              GITHUB_TOKEN=$(echo "${CREDS_LINE}" | sed -n 's|https://x-access-token:\([^@]*\)@github\.com.*|\1|p')
+            fi
+
+            # Pattern 3: https://username:TOKEN@github.com (any username)
+            if [[ -z "${GITHUB_TOKEN}" ]]; then
+              GITHUB_TOKEN=$(echo "${CREDS_LINE}" | sed -n 's|https://[^:]*:\([^@]*\)@github\.com.*|\1|p')
+            fi
+          fi
+
+          # Also check for .github-token file (alternative location)
+          if [[ -z "${GITHUB_TOKEN}" && -f "${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/.github-token" ]]; then
+            echo "Found .github-token file" >&2
+            GITHUB_TOKEN=$(cat "${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/.github-token")
+          fi
+        fi
+
+        if [[ -n "${GITHUB_TOKEN}" ]]; then
+          echo "Using authenticated GitHub API (token length: ${#GITHUB_TOKEN} chars)" >&2
+          # Try with 'token' prefix first (classic format)
+          PR_DATA=$(curl -sS -H "Authorization: token ${GITHUB_TOKEN}" "${GITHUB_API_URL}" 2>&1)
+
+          # If that fails with 401, try with 'Bearer' prefix
+          if echo "${PR_DATA}" | grep -q "Bad credentials\|Requires authentication"; then
+            echo "Classic token auth failed, trying Bearer format..." >&2
+            PR_DATA=$(curl -sS -H "Authorization: Bearer ${GITHUB_TOKEN}" "${GITHUB_API_URL}" 2>&1)
+          fi
+
+          # Check if still failing
+          if echo "${PR_DATA}" | grep -q "Bad credentials\|Requires authentication"; then
+            echo "ERROR: GitHub authentication failed with provided token" >&2
+            echo "Response: ${PR_DATA:0:200}" >&2
+            echo "Falling back to unauthenticated API..." >&2
+            PR_DATA=$(curl -sSf "${GITHUB_API_URL}" 2>&1)
+          fi
+        else
+          echo "⚠️  WARNING: No GitHub authentication found, using unauthenticated API (rate limited)" >&2
+          PR_DATA=$(curl -sSf "${GITHUB_API_URL}" 2>&1)
+        fi
+
+        if [[ -z "${PR_DATA}" ]]; then
+          echo "⚠️  WARNING: Failed to fetch PR description from GitHub API" >&2
+          echo "   Falling back to single-PR mode" >&2
+          echo -n "false" > "$(results.has-group-config.path)"
+          echo -n "" > "$(results.invalid-repo-warnings.path)"
+          echo -n "" > "$(results.format-help-warning.path)"
+          # Return components for current repo only
+          COMPONENTS=$(echo "${COMPONENT_MAP}" | jq -c --arg repo "${REPO_NAME}" '.[$repo]')
+          echo -n "${COMPONENTS}" > "$(results.group-components.path)"
+          exit 0
+        fi
+
+        PR_BODY=$(echo "${PR_DATA}" | jq -r '.body // ""')
+        echo "PR description fetched successfully" >&2
+
+        # Remove Windows line endings (CR) if present
+        PR_BODY=$(echo "${PR_BODY}" | tr -d '\r')
+
+        # --- Search for Early Gate section (## heading containing "earlygate") ---
+        echo "Searching for Early Gate section in PR description..." >&2
+
+        # Check if there's a markdown heading containing "earlygate" (case-insensitive)
+        if ! echo "${PR_BODY}" | grep -qi "^#.*${EARLYGATE_SECTION_PATTERN}"; then
+          echo "No Early Gate section found in PR description" >&2
+          echo "Using single-PR mode (repo: ${REPO_NAME}, pr: ${PR_NUMBER})" >&2
+          echo -n "false" > "$(results.has-group-config.path)"
+          echo -n "" > "$(results.invalid-repo-warnings.path)"
+
+          # --- Check for common mistakes and provide helpful guidance ---
+          FORMAT_HELP=""
+
+          # Check 1: "earlygate" mentioned but not in a heading
+          if echo "${PR_BODY}" | grep -qi "${EARLYGATE_SECTION_PATTERN}"; then
+            echo "Found 'earlygate' mention but not in a markdown heading" >&2
+            FORMAT_HELP="## ⚠️ Group Testing Format Issue"$'\n\n'"Found \`earlygate\` mentioned in your PR description, but it's not in the correct format for group testing."$'\n\n'"**To enable group testing, use this format:**"$'\n\n'"\`\`\`markdown"$'\n'"## Early Gate Testing"$'\n'"https://github.com/opendatahub-io/REPO/pull/NUMBER"$'\n'"\`\`\`"$'\n\n'"**Requirements:**"$'\n'"- Must be a markdown heading (# or ##) containing \"earlygate\""$'\n'"- Only PRs from \`opendatahub-io\` organization"$'\n\n'"See [Group Testing](https://github.com/opendatahub-io/odh-konflux-central/blob/main/early-gate/docs/early-gate-user-guide.md#7-group-testing-multi-pr) in the user guide for details."
+          else
+            # Check 2: GitHub PR URLs found in description
+            if echo "${PR_BODY}" | grep -q "https://github.com/opendatahub-io/[^/]*/pull/[0-9]"; then
+              echo "Found opendatahub-io PR URLs but not marked for group testing" >&2
+              FORMAT_HELP="## ℹ️ Group Testing Available"$'\n\n'"Found GitHub PR URLs in your description. If you want to test these PRs together, use group testing:"$'\n\n'"**Format:**"$'\n'"\`\`\`markdown"$'\n'"## Early Gate Testing"$'\n'"https://github.com/opendatahub-io/REPO/pull/NUMBER"$'\n'"\`\`\`"$'\n\n'"See [Group Testing](https://github.com/opendatahub-io/odh-konflux-central/blob/main/early-gate/docs/early-gate-user-guide.md#7-group-testing-multi-pr) in the user guide for details."
+            fi
+          fi
+
+          echo -n "${FORMAT_HELP}" > "$(results.format-help-warning.path)"
+
+          # Return components for current repo only
+          COMPONENTS=$(echo "${COMPONENT_MAP}" | jq -c --arg repo "${REPO_NAME}" '.[$repo]')
+          if [[ -z "${COMPONENTS}" || "${COMPONENTS}" == "null" ]]; then
+            echo "ERROR: No entry found for REPO_NAME=${REPO_NAME} in component_repo_map.json" >&2
+            exit 1
+          fi
+          echo -n "${COMPONENTS}" > "$(results.group-components.path)"
+          exit 0
+        fi
+
+        echo "✓ Early Gate section found" >&2
+        echo -n "true" > "$(results.has-group-config.path)"
+        echo -n "" > "$(results.format-help-warning.path)"  # No format help needed
+
+        # --- Extract PR URLs from Early Gate section ---
+        # Find the section and extract URLs until the next ## heading
+        # Allow optional whitespace and bullets/dashes before URLs
+        PR_URLS=$(echo "${PR_BODY}" | awk -v IGNORECASE=1 "
+          /^#+.*${EARLYGATE_SECTION_PATTERN}/ { found=1; next }
+          found && /^#+/ { exit }
+          found && /https:\/\/github\.com\/[^\/]+\/[^\/]+\/pull\/[0-9]+/ {
+            match(\$0, /https:\/\/github\.com\/[^\/]+\/[^\/]+\/pull\/[0-9]+/)
+            print substr(\$0, RSTART, RLENGTH)
+          }
+        " || true)
+
+        if [[ -z "${PR_URLS}" ]]; then
+          echo "⚠️  WARNING: No PR URLs found in Early Gate section" >&2
+          echo "   Falling back to single-PR mode" >&2
+          echo -n "false" > "$(results.has-group-config.path)"
+          echo -n "" > "$(results.invalid-repo-warnings.path)"
+          FORMAT_HELP="## ⚠️ Empty Early Gate Section"$'\n\n'"Found an Early Gate section in your PR description, but no PR URLs were listed."$'\n\n'"**Add PR URLs like this:**"$'\n'"\`\`\`markdown"$'\n'"## Early Gate Testing"$'\n'"https://github.com/opendatahub-io/REPO/pull/NUMBER"$'\n'"\`\`\`"$'\n\n'"See [Group Testing](https://github.com/opendatahub-io/odh-konflux-central/blob/main/early-gate/docs/early-gate-user-guide.md#7-group-testing-multi-pr) in the user guide for details."
+          echo -n "${FORMAT_HELP}" > "$(results.format-help-warning.path)"
+          COMPONENTS=$(echo "${COMPONENT_MAP}" | jq -c --arg repo "${REPO_NAME}" '.[$repo]')
+          echo -n "${COMPONENTS}" > "$(results.group-components.path)"
+          exit 0
+        fi
+
+        echo "Found PR URLs:" >&2
+        echo "${PR_URLS}" >&2
+
+        # --- ALWAYS include leader PR's components first ---
+        echo "" >&2
+        echo "=== Resolving Components ===" >&2
+        echo "Step 1: Adding leader PR components (${REPO_NAME} #${PR_NUMBER})..." >&2
+        TEMP_COMPONENTS=$(mktemp)
+        echo "{}" > "${TEMP_COMPONENTS}"
+
+        # Initialize warnings tracking
+        WARNINGS=""
+
+        # Get leader PR components with PR metadata
+        LEADER_COMPONENTS=$(echo "${COMPONENT_MAP}" | jq -c --arg repo "${REPO_NAME}" '.[$repo]')
+        if [[ -n "${LEADER_COMPONENTS}" && "${LEADER_COMPONENTS}" != "null" ]]; then
+          LEADER_COMPONENTS_WITH_PR=$(echo "${LEADER_COMPONENTS}" | jq -c --arg pr "${PR_NUMBER}" '
+            to_entries |
+            map({
+              key: .key,
+              value: {
+                quay_path: .value,
+                pr: $pr
+              }
+            }) |
+            from_entries
+          ')
+          NUM_LEADER=$(echo "${LEADER_COMPONENTS_WITH_PR}" | jq 'length')
+          echo "✓ Added ${NUM_LEADER} components from leader PR #${PR_NUMBER}" >&2
+          echo "${LEADER_COMPONENTS_WITH_PR}" > "${TEMP_COMPONENTS}"
+        else
+          echo "⚠️  WARNING: No components found for leader repo: ${REPO_NAME}" >&2
+          echo "   This is unusual - verify component_repo_map.json has an entry for ${REPO_NAME}" >&2
+        fi
+
+        # --- Parse each collaborator PR URL and add their components ---
+        echo "" >&2
+        echo "Step 2: Adding collaborator PR components..." >&2
+        while IFS= read -r url; do
+          echo "Processing collaborator URL: ${url}" >&2
+
+          # Extract org/repo/pr from URL
+          # Format: https://github.com/{org}/{repo}/pull/{number}
+          if [[ ! "${url}" =~ ^https://github\.com/([^/]+)/([^/]+)/pull/([0-9]+)$ ]]; then
+            echo "⚠️  WARNING: Invalid PR URL format: ${url}" >&2
+            echo "   Skipping this entry" >&2
+            continue
+          fi
+
+          ORG="${BASH_REMATCH[1]}"
+          REPO="${BASH_REMATCH[2]}"
+          PR="${BASH_REMATCH[3]}"
+
+          echo "  Org: ${ORG}" >&2
+          echo "  Repo: ${REPO}" >&2
+          echo "  PR: ${PR}" >&2
+
+          # Security check: Only allow PRs from opendatahub-io organization
+          if [[ "${ORG}" != "${ALLOWED_ORG}" ]]; then
+            echo "⚠️  WARNING: PR from unauthorized organization: ${ORG}" >&2
+            echo "   Only PRs from ${ALLOWED_ORG} are allowed" >&2
+            echo "   Skipping this entry" >&2
+            # Track warning for PR comment
+            WARNING_MSG="⚠️ PR from \`${ORG}/${REPO}\` (#${PR}) was skipped - only PRs from \`${ALLOWED_ORG}\` organization are allowed."
+            if [[ -z "${WARNINGS}" ]]; then
+              WARNINGS="${WARNING_MSG}"
+            else
+              WARNINGS="${WARNINGS}"$'\n'"${WARNING_MSG}"
+            fi
+            continue
+          fi
+
+          # Lookup components for this repo in component_repo_map.json
+          REPO_COMPONENTS=$(echo "${COMPONENT_MAP}" | jq -c --arg repo "${REPO}" '.[$repo]')
+
+          if [[ -z "${REPO_COMPONENTS}" || "${REPO_COMPONENTS}" == "null" ]]; then
+            echo "⚠️  WARNING: No components found for repo: ${REPO}" >&2
+            echo "   Skipping this repo" >&2
+            # Track warning for PR comment
+            WARNING_MSG="⚠️ Repo \`${ORG}/${REPO}\` from PR #${PR} is not configured for early-gate testing and was skipped."
+            if [[ -z "${WARNINGS}" ]]; then
+              WARNINGS="${WARNING_MSG}"
+            else
+              WARNINGS="${WARNINGS}"$'\n'"${WARNING_MSG}"
+            fi
+            continue
+          fi
+
+          echo "  Found components for ${REPO}" >&2
+
+          # Add PR metadata to each component
+          # Transform: {"comp1": "path1", "comp2": "path2"}
+          # To: {"comp1": {"quay_path": "path1", "pr": "123"}, "comp2": {...}}
+          REPO_COMPONENTS_WITH_PR=$(echo "${REPO_COMPONENTS}" | jq -c --arg pr "${PR}" '
+            to_entries |
+            map({
+              key: .key,
+              value: {
+                quay_path: .value,
+                pr: $pr
+              }
+            }) |
+            from_entries
+          ')
+
+          echo "  Components with PR metadata:" >&2
+          echo "  ${REPO_COMPONENTS_WITH_PR}" >&2
+
+          # Merge into accumulated components
+          jq -s '.[0] * .[1]' "${TEMP_COMPONENTS}" <(echo "${REPO_COMPONENTS_WITH_PR}") > "${TEMP_COMPONENTS}.tmp"
+          mv "${TEMP_COMPONENTS}.tmp" "${TEMP_COMPONENTS}"
+
+        done <<< "${PR_URLS}"
+
+        # --- Output final components JSON ---
+        FINAL_COMPONENTS=$(cat "${TEMP_COMPONENTS}")
+
+        if [[ "${FINAL_COMPONENTS}" == "{}" ]]; then
+          echo "⚠️  WARNING: No valid components resolved from group configuration" >&2
+          echo "   Falling back to single-PR mode" >&2
+          echo -n "false" > "$(results.has-group-config.path)"
+          echo -n "" > "$(results.invalid-repo-warnings.path)"
+          echo -n "" > "$(results.format-help-warning.path)"
+          COMPONENTS=$(echo "${COMPONENT_MAP}" | jq -c --arg repo "${REPO_NAME}" '.[$repo]')
+          echo -n "${COMPONENTS}" > "$(results.group-components.path)"
+        else
+          echo "✓ Group components resolved successfully:" >&2
+          echo "${FINAL_COMPONENTS}" | jq '.' >&2
+          echo -n "${FINAL_COMPONENTS}" > "$(results.group-components.path)"
+
+          # Output warnings if any
+          if [[ -n "${WARNINGS}" ]]; then
+            echo "" >&2
+            echo "⚠️  Invalid repo warnings:" >&2
+            echo "${WARNINGS}" >&2
+          fi
+          echo -n "${WARNINGS}" > "$(results.invalid-repo-warnings.path)"
+        fi
+
+        # Cleanup
+        rm -f "${TEMP_COMPONENTS}"
+
+        echo "=== Resolution complete ===" >&2

--- a/early-gate/tasks/trigger-test-pipeline.yaml
+++ b/early-gate/tasks/trigger-test-pipeline.yaml
@@ -47,6 +47,10 @@ spec:
     description: "When true, intermediate PR comments include a note that they will be replaced"
     type: string
     default: "false"
+  - name: repositories
+    description: "Comma-separated list of repository names for group testing (e.g., 'kserve,feast')"
+    type: string
+    default: ""
   results:
   - name: queue-url
     description: Relative Jenkins queue path for the triggered job (e.g. /queue/item/12345)
@@ -89,6 +93,8 @@ spec:
       value: $(params.trigger-workflow-file)
     - name: DELETE_INTERMEDIATE_COMMENTS
       value: $(params.delete-intermediate-comments)
+    - name: REPOSITORIES
+      value: $(params.repositories)
     script: |
       #!/bin/bash
       set -euo pipefail
@@ -103,11 +109,19 @@ spec:
       WORKFLOW_REPO_NAME="${WORKFLOW_REPO##*/}"
 
       REPO_NAME="${REPO}"
+
+      # Use repositories from group config if available, otherwise just the current repo
+      if [[ -n "${REPOSITORIES}" ]]; then
+        REPOS_LIST="${REPOSITORIES}"
+      else
+        REPOS_LIST="${REPO_NAME}"
+      fi
+
       FBC_TAG="odh-pr-${PR_NUMBER}-${REPO_NAME}"
       CORRELATION_ID="eg-$(date +%s)"
 
       echo "Triggering early-gate test pipeline for PR #${PR_NUMBER}"
-      echo "Repo: ${REPO_NAME}, FBC tag: ${FBC_TAG}, Correlation ID: ${CORRELATION_ID}"
+      echo "Leader repo: ${REPO_NAME}, All repos: ${REPOS_LIST}, FBC tag: ${FBC_TAG}, Correlation ID: ${CORRELATION_ID}"
 
       # ---------------------------------------------------------------
       # Helper: GitHub API calls with separate tokens per operation type
@@ -145,7 +159,7 @@ spec:
       gh_workflow_api POST \
         "https://api.github.com/repos/${WORKFLOW_REPO}/actions/workflows/${TRIGGER_WORKFLOW}/dispatches" \
         -d "{\"ref\":\"main\",\"inputs\":{
-          \"repositories\":\"${REPO_NAME}\",
+          \"repositories\":\"${REPOS_LIST}\",
           \"fbc_tag\":\"${FBC_TAG}\",
           \"pr_number\":\"${PR_NUMBER}\",
           \"correlation_id\":\"${CORRELATION_ID}\"


### PR DESCRIPTION
## Summary

- Add group testing support to early gate pipelines, enabling multi-PR testing across repositories
- Teams can test related PRs together by adding an `## Early Gate Testing` heading with collaborator PR URLs in their leader PR description
- The pipeline automatically resolves components, queries Quay for PR images (with fallback to stable), builds a combined snapshot, and posts a group testing summary on the PR

## Changes

### New tasks
- **`resolve-group-configuration`** — reads PR description via GitHub API, detects Early Gate heading, extracts collaborator PR URLs, resolves components from `component_repo_map.json`, and outputs group-components JSON
- **`check-group-config`** — lightweight version for the test pipeline that extracts repository names for Jenkins trigger
- **`post-build-complete-comment`** — consolidated build completion + group testing summary into a single PR comment

### Pipeline changes
- **Component & operator pipelines** — added `resolve-group-configuration` task before `generate-snapshot`, wired group testing results through to `post-build-complete-comment`
- **Test pipeline** — added `check-group-config` task, passes repository list to `trigger-test-pipeline` for Jenkins
- **`generate-snapshot-for-group-testing`** — updated to handle new format with per-component PR metadata, tracks fallback warnings and component table for PR comment
- **`trigger-test-pipeline`** — accepts `repositories` param for group testing

### Docs
- **User guide** — added Section 7 (Group Testing) with configuration, examples, PR comment format, best practices, and troubleshooting. Updated limitations, future plans, and FAQ
- **Design doc** — added `early-gate-group-testing-design.md` covering architecture, detection format, image resolution, error handling

### Key design decisions
- Heading-based detection (any `#`/`##`/`###` containing "earlygate", case-insensitive) — flexible, no strict format rules
- Leader PR is always auto-included — only collaborator PRs need to be listed
- Graceful fallback to stable images when PR builds haven't completed
- Format help warnings posted on PR when common config mistakes are detected
- `enable-early-gate-testing` default set to `false` (test pipeline triggering controlled separately)

## Test plan
- [ ] Single PR without group config — verify pipeline runs in single-PR mode (no behavior change)
- [ ] PR with `## Early Gate Testing` heading and valid collaborator URLs — verify group snapshot is built with all PR images
- [ ] PR with collaborator whose build hasn't completed — verify fallback to `odh-stable` with warning
- [ ] PR with invalid repo in config — verify warning posted, valid repos still processed
- [ ] PR with "earlygate" mentioned but not in heading — verify format help comment posted
- [ ] Re-trigger with `/early-gate-build` — verify idempotent behavior