### PR TITLE
feat: support $$PATH_CONTEXT$$ substitution in odh-konflux-onboarder

### DIFF
--- a/.github/workflows/odh-konflux-onboarder.yml
+++ b/.github/workflows/odh-konflux-onboarder.yml
@@ -105,6 +105,17 @@ on:
         required: false
         type: string
 
+      path_context:
+        description: >
+          Build context path relative to the repo root (e.g. "src/myservice/").
+          Replaces the $$PATH_CONTEXT$$ placeholder in pipeline templates.
+          Use this when all templates for the component share the same context path.
+          For components where each template has a different context path, set the
+          path directly in the template file instead of using this input.
+          Defaults to "." (repo root).
+        required: false
+        type: string
+
 jobs:
   update-tekton-pipelines-and-create-pr:
     runs-on: ubuntu-latest
@@ -143,6 +154,14 @@ jobs:
           fi
 
           echo "BUILD_BRANCH=$BUILD_BRANCH" >> $GITHUB_ENV
+
+      - name: Resolve path context
+        run: |
+          if [ -n "${{ inputs.path_context }}" ]; then
+            echo "PATH_CONTEXT=${{ inputs.path_context }}" >> $GITHUB_ENV
+          else
+            echo "PATH_CONTEXT=." >> $GITHUB_ENV
+          fi
 
       - name: Validate and set tag
         run: |
@@ -221,6 +240,7 @@ jobs:
 
                 sed -i -E 's|\$\$OUTPUT_IMAGE_TAG\$\$|'"${EFFECTIVE_TAG}"'|g' "$target_file"
                 sed -i -E 's|\$\$TARGET_BRANCH\$\$|'"${TARGET_BRANCH}"'|g' "$target_file"
+                sed -i -E 's|\$\$PATH_CONTEXT\$\$|'"${PATH_CONTEXT}"'|g' "$target_file"
                 # CI-only: Replace BUILD_MODE placeholder with RHOAI
                 sed -i -E 's|\$\$BUILD_MODE\$\$|RHOAI|g' "$target_file"
 
@@ -233,6 +253,7 @@ jobs:
 
                 sed -i -E 's|\$\$OUTPUT_IMAGE_TAG\$\$|'"${EFFECTIVE_TAG}"'|g' "$target_file"
                 sed -i -E 's|\$\$TARGET_BRANCH\$\$|'"${TARGET_BRANCH}"'|g' "$target_file"
+                sed -i -E 's|\$\$PATH_CONTEXT\$\$|'"${PATH_CONTEXT}"'|g' "$target_file"
                 sed -i -E 's|\$\$BUILD_TYPE\$\$|'"${{ inputs.build_type }}"'|g' "$target_file"
                 # CI-only: Replace BUILD_MODE placeholder with RHOAI
                 sed -i -E 's|\$\$BUILD_MODE\$\$|RHOAI|g' "$target_file"
@@ -275,6 +296,7 @@ jobs:
               sed -i -E 's|(name: .*)-on-push|\1-on-release-push|' "$target_file"
               sed -i -E 's|\$\$OUTPUT_IMAGE_TAG\$\$|'"${VERSION}"'|g' "$target_file"
               sed -i -E 's|\$\$TARGET_BRANCH\$\$|'"${TARGET_BRANCH}"'|g' "$target_file"
+              sed -i -E 's|\$\$PATH_CONTEXT\$\$|'"${PATH_CONTEXT}"'|g' "$target_file"
               sed -i -E 's|\$\$BUILD_TYPE\$\$|'"${{ inputs.build_type }}"'|g' "$target_file"
               sed -i -E 's|Dockerfiles/rhoai\.Dockerfile|Dockerfiles/Dockerfile|g' "$target_file"
               # Release-only: Remove BUILD_MODE parameter entirely
@@ -308,6 +330,7 @@ jobs:
                 # Apply standard substitutions
                 sed -i -E 's|\$\$OUTPUT_IMAGE_TAG\$\$|'"${VERSION}"'|g' "$target_file"
                 sed -i -E 's|\$\$TARGET_BRANCH\$\$|'"${TARGET_BRANCH}"'|g' "$target_file"
+                sed -i -E 's|\$\$PATH_CONTEXT\$\$|'"${PATH_CONTEXT}"'|g' "$target_file"
                 sed -i -E 's|\$\$BUILD_TYPE\$\$|'"${{ inputs.build_type }}"'|g' "$target_file"
                 sed -i -E 's|\$\$VERSION\$\$|'"${VERSION_VALUE}"'|g' "$target_file"
 


### PR DESCRIPTION
## Problem

The `odh-konflux-onboarder` workflow had no way to set `path-context` in the generated Tekton
pipeline files. The value in each template was copied verbatim, with no substitution token, so
any template created with `path-context: .` stayed that way regardless of where the component's
Dockerfile actually lived (e.g. `images/universal/training/th-torch-cpu-py312/`).

This caused Konflux pull-request checks to fail for components whose Dockerfiles are in a
subdirectory, as buildah couldn't find the Dockerfile at the repo root.

## Changes

- Adds an optional `path_context` workflow input (defaults to `.`)
- Adds a `Resolve path context` step that sets the `PATH_CONTEXT` env var
- Adds `$$PATH_CONTEXT$$` → `PATH_CONTEXT` sed substitution in all four pipeline-processing
  branches: CI pull, CI push, Release push, and opendatahub-operator release bundle/FBC

## Usage

For components with a single Dockerfile path shared across all templates, pass `path_context`
at dispatch time:

```
path_context: src/myservice/
```

For components where each template has a **different** context path (e.g. `distributed-workloads`
with cpu/cuda/rocm variants), set the path directly in each template file instead of using
this input.  Templates that do not contain `$$PATH_CONTEXT$$` are unaffected by this change.

Made with [Cursor](https://cursor.com)