### PR TITLE
chore: remove leftover template comments from th-torch pull-request pipelines

### DIFF
--- a/pipelineruns/distributed-workloads/odh-th-torch-cpu-py312-pull-request.yaml
+++ b/pipelineruns/distributed-workloads/odh-th-torch-cpu-py312-pull-request.yaml
@@ -28,7 +28,6 @@ spec:
     value: Dockerfile
   - name: path-context
     value: images/universal/training/th-torch-cpu-py312
-  #add these additional params
   - name: additional-tags
     value:
     - 'odh-pr-{{revision}}'

--- a/pipelineruns/distributed-workloads/odh-th-torch-cuda-py312-pull-request.yaml
+++ b/pipelineruns/distributed-workloads/odh-th-torch-cuda-py312-pull-request.yaml
@@ -28,7 +28,6 @@ spec:
     value: Dockerfile
   - name: path-context
     value: images/universal/training/th-torch-cuda-py312
-  #add these additional params
   - name: additional-tags
     value:
     - 'odh-pr-{{revision}}'

--- a/pipelineruns/distributed-workloads/odh-th-torch-rocm-py312-pull-request.yaml
+++ b/pipelineruns/distributed-workloads/odh-th-torch-rocm-py312-pull-request.yaml
@@ -28,7 +28,6 @@ spec:
     value: Dockerfile
   - name: path-context
     value: images/universal/training/th-torch-rocm-py312
-  #add these additional params
   - name: additional-tags
     value:
     - 'odh-pr-{{revision}}'


### PR DESCRIPTION
Removes the `#add these additional params` comment that was a template authoring note and should not be present in the pipeline files.

Made with [Cursor](https://cursor.com)