### PR TITLE
feat: add --signoff flag to onboarder commits

### DIFF
--- a/.github/workflows/odh-konflux-onboarder.yml
+++ b/.github/workflows/odh-konflux-onboarder.yml
@@ -473,7 +473,7 @@ jobs:
 
           fi
 
-          git commit -F commit_message.txt
+          git commit --signoff -F commit_message.txt
           git push --set-upstream origin "$branch_name"
 
           echo "commit=true" >> $GITHUB_ENV


### PR DESCRIPTION
## Summary
- Adds the `-s` (signoff) flag to the `git commit` command in the odh-konflux-onboarder workflow
- This ensures all commits created by the onboarder in component repos include the `Signed-off-by` trailer required by DCO checks

## Test plan
- [ ] Trigger the onboarder workflow for a test component and verify the resulting commit includes the `Signed-off-by` trailer
- [ ] Confirm DCO Sign-off Check passes on the resulting PR

Fixes: RHOAIENG-81192

Made with [Cursor](https://cursor.com)