### PR TITLE
Add openshell CLI component pipelineruns

### DIFF
--- a/config/component_repo_map.json
+++ b/config/component_repo_map.json
@@ -198,6 +198,7 @@
     "odh-operator-ci": "opendatahub/opendatahub-operator"
   },
   "openshell": {
+    "odh-openshell-cli-ci": "opendatahub/odh-openshell-cli",
     "odh-openshell-gateway-ci": "opendatahub/odh-openshell-gateway",
     "odh-openshell-supervisor-ci": "opendatahub/odh-openshell-supervisor"
   },

--- a/pipelineruns/openshell/odh-openshell-cli-pull-request.yaml
+++ b/pipelineruns/openshell/odh-openshell-cli-pull-request.yaml
@@ -1,0 +1,64 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/openshell?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
+      == "$$TARGET_BRANCH$$"
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: opendatahub-builds
+    appstudio.openshift.io/component: odh-openshell-cli-ci
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-openshell-cli-on-pull-request
+  namespace: open-data-hub-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/opendatahub/odh-openshell-cli:$$OUTPUT_IMAGE_TAG$$
+  - name: dockerfile
+    value: deploy/docker/Dockerfile.konflux.cli
+  - name: path-context
+    value: .
+  - name: hermetic
+    value: "true"
+  - name: build-platforms
+    value:
+    - linux/x86_64
+    - linux/arm64
+  - name: prefetch-input
+    value: |
+      [
+        {"type": "cargo", "path": "."},
+        {"type": "rpm", "path": "deploy/konflux/cli"},
+        {"type": "generic", "path": "deploy/konflux/cli", "lockfile": "generic-fetcher.yaml"}
+      ]
+  - name: additional-tags
+    value:
+    - 'odh-pr-{{revision}}'
+  - name: pipeline-type
+    value: pull-request
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/opendatahub-io/odh-konflux-central.git
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipeline/multi-arch-container-build.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-odh-openshell-cli-ci
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/pipelineruns/openshell/odh-openshell-cli-push.yaml
+++ b/pipelineruns/openshell/odh-openshell-cli-push.yaml
@@ -1,0 +1,60 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+#
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/openshell?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "$$TARGET_BRANCH$$"
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: opendatahub-builds
+    appstudio.openshift.io/component: odh-openshell-cli-ci
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-openshell-cli-on-push
+  namespace: open-data-hub-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/opendatahub/odh-openshell-cli:$$OUTPUT_IMAGE_TAG$$
+  - name: dockerfile
+    value: deploy/docker/Dockerfile.konflux.cli
+  - name: path-context
+    value: .
+  - name: hermetic
+    value: "true"
+  - name: build-platforms
+    value:
+    - linux/x86_64
+    - linux/arm64
+  - name: prefetch-input
+    value: |
+      [
+        {"type": "cargo", "path": "."},
+        {"type": "rpm", "path": "deploy/konflux/cli"},
+        {"type": "generic", "path": "deploy/konflux/cli", "lockfile": "generic-fetcher.yaml"}
+      ]
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/opendatahub-io/odh-konflux-central.git
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipeline/multi-arch-container-build.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-odh-openshell-cli-ci
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/pipelineruns/openshell/odh-openshell-cli-tag.yaml
+++ b/pipelineruns/openshell/odh-openshell-cli-tag.yaml
@@ -1,0 +1,64 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+#
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/openshell?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "push"
+      && target_branch.matches("^refs/tags/v[0-9]+\\.[0-9]+\\.[0-9]+-rhaiv\\.[0-9]+$")
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: opendatahub-builds
+    appstudio.openshift.io/component: odh-openshell-cli-ci
+    pipelines.appstudio.openshift.io/type: build
+  name: odh-openshell-cli-on-tag
+  namespace: open-data-hub-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/opendatahub/odh-openshell-cli:{{git_tag}}
+  - name: dockerfile
+    value: deploy/docker/Dockerfile.konflux.cli
+  - name: path-context
+    value: .
+  - name: hermetic
+    value: "true"
+  - name: build-platforms
+    value:
+    - linux/x86_64
+    - linux/arm64
+  - name: prefetch-input
+    value: |
+      [
+        {"type": "cargo", "path": "."},
+        {"type": "rpm", "path": "deploy/konflux/cli"},
+        {"type": "generic", "path": "deploy/konflux/cli", "lockfile": "generic-fetcher.yaml"}
+      ]
+  - name: build-args
+    value:
+    - "OPENSHELL_VERSION={{git_tag}}"
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/opendatahub-io/odh-konflux-central.git
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipeline/multi-arch-container-build.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-odh-openshell-cli-ci
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}


### PR DESCRIPTION
## Summary
- Add PipelineRun definitions for `odh-openshell-cli` (pull-request, push, tag triggers)
- Register `odh-openshell-cli-ci` component in `component_repo_map.json`
- Mirrors existing supervisor pattern: standard build platforms (`linux/x86_64`, `linux/arm64`), hermetic build with cargo + RPM + generic prefetch
- Tag builds pass `OPENSHELL_VERSION={{git_tag}}` as build-arg for version stamping

## Related
- Depends on opendatahub-io/openshell#22 (Dockerfile and prefetch configs in the openshell repo)
- Context: CLI removed from Python wheel (NVIDIA/OpenShell#2321), now ships as standalone container