### PR TITLE
Add GOTOOLCHAIN environment variable to trustyai-service-operator integration tests pipeline

### DIFF
--- a/integration-tests/trustyai-service-operator/pr-testing-pipeline.yaml
+++ b/integration-tests/trustyai-service-operator/pr-testing-pipeline.yaml
@@ -245,6 +245,8 @@ spec:
                 value: "/credentials/$(steps.get-kubeconfig.results.kubeconfig)"
               - name: GOMEMLIMIT
                 value: "10GiB"
+              - name: GOTOOLCHAIN
+                value: "auto"
               - name: TRUSTYAI_OPERATOR_IMAGE
                 value: $(params.trustyai-operator-image)
               - name: ARTIFACT_DIR


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
attending to failure here https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/open-data-hub-tenant/applications/opendatahub-builds/pipelineruns/trustyai-service-operator-its-hxrg5?integrationTestName=trustyai-service-operator-its

Error: load packages in root "/workspace/source": err: exit status 1: stderr: go: go.mod requires go >= 1.26.5 (running go 1.26.3; GOTOOLCHAIN=local)

  
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
