### PR TITLE
fix(early-gate): fail loudly on GitHub API errors in check-group-config

### DIFF
--- a/early-gate/tasks/check-group-config.yaml
+++ b/early-gate/tasks/check-group-config.yaml
@@ -41,10 +41,15 @@ spec:
         GITHUB_API_URL="https://api.github.com/repos/${GITHUB_ORG}/${REPO_NAME}/pulls/${PR_NUMBER}"
 
         # Unauthenticated call (rate limited but sufficient for most cases)
-        PR_DATA=$(curl -sSf "${GITHUB_API_URL}" 2>&1 || echo "")
+        if ! PR_DATA=$(curl -sSf "${GITHUB_API_URL}" 2>/tmp/curl_err); then
+          echo "ERROR: Failed to fetch PR description from GitHub API" >&2
+          echo "  URL: ${GITHUB_API_URL}" >&2
+          echo "  curl error: $(cat /tmp/curl_err)" >&2
+          exit 1
+        fi
 
         if [[ -z "${PR_DATA}" ]]; then
-          echo "Failed to fetch PR description" >&2
+          echo "WARNING: GitHub API returned empty response — skipping group config check" >&2
           echo -n "false" > "$(results.has-group-config.path)"
           echo -n "${REPO_NAME}" > "$(results.repositories.path)"
           exit 0


### PR DESCRIPTION
The curl error handling captured stderr into stdout via 2>&1, causing jq to choke on the curl error message instead of valid JSON. Fix by redirecting stderr to a temp file and checking the exit code properly.

Now the task fails with a clear error when the API call fails (e.g. rate limiting) instead of silently producing a jq parse error.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
