### PR TITLE
fix(early-gate): use authenticated GitHub API in check-group-config

### DIFF
--- a/early-gate/early-gate-test-pipeline.yaml
+++ b/early-gate/early-gate-test-pipeline.yaml
@@ -116,6 +116,9 @@ spec:
   - name: check-group-config
     runAfter:
     - check-prerequisites
+    workspaces:
+    - name: basic-auth
+      workspace: git-auth
     taskRef:
       resolver: git
       params:
@@ -304,3 +307,7 @@ spec:
       value: $(params.jenkins-url-secret-name)
     - name: jenkins-url-secret-key
       value: $(params.jenkins-url-secret-key)
+
+  workspaces:
+  - name: git-auth
+    optional: true

--- a/early-gate/tasks/check-group-config.yaml
+++ b/early-gate/tasks/check-group-config.yaml
@@ -6,6 +6,10 @@ spec:
   description: |
     Extracts repository names from Early Gate Testing section in PR description
     for passing to Jenkins trigger workflow
+  workspaces:
+    - name: basic-auth
+      description: Workspace containing .git-credentials for authenticated GitHub API calls
+      optional: true
   results:
     - name: repositories
       description: Comma-separated list of repository names (leader + collaborators)
@@ -25,6 +29,10 @@ spec:
               fieldPath: metadata.labels['pipelinesascode.tekton.dev/url-repository']
         - name: GITHUB_ORG
           value: "opendatahub-io"
+        - name: WORKSPACE_BASIC_AUTH_DIRECTORY_BOUND
+          value: $(workspaces.basic-auth.bound)
+        - name: WORKSPACE_BASIC_AUTH_DIRECTORY_PATH
+          value: $(workspaces.basic-auth.path)
       script: |
         #!/bin/bash
         set -e
@@ -40,12 +48,63 @@ spec:
         echo "Fetching PR description from GitHub..." >&2
         GITHUB_API_URL="https://api.github.com/repos/${GITHUB_ORG}/${REPO_NAME}/pulls/${PR_NUMBER}"
 
-        # Unauthenticated call (rate limited but sufficient for most cases)
-        if ! PR_DATA=$(curl -sSf "${GITHUB_API_URL}" 2>/tmp/curl_err); then
-          echo "ERROR: Failed to fetch PR description from GitHub API" >&2
-          echo "  URL: ${GITHUB_API_URL}" >&2
-          echo "  curl error: $(cat /tmp/curl_err)" >&2
-          exit 1
+        # Extract GitHub token from workspace if available
+        GITHUB_TOKEN=""
+        if [[ "${WORKSPACE_BASIC_AUTH_DIRECTORY_BOUND}" == "true" ]]; then
+          echo "Checking for GitHub token in workspace..." >&2
+          if [[ -f "${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/.git-credentials" ]]; then
+            echo "Found .git-credentials file" >&2
+            # Format examples:
+            # https://TOKEN:x-oauth-basic@github.com
+            # https://x-access-token:TOKEN@github.com
+            # https://username:TOKEN@github.com
+            CREDS_LINE=$(cat "${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/.git-credentials" | grep github.com | head -1)
+
+            # Pattern 1: https://TOKEN:x-oauth-basic@github.com
+            GITHUB_TOKEN=$(echo "${CREDS_LINE}" | sed -n 's|https://\([^:]*\):x-oauth-basic@github\.com.*|\1|p')
+
+            # Pattern 2: https://x-access-token:TOKEN@github.com
+            if [[ -z "${GITHUB_TOKEN}" ]]; then
+              GITHUB_TOKEN=$(echo "${CREDS_LINE}" | sed -n 's|https://x-access-token:\([^@]*\)@github\.com.*|\1|p')
+            fi
+
+            # Pattern 3: https://username:TOKEN@github.com (any username)
+            if [[ -z "${GITHUB_TOKEN}" ]]; then
+              GITHUB_TOKEN=$(echo "${CREDS_LINE}" | sed -n 's|https://[^:]*:\([^@]*\)@github\.com.*|\1|p')
+            fi
+          fi
+
+          # Also check for .github-token file (alternative location)
+          if [[ -z "${GITHUB_TOKEN}" && -f "${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/.github-token" ]]; then
+            echo "Found .github-token file" >&2
+            GITHUB_TOKEN=$(cat "${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/.github-token")
+          fi
+        fi
+
+        # Make the API call
+        if [[ -n "${GITHUB_TOKEN}" ]]; then
+          echo "Using authenticated GitHub API (token length: ${#GITHUB_TOKEN} chars)" >&2
+          # Try with 'token' prefix first (classic format)
+          if ! PR_DATA=$(curl -sSf -H "Authorization: token ${GITHUB_TOKEN}" "${GITHUB_API_URL}" 2>/tmp/curl_err); then
+            echo "Classic token auth failed, trying Bearer format..." >&2
+            if ! PR_DATA=$(curl -sSf -H "Authorization: Bearer ${GITHUB_TOKEN}" "${GITHUB_API_URL}" 2>/tmp/curl_err); then
+              echo "WARNING: Authenticated requests failed, falling back to unauthenticated API..." >&2
+              if ! PR_DATA=$(curl -sSf "${GITHUB_API_URL}" 2>/tmp/curl_err); then
+                echo "ERROR: Failed to fetch PR description from GitHub API" >&2
+                echo "  URL: ${GITHUB_API_URL}" >&2
+                echo "  curl error: $(cat /tmp/curl_err)" >&2
+                exit 1
+              fi
+            fi
+          fi
+        else
+          echo "WARNING: No GitHub token available — using unauthenticated API (rate limited)" >&2
+          if ! PR_DATA=$(curl -sSf "${GITHUB_API_URL}" 2>/tmp/curl_err); then
+            echo "ERROR: Failed to fetch PR description from GitHub API" >&2
+            echo "  URL: ${GITHUB_API_URL}" >&2
+            echo "  curl error: $(cat /tmp/curl_err)" >&2
+            exit 1
+          fi
         fi
 
         if [[ -z "${PR_DATA}" ]]; then


### PR DESCRIPTION
Wire the git-auth workspace into the check-group-config task so it uses an authenticated GitHub API call instead of the unauthenticated endpoint that hits the 60 req/hour rate limit on the shared Konflux cluster IP.

Aligns with the same auth pattern already used by
resolve-group-configuration in the build pipeline: extract token from .git-credentials (3 formats) or .github-token, try token prefix then Bearer fallback, and fall back to unauthenticated as a last resort.

<!--- Provide a general summary of your changes in the Title above -->

---

This is raised because it looks like I hit the quota limit error here:

https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/open-data-hub-tenant/applications/early-gate/pipelineruns/early-gate-ci-test-qk4nf/logs?task=check-group-config

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
