### PR TITLE
Set GOTOOLCHAIN=auto for opendatahub-operator e2e pipeline

### DIFF
--- a/integration-tests/opendatahub-operator/e2e-test.yaml
+++ b/integration-tests/opendatahub-operator/e2e-test.yaml
@@ -254,6 +254,8 @@ spec:
                   value: "/credentials/$(steps.get-kubeconfig.results.kubeconfig)"
                 - name: GOMEMLIMIT
                   value: "10GiB"
+                - name: GOTOOLCHAIN
+                  value: "auto"
               workingDir: /workspace/source
               volumeMounts:
                 - name: credentials


### PR DESCRIPTION
## Description

Same Go toolchain mismatch as the kuberay ITS: `rhoai-task-toolset:operator` ships Go 1.26.3 with `GOTOOLCHAIN=local`, while `opendatahub-operator` `go.mod` requires `>= 1.26.5`. `make deploy` / `controller-gen` then fails with:

```text
go: go.mod requires go >= 1.26.5 (running go 1.26.3; GOTOOLCHAIN=local)
```

Set `GOTOOLCHAIN=auto` on the `deploy-and-e2e` step in `integration-tests/opendatahub-operator/e2e-test.yaml`, matching kuberay (#603), feast, and trustyai.

## How Has This Been Tested?

Verified against the failing `opendatahub-operator-e2e-test-…-deploy-and-test` log (`GOTOOLCHAIN=local` / Go 1.26.3 vs go.mod 1.26.5).

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
