### PR TITLE
Set GOTOOLCHAIN=auto for operator pr-test-pipelinerun

### DIFF
--- a/integration-tests/opendatahub-operator/pr-test-pipelinerun.yaml
+++ b/integration-tests/opendatahub-operator/pr-test-pipelinerun.yaml
@@ -284,6 +284,8 @@ spec:
                   value: "/credentials/$(steps.get-kubeconfig.results.kubeconfig)"
                 - name: GOMEMLIMIT
                   value: "10GiB"
+                - name: GOTOOLCHAIN
+                  value: "auto"
               workingDir: /workspace/source
               volumeMounts:
                 - name: credentials


### PR DESCRIPTION
## Description

Follow-up to #604. The failing operator e2e run (`opendatahub-operator-e2e-test-x95dp`) matched `pr-test-pipelinerun.yaml` behavior (SHA fetch, no Makefile dump), while #604 only updated `e2e-test.yaml`.

Set `GOTOOLCHAIN=auto` on the `deploy-and-e2e` step in `integration-tests/opendatahub-operator/pr-test-pipelinerun.yaml` so both operator ITS definitions allow Go to fetch the toolchain required by `go.mod` when `rhoai-task-toolset:operator` is older.

## How Has This Been Tested?

Compared against the failing e2e log showing `GOTOOLCHAIN=local` / Go 1.26.3 vs `go.mod` requiring `>= 1.26.5`.

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
