### PR TITLE
Wait for Trainer deployments readiness after upgrade

### DIFF
--- a/integration-tests/trainer-operator/upgrade-testing-pipeline.yaml
+++ b/integration-tests/trainer-operator/upgrade-testing-pipeline.yaml
@@ -371,6 +371,14 @@ spec:
                 oc wait --for=condition=available deployment/trainer-operator-controller-manager \
                   -n trainer-operator-system --timeout=300s
 
+                echo "Waiting 30s for reconciliation to start..."
+                sleep 30
+
+                echo "Waiting for Trainer deployments to have exactly 1 ready replica..."
+                oc wait --for=jsonpath='{.status.readyReplicas}'=1 \
+                  deployment -l platform.opendatahub.io/part-of=trainer \
+                  -n opendatahub --timeout=300s
+
                 echo ""
                 echo "============================================="
                 echo "  Phase 4: Post-upgrade validation"


### PR DESCRIPTION
Add a 30s reconciliation delay and an oc wait check to verify Trainer deployments in opendatahub namespace reach 1 ready replica before running post-upgrade tests.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
