### PR TITLE
Early-gate: add spark-operator to config

### DIFF
--- a/config/early-gate-config.yaml
+++ b/config/early-gate-config.yaml
@@ -36,3 +36,5 @@ config:
       early-gate-enabled: true
     kubeflow:
       early-gate-enabled: true
+    spark-operator:
+      early-gate-enabled: true


### PR DESCRIPTION
This PR adds spark-operator to the early-gate configuration.

## Configuration
- **Repository**: spark-operator
- **Early-gate enabled**: true
- **Target branch**: main

## Related
This is part of onboarding spark-operator to the early-gate system.
A corresponding change in opendatahub-io/spark-operator re-enables early gate testing (reverts enable-early-gate-testing: "false" from PR #155).

