### PR TITLE
Add RHEL subscription activation key parameter to multi-arch-containe…

### DIFF
--- a/pipeline/multi-arch-container-build.yaml
+++ b/pipeline/multi-arch-container-build.yaml
@@ -125,6 +125,10 @@ spec:
     default: "true"
     type: string
     description: Triggers an early gate build pipeline on comment /early-gate-build
+  - name: rhel-subscription-activation-key
+    default: 'custom-activation-key'
+    type: string
+    description: The name of the Kubernetes secret containing org and activationkey for RHEL subscription (used by prefetch-dependencies and buildah for hermetic RPM fetch and builds). See https://konflux-ci.dev/docs/building/activation-keys-subscription/
   results:
   - description: ""
     name: IMAGE_URL
@@ -222,6 +226,8 @@ spec:
       value: $(params.prefetch-log-level)
     - name: config-file-content
       value: $(params.prefetch-config-file-content)
+    - name: ACTIVATION_KEY
+      value: $(params.rhel-subscription-activation-key)
     runAfter:
     - clone-repository
     taskRef:
@@ -270,7 +276,7 @@ spec:
     - name: PRIVILEGED_NESTED
       value: $(params.privileged-nested)
     - name: ACTIVATION_KEY
-      value: custom-activation-key
+      value: $(params.rhel-subscription-activation-key)
     - name: LABELS
       value:
       - $(params.additional-labels[*])


### PR DESCRIPTION
…r-build.yaml

Added a parameter for RHEL subscription activation key to the pipeline configuration, allowing for dynamic configuration of the activation key used in builds.

https://github.com/red-hat-data-services/konflux-central/blob/main/pipelines/multi-arch-container-build.yaml#L130-L133

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
