### PR TITLE
Fix wva pipeline template for release builds

### DIFF
--- a/pipelineruns/workload-variant-autoscaler/odh-workload-variant-autoscaler-controller-push.yaml
+++ b/pipelineruns/workload-variant-autoscaler/odh-workload-variant-autoscaler-controller-push.yaml
@@ -13,8 +13,8 @@ metadata:
       == "$$TARGET_BRANCH$$"
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: opendatahub-builds
-    appstudio.openshift.io/component: odh-workload-variant-autoscaler-controller-ci
+    appstudio.openshift.io/application: opendatahub-release
+    appstudio.openshift.io/component: workload-variant-autoscaler
     pipelines.appstudio.openshift.io/type: build
   name: odh-workload-variant-autoscaler-controller-on-push
   namespace: open-data-hub-tenant
@@ -27,7 +27,7 @@ spec:
   - name: output-image
     value: quay.io/opendatahub/workload-variant-autoscaler:$$OUTPUT_IMAGE_TAG$$
   - name: dockerfile
-    value: Dockerfile
+    value: Dockerfile.konflux
   - name: path-context
     value: .
   pipelineRef:


### PR DESCRIPTION
## Summary
- Fix `application` label: `opendatahub-builds` → `opendatahub-release`
- Fix `component` label: `odh-workload-variant-autoscaler-controller-ci` → `workload-variant-autoscaler`
- Fix `dockerfile`: `Dockerfile` → `Dockerfile.konflux`

The onboarder copies this template verbatim for Release builds. The current values cause the Konflux release pipeline to fail — the application/component labels don't match the release application, and the wrong Dockerfile is used.

Discovered during the v3.6-ea1 release: the generated release-push file didn't produce a container image because of these mismatches. The working `release-v0.6` branch had the correct values (set manually before the onboarder existed).

## Test plan
- [ ] Run the onboarder with `build_type=Release` for `workload-variant-autoscaler` and verify the generated release-push file has correct labels and dockerfile
- [ ] Confirm the Konflux pipeline triggers and builds using `Dockerfile.konflux`

🤖 Generated with [Claude Code](https://claude.com/claude-code)