### PR TITLE
Fix onboarder: apply release labels for Release builds

### DIFF
--- a/.github/workflows/odh-konflux-onboarder.yml
+++ b/.github/workflows/odh-konflux-onboarder.yml
@@ -282,6 +282,12 @@ jobs:
               sed -i -E 's|Dockerfiles/rhoai\.Dockerfile|Dockerfiles/Dockerfile|g' "$target_file"
               # Release-only: Remove BUILD_MODE parameter entirely
               sed -i -E '/\$\$BUILD_MODE\$\$/d' "$target_file"
+              # Release-only: Fix application and component labels for release pipeline
+              sed -i 's|appstudio.openshift.io/application: opendatahub-builds|appstudio.openshift.io/application: opendatahub-release|' "$target_file"
+              sed -i -E "s|appstudio.openshift.io/component: ${COMPONENT_NAME}-ci|appstudio.openshift.io/component: ${COMPONENT_NAME}|" "$target_file"
+              # Release-only: Remove on-comment and on-label triggers (release pipelines trigger on push only)
+              sed -i '/pipelinesascode.tekton.dev\/on-comment/d' "$target_file"
+              sed -i '/pipelinesascode.tekton.dev\/on-label/d' "$target_file"
 
             done
           fi

--- a/pipelineruns/workload-variant-autoscaler/odh-workload-variant-autoscaler-controller-push.yaml
+++ b/pipelineruns/workload-variant-autoscaler/odh-workload-variant-autoscaler-controller-push.yaml
@@ -27,7 +27,7 @@ spec:
   - name: output-image
     value: quay.io/opendatahub/workload-variant-autoscaler:$$OUTPUT_IMAGE_TAG$$
   - name: dockerfile
-    value: Dockerfile
+    value: Dockerfile.konflux
   - name: path-context
     value: .
   pipelineRef:


### PR DESCRIPTION
## Summary
- Apply `opendatahub-release` application label for Release builds (was staying as `opendatahub-builds`)
- Strip `-ci` suffix from component label for Release builds
- Remove `on-comment` and `on-label` annotations for release pipelines (they should trigger on push only)
- Fix wva template to use `Dockerfile.konflux`

## Root cause
The workflow computes `COMPONENT_NAME` differently for CI vs Release, but never applies it to the generated tekton file. The application and component labels are hardcoded in the source template and were being copied verbatim into the release-push file.

Discovered during v3.6-ea1 release: wva's release pipeline ran under the wrong Konflux application/component, preventing the image build.

## Test plan
- [ ] Run the onboarder with `build_type=Release` for `workload-variant-autoscaler` and verify the generated release-push file has `opendatahub-release` application and no `-ci` suffix on the component
- [ ] Verify CI builds still work (labels should remain `opendatahub-builds` and `-ci`)
- [ ] Confirm no `on-comment` or `on-label` annotations in the generated release-push file

🤖 Generated with [Claude Code](https://claude.com/claude-code)