### PR TITLE
fix(its): mount /dev/shm memory volume for OGX Core vLLM sidecars

### DIFF
--- a/integration-tests/ogx-core/pr-its-pipeline.yaml
+++ b/integration-tests/ogx-core/pr-its-pipeline.yaml
@@ -166,6 +166,11 @@ spec:
         results:
           - name: TEST_OUTPUT
             description: Test results in Konflux format
+        volumes:
+          - name: dshm
+            emptyDir:
+              medium: Memory
+              sizeLimit: 1Gi
         sidecars:
           - name: postgres
             image: pgvector/pgvector:pg17
@@ -224,6 +229,9 @@ spec:
               limits:
                 memory: "8Gi"
                 cpu: "4"
+            volumeMounts:
+              - name: dshm
+                mountPath: /dev/shm
 
           - name: vllm-embedding
             image: quay.io/opendatahub/vllm-cpu:Qwen3.5-0.8B-granite-embedding-125m-english
@@ -254,6 +262,9 @@ spec:
               limits:
                 memory: "4Gi"
                 cpu: "2"
+            volumeMounts:
+              - name: dshm
+                mountPath: /dev/shm
 
           - name: ogx
             image: $(params.component-image)


### PR DESCRIPTION
## Summary
vLLM v0.27.1 multiproc executor requires >= 160 MiB of `/dev/shm` space for inter-process communication (IPC) shared memory ring buffers.

In standard Tekton container environments, `/dev/shm` defaults to 64 MiB (63 MiB free), causing `vllm-inference` and `vllm-embedding` sidecars to fail during startup with:
```
RuntimeError: Insufficient space in /dev/shm: 160 MiB required, 63 MiB free. Increase /dev/shm (e.g. --shm-size or --ipc=host).
```

## Fix
Mounts a 1Gi `Memory`-backed `emptyDir` at `/dev/shm` on both `vllm-inference` and `vllm-embedding` sidecars in `integration-tests/ogx-core/pr-its-pipeline.yaml`.